### PR TITLE
Fix newsession login handling when in valid session

### DIFF
--- a/openam-server-auth-ui/src/main/java/com/sun/identity/authentication/UI/LoginViewBean.java
+++ b/openam-server-auth-ui/src/main/java/com/sun/identity/authentication/UI/LoginViewBean.java
@@ -325,6 +325,7 @@ public class LoginViewBean extends AuthViewBeanBase {
             if (ssoToken != null) {
                 if (AuthUtils.newSessionArgExists(reqDataHash)) {
                     SSOTokenManager.getInstance().destroyToken(ssoToken);
+                    ssoToken = null; // Remove destroyed token reference
                 } else {
                     loginDebug.message("Old Session is Active.");
                     newOrgExist = checkNewOrg(ssoToken);


### PR DESCRIPTION
When calling http://foo.bar.local:8080/openam/UI/Login?arg=newsession&goto=http://example.com with an active session, client gets redirected with invalid auth cookie. Expected behaviour is to show login page (that worked with the old DAUI).