### PR TITLE
Use WrenSecurity Artifactory instance as NPM proxy

### DIFF
--- a/openam-ui/openam-ui-ria/.npmrc
+++ b/openam-ui/openam-ui-ria/.npmrc
@@ -1,1 +1,1 @@
-registry = http://maven.forgerock.org/repo/api/npm/npm-virtual/
+registry = https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/

--- a/openam-ui/openam-ui-ria/npm-shrinkwrap.json
+++ b/openam-ui/openam-ui-ria/npm-shrinkwrap.json
@@ -5,22 +5,22 @@
     "abbrev": {
       "version": "1.0.7",
       "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/abbrev/-/abbrev-1.0.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/abbrev/-/abbrev-1.0.7.tgz"
     },
     "accepts": {
       "version": "1.1.4",
       "from": "accepts@1.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/accepts/-/accepts-1.1.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/accepts/-/accepts-1.1.4.tgz",
       "dependencies": {
         "mime-db": {
           "version": "1.12.0",
           "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-db/-/mime-db-1.12.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mime-db/-/mime-db-1.12.0.tgz"
         },
         "mime-types": {
           "version": "2.0.14",
           "from": "mime-types@>=2.0.4 <2.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-types/-/mime-types-2.0.14.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mime-types/-/mime-types-2.0.14.tgz"
         }
       }
     },
@@ -32,27 +32,27 @@
     "acorn-jsx": {
       "version": "3.0.1",
       "from": "acorn-jsx@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
     },
     "after": {
       "version": "0.8.1",
       "from": "after@0.8.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/after/-/after-0.8.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/after/-/after-0.8.1.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
       "from": "amdefine@>=0.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/amdefine/-/amdefine-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
       "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
       "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -62,62 +62,62 @@
     "ansicolors": {
       "version": "0.2.1",
       "from": "ansicolors@>=0.2.1 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ansicolors/-/ansicolors-0.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ansicolors/-/ansicolors-0.2.1.tgz"
     },
     "anymatch": {
       "version": "1.3.0",
       "from": "anymatch@>=1.3.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/anymatch/-/anymatch-1.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/anymatch/-/anymatch-1.3.0.tgz"
     },
     "argparse": {
       "version": "1.0.7",
       "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/argparse/-/argparse-1.0.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/argparse/-/argparse-1.0.7.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
       "from": "arr-diff@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/arr-diff/-/arr-diff-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
       "from": "arr-flatten@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/arr-flatten/-/arr-flatten-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-find-index": {
       "version": "1.0.1",
       "from": "array-find-index@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/array-find-index/-/array-find-index-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/array-find-index/-/array-find-index-1.0.1.tgz"
     },
     "array-slice": {
       "version": "0.2.3",
       "from": "array-slice@>=0.2.3 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/array-slice/-/array-slice-0.2.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/array-slice/-/array-slice-0.2.3.tgz"
     },
     "array-union": {
       "version": "1.0.1",
       "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/array-union/-/array-union-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
       "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/array-uniq/-/array-uniq-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
       "from": "array-unique@>=0.2.1 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/array-unique/-/array-unique-0.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arraybuffer.slice": {
       "version": "0.0.6",
       "from": "arraybuffer.slice@0.0.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
     },
     "arrify": {
       "version": "1.0.1",
       "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/arrify/-/arrify-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/arrify/-/arrify-1.0.1.tgz"
     },
     "asap": {
       "version": "2.0.4",
@@ -127,47 +127,47 @@
     "asn1": {
       "version": "0.2.3",
       "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/asn1/-/asn1-0.2.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/asn1/-/asn1-0.2.3.tgz"
     },
     "assert-plus": {
       "version": "0.2.0",
       "from": "assert-plus@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assert-plus/-/assert-plus-0.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/assert-plus/-/assert-plus-0.2.0.tgz"
     },
     "assertion-error": {
       "version": "1.0.1",
       "from": "assertion-error@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assertion-error/-/assertion-error-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/assertion-error/-/assertion-error-1.0.1.tgz"
     },
     "async": {
       "version": "1.5.2",
       "from": "async@>=1.5.2 <1.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-1.5.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/async/-/async-1.5.2.tgz"
     },
     "async-each": {
       "version": "1.0.0",
       "from": "async-each@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async-each/-/async-each-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/async-each/-/async-each-1.0.0.tgz"
     },
     "aws-sign2": {
       "version": "0.6.0",
       "from": "aws-sign2@>=0.6.0 <0.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/aws-sign2/-/aws-sign2-0.6.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
     "aws4": {
       "version": "1.4.1",
       "from": "aws4@>=1.2.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/aws4/-/aws4-1.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/aws4/-/aws4-1.4.1.tgz"
     },
     "babel-code-frame": {
       "version": "6.8.0",
       "from": "babel-code-frame@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-code-frame/-/babel-code-frame-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-code-frame/-/babel-code-frame-6.8.0.tgz"
     },
     "babel-core": {
       "version": "6.9.1",
       "from": "babel-core@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-core/-/babel-core-6.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-core/-/babel-core-6.9.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -179,7 +179,7 @@
     "babel-eslint": {
       "version": "6.0.4",
       "from": "babel-eslint@6.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-eslint/-/babel-eslint-6.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-eslint/-/babel-eslint-6.0.4.tgz"
     },
     "babel-generator": {
       "version": "6.9.0",
@@ -196,7 +196,7 @@
     "babel-helper-call-delegate": {
       "version": "6.8.0",
       "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-call-delegate/-/babel-helper-call-delegate-6.8.0.tgz"
     },
     "babel-helper-define-map": {
       "version": "6.9.0",
@@ -213,27 +213,27 @@
     "babel-helper-function-name": {
       "version": "6.8.0",
       "from": "babel-helper-function-name@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-function-name/-/babel-helper-function-name-6.8.0.tgz"
     },
     "babel-helper-get-function-arity": {
       "version": "6.8.0",
       "from": "babel-helper-get-function-arity@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.8.0.tgz"
     },
     "babel-helper-hoist-variables": {
       "version": "6.8.0",
       "from": "babel-helper-hoist-variables@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.8.0.tgz"
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.8.0",
       "from": "babel-helper-optimise-call-expression@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.8.0.tgz"
     },
     "babel-helper-regex": {
       "version": "6.9.0",
       "from": "babel-helper-regex@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -245,42 +245,42 @@
     "babel-helper-replace-supers": {
       "version": "6.8.0",
       "from": "babel-helper-replace-supers@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helper-replace-supers/-/babel-helper-replace-supers-6.8.0.tgz"
     },
     "babel-helpers": {
       "version": "6.8.0",
       "from": "babel-helpers@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-helpers/-/babel-helpers-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-helpers/-/babel-helpers-6.8.0.tgz"
     },
     "babel-messages": {
       "version": "6.8.0",
       "from": "babel-messages@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-messages/-/babel-messages-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-messages/-/babel-messages-6.8.0.tgz"
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.8.0",
       "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.8.0.tgz"
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.8.0",
       "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.9.0",
       "from": "babel-plugin-transform-es2015-block-scoping@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.9.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.9.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -297,97 +297,97 @@
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.9.0",
       "from": "babel-plugin-transform-es2015-destructuring@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.6.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-for-of@>=6.6.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.9.0",
       "from": "babel-plugin-transform-es2015-function-name@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-modules-amd@6.8.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.9.0",
       "from": "babel-plugin-transform-es2015-parameters@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.9.0.tgz"
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-template-literals@>=6.6.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.6.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.8.0.tgz"
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.8.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.9.0",
       "from": "babel-plugin-transform-regenerator@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.9.0.tgz"
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.8.0",
       "from": "babel-plugin-transform-strict-mode@>=6.8.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.8.0.tgz"
     },
     "babel-preset-es2015": {
       "version": "6.9.0",
       "from": "babel-preset-es2015@6.9.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-preset-es2015/-/babel-preset-es2015-6.9.0.tgz"
     },
     "babel-register": {
       "version": "6.9.0",
@@ -404,7 +404,7 @@
     "babel-runtime": {
       "version": "6.9.2",
       "from": "babel-runtime@>=6.9.0 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-runtime/-/babel-runtime-6.9.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-runtime/-/babel-runtime-6.9.2.tgz"
     },
     "babel-template": {
       "version": "6.9.0",
@@ -433,7 +433,7 @@
     "babel-types": {
       "version": "6.9.1",
       "from": "babel-types@>=6.0.19 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babel-types/-/babel-types-6.9.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babel-types/-/babel-types-6.9.1.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -445,57 +445,57 @@
     "babylon": {
       "version": "6.8.0",
       "from": "babylon@>=6.0.18 <7.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/babylon/-/babylon-6.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/babylon/-/babylon-6.8.0.tgz"
     },
     "backo2": {
       "version": "1.0.2",
       "from": "backo2@1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/backo2/-/backo2-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/backo2/-/backo2-1.0.2.tgz"
     },
     "balanced-match": {
       "version": "0.4.1",
       "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/balanced-match/-/balanced-match-0.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/balanced-match/-/balanced-match-0.4.1.tgz"
     },
     "base64-arraybuffer": {
       "version": "0.1.2",
       "from": "base64-arraybuffer@0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
     },
     "base64id": {
       "version": "0.1.0",
       "from": "base64id@0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/base64id/-/base64id-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/base64id/-/base64id-0.1.0.tgz"
     },
     "batch": {
       "version": "0.5.3",
       "from": "batch@>=0.5.3 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/batch/-/batch-0.5.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/batch/-/batch-0.5.3.tgz"
     },
     "benchmark": {
       "version": "1.0.0",
       "from": "benchmark@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/benchmark/-/benchmark-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/benchmark/-/benchmark-1.0.0.tgz"
     },
     "better-assert": {
       "version": "1.0.2",
       "from": "better-assert@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/better-assert/-/better-assert-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/better-assert/-/better-assert-1.0.2.tgz"
     },
     "binary-extensions": {
       "version": "1.4.1",
       "from": "binary-extensions@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/binary-extensions/-/binary-extensions-1.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/binary-extensions/-/binary-extensions-1.4.1.tgz"
     },
     "bl": {
       "version": "1.1.2",
       "from": "bl@>=1.1.2 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bl/-/bl-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bl/-/bl-1.1.2.tgz"
     },
     "blob": {
       "version": "0.0.4",
       "from": "blob@0.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/blob/-/blob-0.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/blob/-/blob-0.0.4.tgz"
     },
     "bluebird": {
       "version": "3.4.0",
@@ -505,7 +505,7 @@
     "body-parser": {
       "version": "1.14.2",
       "from": "body-parser@>=1.14.0 <1.15.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/body-parser/-/body-parser-1.14.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/body-parser/-/body-parser-1.14.2.tgz",
       "dependencies": {
         "qs": {
           "version": "5.2.0",
@@ -517,12 +517,12 @@
     "boom": {
       "version": "2.10.1",
       "from": "boom@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/boom/-/boom-2.10.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/boom/-/boom-2.10.1.tgz"
     },
     "brace-expansion": {
       "version": "1.1.4",
       "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.4.tgz"
     },
     "braces": {
       "version": "1.8.5",
@@ -532,12 +532,12 @@
     "builtin-modules": {
       "version": "1.1.1",
       "from": "builtin-modules@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/builtin-modules/-/builtin-modules-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "bytes": {
       "version": "2.2.0",
       "from": "bytes@2.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bytes/-/bytes-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bytes/-/bytes-2.2.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
@@ -547,7 +547,7 @@
     "callsite": {
       "version": "1.0.0",
       "from": "callsite@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/callsite/-/callsite-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/callsite/-/callsite-1.0.0.tgz"
     },
     "callsites": {
       "version": "0.2.0",
@@ -557,32 +557,32 @@
     "camelcase": {
       "version": "2.1.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/camelcase/-/camelcase-2.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/camelcase/-/camelcase-2.1.1.tgz"
     },
     "camelcase-keys": {
       "version": "2.1.0",
       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
     },
     "cardinal": {
       "version": "0.5.0",
       "from": "cardinal@>=0.5.0 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cardinal/-/cardinal-0.5.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cardinal/-/cardinal-0.5.0.tgz"
     },
     "caseless": {
       "version": "0.11.0",
       "from": "caseless@>=0.11.0 <0.12.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/caseless/-/caseless-0.11.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/caseless/-/caseless-0.11.0.tgz"
     },
     "catharsis": {
       "version": "0.8.8",
       "from": "catharsis@>=0.8.7 <0.9.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/catharsis/-/catharsis-0.8.8.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/catharsis/-/catharsis-0.8.8.tgz"
     },
     "chai": {
       "version": "3.5.0",
       "from": "chai@3.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/chai/-/chai-3.5.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/chai/-/chai-3.5.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
@@ -597,29 +597,29 @@
     "clean-css": {
       "version": "3.4.16",
       "from": "clean-css@>=3.0.1 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/clean-css/-/clean-css-3.4.16.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/clean-css/-/clean-css-3.4.16.tgz",
       "dependencies": {
         "commander": {
           "version": "2.8.1",
           "from": "commander@>=2.8.0 <2.9.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/commander/-/commander-2.8.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/commander/-/commander-2.8.1.tgz"
         },
         "source-map": {
           "version": "0.4.4",
           "from": "source-map@>=0.4.0 <0.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "cli-color": {
       "version": "0.3.3",
       "from": "cli-color@>=0.3.2 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-color/-/cli-color-0.3.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cli-color/-/cli-color-0.3.3.tgz"
     },
     "cli-cursor": {
       "version": "1.0.2",
       "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-cursor/-/cli-cursor-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-table": {
       "version": "0.3.1",
@@ -636,12 +636,12 @@
     "cli-usage": {
       "version": "0.1.2",
       "from": "cli-usage@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cli-usage/-/cli-usage-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cli-usage/-/cli-usage-0.1.2.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.2.0",
           "from": "minimist@>=0.2.0 <0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-0.2.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimist/-/minimist-0.2.0.tgz"
         }
       }
     },
@@ -653,188 +653,188 @@
     "code-point-at": {
       "version": "1.0.0",
       "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/code-point-at/-/code-point-at-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "coffee-script": {
       "version": "1.10.0",
       "from": "coffee-script@>=1.10.0 <1.11.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/coffee-script/-/coffee-script-1.10.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/coffee-script/-/coffee-script-1.10.0.tgz"
     },
     "colors": {
       "version": "1.1.2",
       "from": "colors@>=1.1.2 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/colors/-/colors-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/colors/-/colors-1.1.2.tgz"
     },
     "combined-stream": {
       "version": "1.0.5",
       "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/combined-stream/-/combined-stream-1.0.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/combined-stream/-/combined-stream-1.0.5.tgz"
     },
     "commander": {
       "version": "2.9.0",
       "from": "commander@>=2.9.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/commander/-/commander-2.9.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/commander/-/commander-2.9.0.tgz"
     },
     "component-bind": {
       "version": "1.0.0",
       "from": "component-bind@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/component-bind/-/component-bind-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/component-bind/-/component-bind-1.0.0.tgz"
     },
     "component-emitter": {
       "version": "1.1.2",
       "from": "component-emitter@1.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/component-emitter/-/component-emitter-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/component-emitter/-/component-emitter-1.1.2.tgz"
     },
     "component-inherit": {
       "version": "0.0.3",
       "from": "component-inherit@0.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/component-inherit/-/component-inherit-0.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/component-inherit/-/component-inherit-0.0.3.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
       "from": "concat-map@0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.1",
       "from": "concat-stream@>=1.4.6 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-stream/-/concat-stream-1.5.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "connect": {
       "version": "3.4.1",
       "from": "connect@>=3.3.5 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/connect/-/connect-3.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/connect/-/connect-3.4.1.tgz"
     },
     "content-type": {
       "version": "1.0.2",
       "from": "content-type@>=1.0.1 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/content-type/-/content-type-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/content-type/-/content-type-1.0.2.tgz"
     },
     "convert-source-map": {
       "version": "1.2.0",
       "from": "convert-source-map@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/convert-source-map/-/convert-source-map-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/convert-source-map/-/convert-source-map-1.2.0.tgz"
     },
     "core-js": {
       "version": "2.4.0",
       "from": "core-js@>=2.4.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/core-js/-/core-js-2.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/core-js/-/core-js-2.4.0.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
       "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cross-env": {
       "version": "1.0.8",
       "from": "cross-env@1.0.8",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cross-env/-/cross-env-1.0.8.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cross-env/-/cross-env-1.0.8.tgz",
       "dependencies": {
         "lodash.assign": {
           "version": "3.2.0",
           "from": "lodash.assign@>=3.2.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.assign/-/lodash.assign-3.2.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.assign/-/lodash.assign-3.2.0.tgz"
         },
         "lodash.keys": {
           "version": "3.1.2",
           "from": "lodash.keys@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
         }
       }
     },
     "cross-spawn": {
       "version": "3.0.1",
       "from": "cross-spawn@>=3.0.1 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cross-spawn/-/cross-spawn-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cross-spawn/-/cross-spawn-3.0.1.tgz"
     },
     "cryptiles": {
       "version": "2.0.5",
       "from": "cryptiles@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/cryptiles/-/cryptiles-2.0.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/cryptiles/-/cryptiles-2.0.5.tgz"
     },
     "custom-event": {
       "version": "1.0.0",
       "from": "custom-event@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/custom-event/-/custom-event-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/custom-event/-/custom-event-1.0.0.tgz"
     },
     "d": {
       "version": "0.1.1",
       "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/d/-/d-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/d/-/d-0.1.1.tgz"
     },
     "dashdash": {
       "version": "1.14.0",
       "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dashdash/-/dashdash-1.14.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/dashdash/-/dashdash-1.14.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "dateformat": {
       "version": "1.0.12",
       "from": "dateformat@>=1.0.12 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dateformat/-/dateformat-1.0.12.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/dateformat/-/dateformat-1.0.12.tgz"
     },
     "debug": {
       "version": "2.2.0",
       "from": "debug@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/debug/-/debug-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/debug/-/debug-2.2.0.tgz"
     },
     "decamelize": {
       "version": "1.2.0",
       "from": "decamelize@>=1.1.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/decamelize/-/decamelize-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
       "from": "deep-eql@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/deep-eql/-/deep-eql-0.1.3.tgz",
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
           "from": "type-detect@0.1.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-detect/-/type-detect-0.1.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-is": {
       "version": "0.1.3",
       "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz"
     },
     "del": {
       "version": "2.2.0",
       "from": "del@>=2.0.2 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/del/-/del-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/del/-/del-2.2.0.tgz"
     },
     "delayed-stream": {
       "version": "1.0.0",
       "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz"
     },
     "depd": {
       "version": "1.1.0",
       "from": "depd@>=1.1.0 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/depd/-/depd-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/depd/-/depd-1.1.0.tgz"
     },
     "detect-indent": {
       "version": "3.0.1",
       "from": "detect-indent@>=3.0.1 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/detect-indent/-/detect-indent-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/detect-indent/-/detect-indent-3.0.1.tgz"
     },
     "di": {
       "version": "0.0.1",
       "from": "di@>=0.0.1 <0.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/di/-/di-0.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/di/-/di-0.0.1.tgz"
     },
     "diff": {
       "version": "1.4.0",
       "from": "diff@1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/diff/-/diff-1.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/diff/-/diff-1.4.0.tgz"
     },
     "doctrine": {
       "version": "1.2.2",
@@ -844,44 +844,44 @@
         "esutils": {
           "version": "1.1.6",
           "from": "esutils@>=1.1.6 <2.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/esutils/-/esutils-1.1.6.tgz"
         }
       }
     },
     "dom-serialize": {
       "version": "2.2.1",
       "from": "dom-serialize@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/dom-serialize/-/dom-serialize-2.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/dom-serialize/-/dom-serialize-2.2.1.tgz"
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ee-first": {
       "version": "1.1.1",
       "from": "ee-first@1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ee-first/-/ee-first-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ee-first/-/ee-first-1.1.1.tgz"
     },
     "engine.io": {
       "version": "1.6.9",
       "from": "engine.io@1.6.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/engine.io/-/engine.io-1.6.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/engine.io/-/engine.io-1.6.9.tgz"
     },
     "engine.io-client": {
       "version": "1.6.9",
       "from": "engine.io-client@1.6.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/engine.io-client/-/engine.io-client-1.6.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/engine.io-client/-/engine.io-client-1.6.9.tgz"
     },
     "engine.io-parser": {
       "version": "1.2.4",
       "from": "engine.io-parser@1.2.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "from": "has-binary@0.1.6",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-binary/-/has-binary-0.1.6.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/has-binary/-/has-binary-0.1.6.tgz"
         },
         "isarray": {
           "version": "0.0.1",
@@ -893,52 +893,52 @@
     "ent": {
       "version": "2.2.0",
       "from": "ent@>=2.2.0 <2.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ent/-/ent-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ent/-/ent-2.2.0.tgz"
     },
     "errno": {
       "version": "0.1.4",
       "from": "errno@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/errno/-/errno-0.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/errno/-/errno-0.1.4.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
       "from": "error-ex@>=1.2.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/error-ex/-/error-ex-1.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.11",
       "from": "es5-ext@>=0.10.8 <0.11.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.11.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es5-ext/-/es5-ext-0.10.11.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
       "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.3",
       "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-map/-/es6-map-0.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-map/-/es6-map-0.1.3.tgz"
     },
     "es6-set": {
       "version": "0.1.4",
       "from": "es6-set@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-set/-/es6-set-0.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
       "version": "3.0.2",
       "from": "es6-symbol@>=3.0.1 <3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-symbol/-/es6-symbol-3.0.2.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
       "from": "es6-weak-map@>=2.0.1 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
       "from": "escape-html@>=1.0.3 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escape-html/-/escape-html-1.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/escape-html/-/escape-html-1.0.3.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -948,12 +948,12 @@
     "escope": {
       "version": "3.6.0",
       "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/escope/-/escope-3.6.0.tgz"
     },
     "eslint": {
       "version": "2.11.1",
       "from": "eslint@2.11.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eslint/-/eslint-2.11.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/eslint/-/eslint-2.11.1.tgz",
       "dependencies": {
         "globals": {
           "version": "9.7.0",
@@ -968,133 +968,133 @@
         "user-home": {
           "version": "2.0.0",
           "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/user-home/-/user-home-2.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/user-home/-/user-home-2.0.0.tgz"
         }
       }
     },
     "eslint-config-forgerock": {
       "version": "1.1.1",
       "from": "eslint-config-forgerock@1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eslint-config-forgerock/-/eslint-config-forgerock-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/npm-virtual/eslint-config-forgerock/-/eslint-config-forgerock-1.1.1.tgz"
     },
     "eslint-formatter-warning-summary": {
       "version": "1.0.1",
       "from": "eslint-formatter-warning-summary@1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/eslint-formatter-warning-summary/-/eslint-formatter-warning-summary-1.0.1.tgz"
     },
     "espree": {
       "version": "3.1.4",
       "from": "espree@3.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/espree/-/espree-3.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/espree/-/espree-3.1.4.tgz"
     },
     "esprima": {
       "version": "2.7.2",
       "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esprima/-/esprima-2.7.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/esprima/-/esprima-2.7.2.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
       "from": "esrecurse@>=4.1.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esrecurse/-/esrecurse-4.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/esrecurse/-/esrecurse-4.1.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
           "from": "estraverse@>=4.1.0 <4.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-4.1.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/estraverse/-/estraverse-4.1.1.tgz"
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
       "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/estraverse/-/estraverse-4.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
       "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esutils/-/esutils-2.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/esutils/-/esutils-2.0.2.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
       "from": "event-emitter@>=0.3.4 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "eventemitter2": {
       "version": "0.4.14",
       "from": "eventemitter2@>=0.4.13 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/eventemitter2/-/eventemitter2-0.4.14.tgz"
     },
     "eventemitter3": {
       "version": "1.2.0",
       "from": "eventemitter3@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/eventemitter3/-/eventemitter3-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/eventemitter3/-/eventemitter3-1.2.0.tgz"
     },
     "exit": {
       "version": "0.1.2",
       "from": "exit@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/exit/-/exit-0.1.2.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
       "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/exit-hook/-/exit-hook-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expand-braces": {
       "version": "0.1.2",
       "from": "expand-braces@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/expand-braces/-/expand-braces-0.1.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/expand-braces/-/expand-braces-0.1.2.tgz",
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "from": "braces@>=0.1.2 <0.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/braces/-/braces-0.1.5.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/braces/-/braces-0.1.5.tgz"
         },
         "expand-range": {
           "version": "0.1.1",
           "from": "expand-range@>=0.1.0 <0.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/expand-range/-/expand-range-0.1.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/expand-range/-/expand-range-0.1.1.tgz"
         },
         "is-number": {
           "version": "0.1.1",
           "from": "is-number@>=0.1.1 <0.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-number/-/is-number-0.1.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-number/-/is-number-0.1.1.tgz"
         },
         "repeat-string": {
           "version": "0.2.2",
           "from": "repeat-string@>=0.2.2 <0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/repeat-string/-/repeat-string-0.2.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/repeat-string/-/repeat-string-0.2.2.tgz"
         }
       }
     },
     "expand-brackets": {
       "version": "0.1.5",
       "from": "expand-brackets@>=0.1.4 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/expand-brackets/-/expand-brackets-0.1.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
       "from": "expand-range@>=1.8.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/expand-range/-/expand-range-1.8.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/expand-range/-/expand-range-1.8.2.tgz"
     },
     "extend": {
       "version": "3.0.0",
       "from": "extend@>=3.0.0 <3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extend/-/extend-3.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
       "version": "0.3.2",
       "from": "extglob@>=0.3.1 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extglob/-/extglob-0.3.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-zip": {
       "version": "1.5.0",
       "from": "extract-zip@>=1.5.0 <1.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extract-zip/-/extract-zip-1.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/extract-zip/-/extract-zip-1.5.0.tgz",
       "dependencies": {
         "concat-stream": {
           "version": "1.5.0",
           "from": "concat-stream@1.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/concat-stream/-/concat-stream-1.5.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/concat-stream/-/concat-stream-1.5.0.tgz"
         },
         "debug": {
           "version": "0.7.4",
@@ -1104,19 +1104,19 @@
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz"
         },
         "mkdirp": {
           "version": "0.5.0",
           "from": "mkdirp@0.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.0.tgz"
         }
       }
     },
     "extsprintf": {
       "version": "1.0.2",
       "from": "extsprintf@1.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/extsprintf/-/extsprintf-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/extsprintf/-/extsprintf-1.0.2.tgz"
     },
     "fast-levenshtein": {
       "version": "1.1.3",
@@ -1126,12 +1126,12 @@
     "faye-websocket": {
       "version": "0.10.0",
       "from": "faye-websocket@>=0.10.0 <0.11.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/faye-websocket/-/faye-websocket-0.10.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/faye-websocket/-/faye-websocket-0.10.0.tgz"
     },
     "fd-slicer": {
       "version": "1.0.1",
       "from": "fd-slicer@>=1.0.1 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fd-slicer/-/fd-slicer-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "figures": {
       "version": "1.7.0",
@@ -1141,27 +1141,27 @@
     "file-entry-cache": {
       "version": "1.2.4",
       "from": "file-entry-cache@>=1.1.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
     },
     "file-sync-cmp": {
       "version": "0.1.1",
       "from": "file-sync-cmp@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
     },
     "filename-regex": {
       "version": "2.0.0",
       "from": "filename-regex@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/filename-regex/-/filename-regex-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
       "from": "fill-range@>=2.1.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fill-range/-/fill-range-2.2.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/fill-range/-/fill-range-2.2.3.tgz"
     },
     "finalhandler": {
       "version": "0.4.1",
       "from": "finalhandler@0.4.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/finalhandler/-/finalhandler-0.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/finalhandler/-/finalhandler-0.4.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
@@ -1178,54 +1178,54 @@
     "findup-sync": {
       "version": "0.3.0",
       "from": "findup-sync@>=0.3.0 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/findup-sync/-/findup-sync-0.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/findup-sync/-/findup-sync-0.3.0.tgz",
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "from": "glob@>=5.0.0 <5.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz"
         }
       }
     },
     "flat-cache": {
       "version": "1.0.10",
       "from": "flat-cache@>=1.0.9 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/flat-cache/-/flat-cache-1.0.10.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/flat-cache/-/flat-cache-1.0.10.tgz"
     },
     "for-in": {
       "version": "0.1.5",
       "from": "for-in@>=0.1.5 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/for-in/-/for-in-0.1.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/for-in/-/for-in-0.1.5.tgz"
     },
     "for-own": {
       "version": "0.1.4",
       "from": "for-own@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/for-own/-/for-own-0.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/for-own/-/for-own-0.1.4.tgz"
     },
     "forever-agent": {
       "version": "0.6.1",
       "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz"
     },
     "form-data": {
       "version": "1.0.0-rc4",
       "from": "form-data@>=1.0.0-rc3 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/form-data/-/form-data-1.0.0-rc4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/form-data/-/form-data-1.0.0-rc4.tgz"
     },
     "formatio": {
       "version": "1.1.1",
       "from": "formatio@1.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/formatio/-/formatio-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/formatio/-/formatio-1.1.1.tgz"
     },
     "fs-extra": {
       "version": "0.26.7",
       "from": "fs-extra@>=0.26.4 <0.27.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fs-extra/-/fs-extra-0.26.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/fs-extra/-/fs-extra-0.26.7.tgz"
     },
     "fsevents": {
       "version": "1.0.12",
       "from": "fsevents@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/fsevents/-/fsevents-1.0.12.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/fsevents/-/fsevents-1.0.12.tgz",
       "dependencies": {
         "ansi": {
           "version": "0.3.1",
@@ -1852,59 +1852,59 @@
     "gaze": {
       "version": "1.0.0",
       "from": "gaze@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/gaze/-/gaze-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/gaze/-/gaze-1.0.0.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
       "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-function/-/generate-function-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
       "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
       "from": "get-stdin@>=4.0.1 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/get-stdin/-/get-stdin-4.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "getobject": {
       "version": "0.1.0",
       "from": "getobject@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/getobject/-/getobject-0.1.0.tgz"
     },
     "getpass": {
       "version": "0.1.6",
       "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/getpass/-/getpass-0.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/getpass/-/getpass-0.1.6.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "glob": {
       "version": "7.0.3",
       "from": "glob@>=7.0.3 <8.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-7.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-7.0.3.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
       "from": "glob-base@>=0.3.0 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob-base/-/glob-base-0.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
       "from": "glob-parent@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob-parent/-/glob-parent-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "globals": {
       "version": "8.18.0",
       "from": "globals@>=8.3.0 <9.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/globals/-/globals-8.18.0.tgz"
     },
     "globby": {
       "version": "4.1.0",
@@ -1914,105 +1914,105 @@
         "glob": {
           "version": "6.0.4",
           "from": "glob@>=6.0.1 <7.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-6.0.4.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-6.0.4.tgz"
         }
       }
     },
     "globule": {
       "version": "0.2.0",
       "from": "globule@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/globule/-/globule-0.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/globule/-/globule-0.2.0.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
           "from": "glob@>=3.2.7 <3.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz",
           "dependencies": {
             "minimatch": {
               "version": "0.3.0",
               "from": "minimatch@>=0.3.0 <0.4.0",
-              "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz"
+              "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz"
             }
           }
         },
         "lodash": {
           "version": "2.4.2",
           "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash/-/lodash-2.4.2.tgz"
         },
         "lru-cache": {
           "version": "2.7.3",
           "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@>=0.2.11 <0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-0.2.14.tgz"
         }
       }
     },
     "graceful-fs": {
       "version": "4.1.4",
       "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/graceful-fs/-/graceful-fs-4.1.4.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
       "from": "graceful-readlink@>=1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.9.2",
       "from": "growl@1.9.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/growl/-/growl-1.9.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/growl/-/growl-1.9.2.tgz"
     },
     "growly": {
       "version": "1.3.0",
       "from": "growly@>=1.2.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/growly/-/growly-1.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/growly/-/growly-1.3.0.tgz"
     },
     "grunt": {
       "version": "1.0.1",
       "from": "grunt@1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt/-/grunt-1.0.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt/-/grunt-1.0.1.tgz",
       "dependencies": {
         "js-yaml": {
           "version": "3.5.5",
           "from": "js-yaml@>=3.5.2 <3.6.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-yaml/-/js-yaml-3.5.5.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/js-yaml/-/js-yaml-3.5.5.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
           "from": "minimatch@>=3.0.0 <3.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-3.0.0.tgz"
         },
         "rimraf": {
           "version": "2.2.8",
           "from": "rimraf@>=2.2.8 <2.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/rimraf/-/rimraf-2.2.8.tgz"
         }
       }
     },
     "grunt-babel": {
       "version": "6.0.0",
       "from": "grunt-babel@6.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-babel/-/grunt-babel-6.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-babel/-/grunt-babel-6.0.0.tgz"
     },
     "grunt-cli": {
       "version": "1.2.0",
       "from": "grunt-cli@1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-cli/-/grunt-cli-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-cli/-/grunt-cli-1.2.0.tgz"
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
       "from": "grunt-contrib-copy@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz"
     },
     "grunt-contrib-less": {
       "version": "1.3.0",
       "from": "grunt-contrib-less@1.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-contrib-less/-/grunt-contrib-less-1.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-contrib-less/-/grunt-contrib-less-1.3.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -2024,12 +2024,12 @@
     "grunt-contrib-requirejs": {
       "version": "1.0.0",
       "from": "grunt-contrib-requirejs@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-contrib-requirejs/-/grunt-contrib-requirejs-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-contrib-requirejs/-/grunt-contrib-requirejs-1.0.0.tgz"
     },
     "grunt-contrib-watch": {
       "version": "1.0.0",
       "from": "grunt-contrib-watch@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz"
     },
     "grunt-eslint": {
       "version": "18.1.0",
@@ -2039,78 +2039,78 @@
     "grunt-karma": {
       "version": "2.0.0",
       "from": "grunt-karma@2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-karma/-/grunt-karma-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-karma/-/grunt-karma-2.0.0.tgz"
     },
     "grunt-known-options": {
       "version": "1.1.0",
       "from": "grunt-known-options@>=1.1.0 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-known-options/-/grunt-known-options-1.1.0.tgz"
     },
     "grunt-legacy-log": {
       "version": "1.0.0",
       "from": "grunt-legacy-log@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-legacy-log/-/grunt-legacy-log-1.0.0.tgz"
     },
     "grunt-legacy-log-utils": {
       "version": "1.0.0",
       "from": "grunt-legacy-log-utils@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.3.0",
           "from": "lodash@>=4.3.0 <4.4.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-4.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash/-/lodash-4.3.0.tgz"
         }
       }
     },
     "grunt-legacy-util": {
       "version": "1.0.0",
       "from": "grunt-legacy-util@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.3.0",
           "from": "lodash@>=4.3.0 <4.4.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-4.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash/-/lodash-4.3.0.tgz"
         }
       }
     },
     "grunt-newer": {
       "version": "1.2.0",
       "from": "grunt-newer@1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-newer/-/grunt-newer-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-newer/-/grunt-newer-1.2.0.tgz"
     },
     "grunt-sync": {
       "version": "0.5.2",
       "from": "grunt-sync@0.5.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-sync/-/grunt-sync-0.5.2.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-sync/-/grunt-sync-0.5.2.tgz",
       "dependencies": {
         "glob": {
           "version": "4.5.3",
           "from": "glob@>=4.0.5 <5.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-4.5.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-4.5.3.tgz"
         }
       }
     },
     "grunt-text-replace": {
       "version": "0.4.0",
       "from": "grunt-text-replace@0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/grunt-text-replace/-/grunt-text-replace-0.4.0.tgz"
     },
     "har-validator": {
       "version": "2.0.6",
       "from": "har-validator@>=2.0.6 <2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/har-validator/-/har-validator-2.0.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/har-validator/-/har-validator-2.0.6.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
       "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-binary": {
       "version": "0.1.7",
       "from": "has-binary@0.1.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-binary/-/has-binary-0.1.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/has-binary/-/has-binary-0.1.7.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2122,32 +2122,32 @@
     "has-cors": {
       "version": "1.1.0",
       "from": "has-cors@1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/has-cors/-/has-cors-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/has-cors/-/has-cors-1.1.0.tgz"
     },
     "hasha": {
       "version": "2.2.0",
       "from": "hasha@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hasha/-/hasha-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/hasha/-/hasha-2.2.0.tgz"
     },
     "hawk": {
       "version": "3.1.3",
       "from": "hawk@>=3.1.3 <3.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hawk/-/hawk-3.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/hawk/-/hawk-3.1.3.tgz"
     },
     "hoek": {
       "version": "2.16.3",
       "from": "hoek@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hoek/-/hoek-2.16.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/hoek/-/hoek-2.16.3.tgz"
     },
     "home-or-tmp": {
       "version": "1.0.0",
       "from": "home-or-tmp@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/home-or-tmp/-/home-or-tmp-1.0.0.tgz"
     },
     "hooker": {
       "version": "0.2.3",
       "from": "hooker@>=0.2.3 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/hooker/-/hooker-0.2.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.5",
@@ -2157,7 +2157,7 @@
     "http-errors": {
       "version": "1.3.1",
       "from": "http-errors@>=1.3.1 <1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/http-errors/-/http-errors-1.3.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/http-errors/-/http-errors-1.3.1.tgz"
     },
     "http-proxy": {
       "version": "1.13.3",
@@ -2167,22 +2167,22 @@
     "http-signature": {
       "version": "1.1.1",
       "from": "http-signature@>=1.1.0 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/http-signature/-/http-signature-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/http-signature/-/http-signature-1.1.1.tgz"
     },
     "iconv-lite": {
       "version": "0.4.13",
       "from": "iconv-lite@>=0.4.13 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.4.13.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "ignore": {
       "version": "3.1.2",
       "from": "ignore@>=3.1.2 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ignore/-/ignore-3.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ignore/-/ignore-3.1.2.tgz"
     },
     "image-size": {
       "version": "0.4.0",
       "from": "image-size@>=0.4.0 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/image-size/-/image-size-0.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/image-size/-/image-size-0.4.0.tgz"
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2192,19 +2192,19 @@
     "indent-string": {
       "version": "2.1.0",
       "from": "indent-string@>=2.1.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/indent-string/-/indent-string-2.1.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/indent-string/-/indent-string-2.1.0.tgz",
       "dependencies": {
         "repeating": {
           "version": "2.0.1",
           "from": "repeating@>=2.0.0 <3.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/repeating/-/repeating-2.0.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/repeating/-/repeating-2.0.1.tgz"
         }
       }
     },
     "indexof": {
       "version": "0.0.1",
       "from": "indexof@0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/indexof/-/indexof-0.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/indexof/-/indexof-0.0.1.tgz"
     },
     "inflight": {
       "version": "1.0.5",
@@ -2214,7 +2214,7 @@
     "inherits": {
       "version": "2.0.1",
       "from": "inherits@>=2.0.1 <2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/inherits/-/inherits-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/inherits/-/inherits-2.0.1.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2231,122 +2231,122 @@
     "invariant": {
       "version": "2.2.1",
       "from": "invariant@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/invariant/-/invariant-2.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/invariant/-/invariant-2.2.1.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
       "from": "is-arrayish@>=0.2.1 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
       "from": "is-binary-path@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-binary-path/-/is-binary-path-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.3",
       "from": "is-buffer@>=1.0.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-buffer/-/is-buffer-1.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-buffer/-/is-buffer-1.1.3.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "from": "is-builtin-module@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
       "from": "is-dotfile@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-dotfile/-/is-dotfile-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
       "from": "is-extendable@>=0.1.1 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
       "from": "is-extglob@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
       "from": "is-finite@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-finite/-/is-finite-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-glob": {
       "version": "2.0.1",
       "from": "is-glob@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-glob/-/is-glob-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
       "version": "2.13.1",
       "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
     },
     "is-number": {
       "version": "2.1.0",
       "from": "is-number@>=2.1.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-number/-/is-number-2.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-number/-/is-number-2.1.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
       "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
       "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
       "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-path-inside/-/is-path-inside-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
       "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
       "from": "is-primitive@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-primitive/-/is-primitive-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
       "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-property/-/is-property-1.0.2.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
       "from": "is-resolvable@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-stream/-/is-stream-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-stream/-/is-stream-1.1.0.tgz"
     },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz"
     },
     "is-utf8": {
       "version": "0.2.1",
       "from": "is-utf8@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/is-utf8/-/is-utf8-0.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
       "version": "1.0.0",
@@ -2356,116 +2356,116 @@
     "isbinaryfile": {
       "version": "3.0.0",
       "from": "isbinaryfile@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/isbinaryfile/-/isbinaryfile-3.0.0.tgz"
     },
     "isexe": {
       "version": "1.1.2",
       "from": "isexe@>=1.1.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isexe/-/isexe-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/isexe/-/isexe-1.1.2.tgz"
     },
     "isobject": {
       "version": "2.1.0",
       "from": "isobject@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isobject/-/isobject-2.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/isobject/-/isobject-2.1.0.tgz"
     },
     "isstream": {
       "version": "0.1.2",
       "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz"
     },
     "jade": {
       "version": "0.26.3",
       "from": "jade@0.26.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jade/-/jade-0.26.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jade/-/jade-0.26.3.tgz",
       "dependencies": {
         "commander": {
           "version": "0.6.1",
           "from": "commander@0.6.1",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/commander/-/commander-0.6.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/commander/-/commander-0.6.1.tgz"
         },
         "mkdirp": {
           "version": "0.3.0",
           "from": "mkdirp@0.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
     },
     "jodid25519": {
       "version": "1.0.2",
       "from": "jodid25519@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jodid25519/-/jodid25519-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "js-tokens": {
       "version": "1.0.3",
       "from": "js-tokens@>=1.0.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-tokens/-/js-tokens-1.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/js-tokens/-/js-tokens-1.0.3.tgz"
     },
     "js-yaml": {
       "version": "3.6.1",
       "from": "js-yaml@>=3.5.1 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js-yaml/-/js-yaml-3.6.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/js-yaml/-/js-yaml-3.6.1.tgz"
     },
     "js2xmlparser": {
       "version": "1.0.0",
       "from": "js2xmlparser@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/js2xmlparser/-/js2xmlparser-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/js2xmlparser/-/js2xmlparser-1.0.0.tgz"
     },
     "jsbn": {
       "version": "0.1.0",
       "from": "jsbn@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsbn/-/jsbn-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsbn/-/jsbn-0.1.0.tgz"
     },
     "jsdoc": {
       "version": "3.4.0",
       "from": "jsdoc@3.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsdoc/-/jsdoc-3.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsdoc/-/jsdoc-3.4.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.4.2",
           "from": "async@>=1.4.0 <1.5.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/async/-/async-1.4.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/async/-/async-1.4.2.tgz"
         },
         "bluebird": {
           "version": "2.9.34",
           "from": "bluebird@>=2.9.34 <2.10.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bluebird/-/bluebird-2.9.34.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bluebird/-/bluebird-2.9.34.tgz"
         },
         "espree": {
           "version": "2.2.5",
           "from": "espree@>=2.2.3 <2.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/espree/-/espree-2.2.5.tgz"
         }
       }
     },
     "jsesc": {
       "version": "0.5.0",
       "from": "jsesc@>=0.5.0 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsesc/-/jsesc-0.5.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsesc/-/jsesc-0.5.0.tgz"
     },
     "json-schema": {
       "version": "0.2.2",
       "from": "json-schema@0.2.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-schema/-/json-schema-0.2.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json-schema/-/json-schema-0.2.2.tgz"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
     },
     "json3": {
       "version": "3.2.6",
       "from": "json3@3.2.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json3/-/json3-3.2.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json3/-/json3-3.2.6.tgz"
     },
     "json5": {
       "version": "0.4.0",
       "from": "json5@>=0.4.0 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json5/-/json5-0.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json5/-/json5-0.4.0.tgz"
     },
     "jsonfile": {
       "version": "2.3.1",
@@ -2475,64 +2475,64 @@
     "jsonify": {
       "version": "0.0.0",
       "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsonify/-/jsonify-0.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
       "from": "jsonpointer@2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsonpointer/-/jsonpointer-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsprim": {
       "version": "1.2.2",
       "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/jsprim/-/jsprim-1.2.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/jsprim/-/jsprim-1.2.2.tgz"
     },
     "karma": {
       "version": "0.13.22",
       "from": "karma@0.13.22",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma/-/karma-0.13.22.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma/-/karma-0.13.22.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
           "from": "bluebird@>=2.9.27 <3.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bluebird/-/bluebird-2.10.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bluebird/-/bluebird-2.10.2.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
           "from": "minimatch@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-3.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-3.0.0.tgz"
         }
       }
     },
     "karma-babel-preprocessor": {
       "version": "6.0.1",
       "from": "karma-babel-preprocessor@6.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-babel-preprocessor/-/karma-babel-preprocessor-6.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-babel-preprocessor/-/karma-babel-preprocessor-6.0.1.tgz"
     },
     "karma-mocha": {
       "version": "1.0.1",
       "from": "karma-mocha@1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-mocha/-/karma-mocha-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-mocha/-/karma-mocha-1.0.1.tgz"
     },
     "karma-mocha-reporter": {
       "version": "2.0.3",
       "from": "karma-mocha-reporter@2.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-mocha-reporter/-/karma-mocha-reporter-2.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-mocha-reporter/-/karma-mocha-reporter-2.0.3.tgz"
     },
     "karma-notify-reporter": {
       "version": "1.0.0",
       "from": "karma-notify-reporter@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-notify-reporter/-/karma-notify-reporter-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-notify-reporter/-/karma-notify-reporter-1.0.0.tgz"
     },
     "karma-nyan-reporter": {
       "version": "0.2.4",
       "from": "karma-nyan-reporter@0.2.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-nyan-reporter/-/karma-nyan-reporter-0.2.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-nyan-reporter/-/karma-nyan-reporter-0.2.4.tgz"
     },
     "karma-phantomjs-launcher": {
       "version": "1.0.0",
       "from": "karma-phantomjs-launcher@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.0.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.13.1",
@@ -2544,32 +2544,32 @@
     "karma-requirejs": {
       "version": "1.0.0",
       "from": "karma-requirejs@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/karma-requirejs/-/karma-requirejs-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/karma-requirejs/-/karma-requirejs-1.0.0.tgz"
     },
     "kew": {
       "version": "0.7.0",
       "from": "kew@>=0.7.0 <0.8.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/kew/-/kew-0.7.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/kew/-/kew-0.7.0.tgz"
     },
     "kind-of": {
       "version": "3.0.3",
       "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/kind-of/-/kind-of-3.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/kind-of/-/kind-of-3.0.3.tgz"
     },
     "klaw": {
       "version": "1.2.0",
       "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/klaw/-/klaw-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/klaw/-/klaw-1.2.0.tgz"
     },
     "less": {
       "version": "2.6.1",
       "from": "less@>=2.6.0 <2.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/less/-/less-2.6.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/less/-/less-2.6.1.tgz"
     },
     "less-plugin-clean-css": {
       "version": "1.5.1",
       "from": "less-plugin-clean-css@1.5.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz"
     },
     "levn": {
       "version": "0.3.0",
@@ -2579,66 +2579,66 @@
     "livereload-js": {
       "version": "2.2.2",
       "from": "livereload-js@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/livereload-js/-/livereload-js-2.2.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/livereload-js/-/livereload-js-2.2.2.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/load-json-file/-/load-json-file-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/load-json-file/-/load-json-file-1.1.0.tgz"
     },
     "lodash": {
       "version": "3.10.1",
       "from": "lodash@3.10.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
       "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
       "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
       "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "from": "lodash.keys@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
         }
       }
     },
     "lodash._baseclone": {
       "version": "3.3.0",
       "from": "lodash._baseclone@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "dependencies": {
         "lodash.keys": {
           "version": "3.1.2",
           "from": "lodash.keys@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
         }
       }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basefor": {
       "version": "3.0.3",
       "from": "lodash._basefor@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
     },
     "lodash._baseiteratee": {
       "version": "4.7.0",
       "from": "lodash._baseiteratee@>=4.7.0 <4.8.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz"
     },
     "lodash._basetostring": {
       "version": "4.12.0",
@@ -2648,22 +2648,22 @@
     "lodash._bindcallback": {
       "version": "3.0.1",
       "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._createassigner": {
       "version": "3.1.1",
       "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._stringtopath": {
       "version": "4.8.0",
@@ -2678,17 +2678,17 @@
     "lodash.clonedeep": {
       "version": "3.0.2",
       "from": "lodash.clonedeep@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.8",
       "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.isarguments/-/lodash.isarguments-3.0.8.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.keys": {
       "version": "4.0.7",
@@ -2698,12 +2698,12 @@
     "lodash.keysin": {
       "version": "4.1.4",
       "from": "lodash.keysin@>=4.0.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-4.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.keysin/-/lodash.keysin-4.1.4.tgz"
     },
     "lodash.pickby": {
       "version": "4.4.0",
       "from": "lodash.pickby@>=4.0.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.pickby/-/lodash.pickby-4.4.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.pickby/-/lodash.pickby-4.4.0.tgz"
     },
     "lodash.rest": {
       "version": "4.0.3",
@@ -2713,12 +2713,12 @@
     "lodash.restparam": {
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "log4js": {
       "version": "0.6.36",
       "from": "log4js@>=0.6.31 <0.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/log4js/-/log4js-0.6.36.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/log4js/-/log4js-0.6.36.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2728,19 +2728,19 @@
         "readable-stream": {
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.2 <1.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz"
         },
         "semver": {
           "version": "4.3.6",
           "from": "semver@>=4.3.3 <4.4.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/semver/-/semver-4.3.6.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "lolex": {
       "version": "1.3.2",
       "from": "lolex@1.3.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lolex/-/lolex-1.3.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lolex/-/lolex-1.3.2.tgz"
     },
     "loose-envify": {
       "version": "1.2.0",
@@ -2750,270 +2750,270 @@
     "loud-rejection": {
       "version": "1.3.0",
       "from": "loud-rejection@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/loud-rejection/-/loud-rejection-1.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/loud-rejection/-/loud-rejection-1.3.0.tgz"
     },
     "lru-cache": {
       "version": "4.0.1",
       "from": "lru-cache@>=4.0.1 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-4.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lru-cache/-/lru-cache-4.0.1.tgz"
     },
     "lru-queue": {
       "version": "0.1.0",
       "from": "lru-queue@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-queue/-/lru-queue-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lru-queue/-/lru-queue-0.1.0.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
       "from": "map-obj@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/map-obj/-/map-obj-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/map-obj/-/map-obj-1.0.1.tgz"
     },
     "marked": {
       "version": "0.3.5",
       "from": "marked@>=0.3.4 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/marked/-/marked-0.3.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/marked/-/marked-0.3.5.tgz"
     },
     "marked-terminal": {
       "version": "1.6.1",
       "from": "marked-terminal@>=1.6.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/marked-terminal/-/marked-terminal-1.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/marked-terminal/-/marked-terminal-1.6.1.tgz",
       "dependencies": {
         "lodash.assign": {
           "version": "3.2.0",
           "from": "lodash.assign@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.assign/-/lodash.assign-3.2.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.assign/-/lodash.assign-3.2.0.tgz"
         },
         "lodash.keys": {
           "version": "3.1.2",
           "from": "lodash.keys@>=3.0.0 <4.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz"
         }
       }
     },
     "md5-file": {
       "version": "2.0.7",
       "from": "md5-file@>=2.0.3 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/md5-file/-/md5-file-2.0.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/md5-file/-/md5-file-2.0.7.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/media-typer/-/media-typer-0.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/media-typer/-/media-typer-0.3.0.tgz"
     },
     "memoizee": {
       "version": "0.3.10",
       "from": "memoizee@>=0.3.8 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/memoizee/-/memoizee-0.3.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/memoizee/-/memoizee-0.3.10.tgz",
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
           "from": "es6-iterator@>=0.1.3 <0.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-iterator/-/es6-iterator-0.1.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-iterator/-/es6-iterator-0.1.3.tgz"
         },
         "es6-symbol": {
           "version": "2.0.1",
           "from": "es6-symbol@>=2.0.1 <2.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-symbol/-/es6-symbol-2.0.1.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-symbol/-/es6-symbol-2.0.1.tgz"
         },
         "es6-weak-map": {
           "version": "0.1.4",
           "from": "es6-weak-map@>=0.1.4 <0.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-0.1.4.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/es6-weak-map/-/es6-weak-map-0.1.4.tgz"
         }
       }
     },
     "meow": {
       "version": "3.7.0",
       "from": "meow@>=3.3.0 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/meow/-/meow-3.7.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/meow/-/meow-3.7.0.tgz"
     },
     "micromatch": {
       "version": "2.3.8",
       "from": "micromatch@>=2.1.5 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/micromatch/-/micromatch-2.3.8.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/micromatch/-/micromatch-2.3.8.tgz"
     },
     "mime": {
       "version": "1.3.4",
       "from": "mime@>=1.2.11 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime/-/mime-1.3.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
       "version": "1.23.0",
       "from": "mime-db@>=1.23.0 <1.24.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-db/-/mime-db-1.23.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mime-db/-/mime-db-1.23.0.tgz"
     },
     "mime-types": {
       "version": "2.1.11",
       "from": "mime-types@>=2.1.7 <2.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mime-types/-/mime-types-2.1.11.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mime-types/-/mime-types-2.1.11.tgz"
     },
     "minimatch": {
       "version": "2.0.10",
       "from": "minimatch@>=2.0.3 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz"
     },
     "minimist": {
       "version": "1.2.0",
       "from": "minimist@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
       "from": "mkdirp@>=0.5.1 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
           "from": "minimist@0.0.8",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "mocha": {
       "version": "2.5.3",
       "from": "mocha@2.5.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mocha/-/mocha-2.5.3.tgz",
       "dependencies": {
         "commander": {
           "version": "2.3.0",
           "from": "commander@2.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/commander/-/commander-2.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/commander/-/commander-2.3.0.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.2",
           "from": "escape-string-regexp@1.0.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
         },
         "glob": {
           "version": "3.2.11",
           "from": "glob@3.2.11",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/glob/-/glob-3.2.11.tgz"
         },
         "lru-cache": {
           "version": "2.7.3",
           "from": "lru-cache@>=2.0.0 <3.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lru-cache/-/lru-cache-2.7.3.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
           "from": "minimatch@>=0.3.0 <0.4.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimatch/-/minimatch-0.3.0.tgz"
         },
         "supports-color": {
           "version": "1.2.0",
           "from": "supports-color@1.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/supports-color/-/supports-color-1.2.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/supports-color/-/supports-color-1.2.0.tgz"
         }
       }
     },
     "ms": {
       "version": "0.7.1",
       "from": "ms@0.7.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ms/-/ms-0.7.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ms/-/ms-0.7.1.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
       "from": "mute-stream@0.0.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "nan": {
       "version": "2.3.5",
       "from": "nan@>=2.3.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/nan/-/nan-2.3.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/nan/-/nan-2.3.5.tgz"
     },
     "negotiator": {
       "version": "0.4.9",
       "from": "negotiator@0.4.9",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/negotiator/-/negotiator-0.4.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/negotiator/-/negotiator-0.4.9.tgz"
     },
     "next-tick": {
       "version": "0.2.2",
       "from": "next-tick@>=0.2.2 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/next-tick/-/next-tick-0.2.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/next-tick/-/next-tick-0.2.2.tgz"
     },
     "node-emoji": {
       "version": "0.1.0",
       "from": "node-emoji@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/node-emoji/-/node-emoji-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/node-emoji/-/node-emoji-0.1.0.tgz"
     },
     "node-notifier": {
       "version": "4.6.0",
       "from": "node-notifier@>=4.5.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/node-notifier/-/node-notifier-4.6.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/node-notifier/-/node-notifier-4.6.0.tgz"
     },
     "node-uuid": {
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.7 <1.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/node-uuid/-/node-uuid-1.4.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/node-uuid/-/node-uuid-1.4.7.tgz"
     },
     "nopt": {
       "version": "3.0.6",
       "from": "nopt@>=3.0.6 <3.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/nopt/-/nopt-3.0.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/nopt/-/nopt-3.0.6.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
       "from": "normalize-package-data@>=2.3.4 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "normalize-path": {
       "version": "2.0.1",
       "from": "normalize-path@>=2.0.1 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/normalize-path/-/normalize-path-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/normalize-path/-/normalize-path-2.0.1.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
       "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/number-is-nan/-/number-is-nan-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "oauth-sign": {
       "version": "0.8.2",
       "from": "oauth-sign@>=0.8.1 <0.9.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/oauth-sign/-/oauth-sign-0.8.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/oauth-sign/-/oauth-sign-0.8.2.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
       "from": "object-assign@>=4.0.1 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-assign/-/object-assign-4.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-component": {
       "version": "0.0.3",
       "from": "object-component@0.0.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object-component/-/object-component-0.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/object-component/-/object-component-0.0.3.tgz"
     },
     "object.omit": {
       "version": "2.0.0",
       "from": "object.omit@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/object.omit/-/object.omit-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/object.omit/-/object.omit-2.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
       "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/on-finished/-/on-finished-2.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/on-finished/-/on-finished-2.3.0.tgz"
     },
     "once": {
       "version": "1.3.3",
       "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/once/-/once-1.3.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/once/-/once-1.3.3.tgz"
     },
     "onetime": {
       "version": "1.1.0",
       "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/onetime/-/onetime-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/onetime/-/onetime-1.1.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
       "from": "optimist@>=0.6.1 <0.7.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
           "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/minimist/-/minimist-0.0.10.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/minimist/-/minimist-0.0.10.tgz"
         },
         "wordwrap": {
           "version": "0.0.3",
           "from": "wordwrap@>=0.0.2 <0.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz"
         }
       }
     },
@@ -3025,82 +3025,82 @@
     "options": {
       "version": "0.0.6",
       "from": "options@>=0.0.5",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/options/-/options-0.0.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/options/-/options-0.0.6.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
       "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/os-homedir/-/os-homedir-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "os-tmpdir": {
       "version": "1.0.1",
       "from": "os-tmpdir@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parse-glob/-/parse-glob-3.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
       "from": "parse-json@>=2.2.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parse-json/-/parse-json-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parsejson": {
       "version": "0.0.1",
       "from": "parsejson@0.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parsejson/-/parsejson-0.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parsejson/-/parsejson-0.0.1.tgz"
     },
     "parseqs": {
       "version": "0.0.2",
       "from": "parseqs@0.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parseqs/-/parseqs-0.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parseqs/-/parseqs-0.0.2.tgz"
     },
     "parseuri": {
       "version": "0.0.4",
       "from": "parseuri@0.0.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parseuri/-/parseuri-0.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parseuri/-/parseuri-0.0.4.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
       "from": "parseurl@>=1.3.0 <1.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/parseurl/-/parseurl-1.3.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/parseurl/-/parseurl-1.3.1.tgz"
     },
     "path-exists": {
       "version": "1.0.0",
       "from": "path-exists@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-exists/-/path-exists-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/path-exists/-/path-exists-1.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
       "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.1",
       "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-type": {
       "version": "1.1.0",
       "from": "path-type@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/path-type/-/path-type-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/path-type/-/path-type-1.1.0.tgz"
     },
     "pend": {
       "version": "1.2.0",
       "from": "pend@>=1.2.0 <1.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/pend/-/pend-1.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/pend/-/pend-1.2.0.tgz"
     },
     "phantomjs-prebuilt": {
       "version": "2.1.7",
       "from": "phantomjs-prebuilt@2.1.7",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.7.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.7.tgz",
       "dependencies": {
         "bl": {
           "version": "1.0.3",
           "from": "bl@>=1.0.0 <1.1.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bl/-/bl-1.0.3.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bl/-/bl-1.0.3.tgz"
         },
         "qs": {
           "version": "5.2.0",
@@ -3110,24 +3110,24 @@
         "request": {
           "version": "2.67.0",
           "from": "request@>=2.67.0 <2.68.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/request/-/request-2.67.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/request/-/request-2.67.0.tgz"
         }
       }
     },
     "pify": {
       "version": "2.3.0",
       "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/pify/-/pify-2.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
       "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/pinkie/-/pinkie-2.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pluralize": {
       "version": "1.2.1",
@@ -3137,84 +3137,84 @@
     "prelude-ls": {
       "version": "1.1.2",
       "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "preserve": {
       "version": "0.2.0",
       "from": "preserve@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/preserve/-/preserve-0.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/preserve/-/preserve-0.2.0.tgz"
     },
     "private": {
       "version": "0.1.6",
       "from": "private@>=0.1.5 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/private/-/private-0.1.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/private/-/private-0.1.6.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
       "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/progress/-/progress-1.1.8.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/progress/-/progress-1.1.8.tgz"
     },
     "promise": {
       "version": "7.1.1",
       "from": "promise@>=7.1.1 <8.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/promise/-/promise-7.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/promise/-/promise-7.1.1.tgz"
     },
     "promised-io": {
       "version": "0.3.3",
       "from": "promised-io@0.3.3",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/promised-io/-/promised-io-0.3.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/promised-io/-/promised-io-0.3.3.tgz"
     },
     "prr": {
       "version": "0.0.0",
       "from": "prr@>=0.0.0 <0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/prr/-/prr-0.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/prr/-/prr-0.0.0.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
       "from": "pseudomap@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/pseudomap/-/pseudomap-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/pseudomap/-/pseudomap-1.0.2.tgz"
     },
     "qs": {
       "version": "6.1.0",
       "from": "qs@>=6.1.0 <6.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/qs/-/qs-6.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/qs/-/qs-6.1.0.tgz"
     },
     "randomatic": {
       "version": "1.1.5",
       "from": "randomatic@>=1.1.3 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/randomatic/-/randomatic-1.1.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/randomatic/-/randomatic-1.1.5.tgz"
     },
     "raw-body": {
       "version": "2.1.6",
       "from": "raw-body@>=2.1.5 <2.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/raw-body/-/raw-body-2.1.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/raw-body/-/raw-body-2.1.6.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.3.0",
           "from": "bytes@2.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/bytes/-/bytes-2.3.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/bytes/-/bytes-2.3.0.tgz"
         }
       }
     },
     "read-json-sync": {
       "version": "1.1.1",
       "from": "read-json-sync@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/read-json-sync/-/read-json-sync-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/read-json-sync/-/read-json-sync-1.1.1.tgz"
     },
     "read-pkg": {
       "version": "1.1.0",
       "from": "read-pkg@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/read-pkg/-/read-pkg-1.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "from": "read-pkg-up@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "2.0.6",
@@ -3224,84 +3224,84 @@
     "readdirp": {
       "version": "2.0.0",
       "from": "readdirp@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readdirp/-/readdirp-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/readdirp/-/readdirp-2.0.0.tgz"
     },
     "readline2": {
       "version": "1.0.1",
       "from": "readline2@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/readline2/-/readline2-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/readline2/-/readline2-1.0.1.tgz"
     },
     "redent": {
       "version": "1.0.0",
       "from": "redent@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/redent/-/redent-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/redent/-/redent-1.0.0.tgz"
     },
     "redeyed": {
       "version": "0.5.0",
       "from": "redeyed@>=0.5.0 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/redeyed/-/redeyed-0.5.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/redeyed/-/redeyed-0.5.0.tgz",
       "dependencies": {
         "esprima-fb": {
           "version": "12001.1.0-dev-harmony-fb",
           "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
         }
       }
     },
     "regenerate": {
       "version": "1.3.1",
       "from": "regenerate@>=1.2.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regenerate/-/regenerate-1.3.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regenerate/-/regenerate-1.3.1.tgz"
     },
     "regenerator-runtime": {
       "version": "0.9.5",
       "from": "regenerator-runtime@>=0.9.5 <0.10.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
       "from": "regex-cache@>=0.4.2 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regex-cache/-/regex-cache-0.4.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "regexpu-core": {
       "version": "1.0.0",
       "from": "regexpu-core@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regexpu-core/-/regexpu-core-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regexpu-core/-/regexpu-core-1.0.0.tgz"
     },
     "regjsgen": {
       "version": "0.2.0",
       "from": "regjsgen@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regjsgen/-/regjsgen-0.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regjsgen/-/regjsgen-0.2.0.tgz"
     },
     "regjsparser": {
       "version": "0.1.5",
       "from": "regjsparser@>=0.1.4 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/regjsparser/-/regjsparser-0.1.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/regjsparser/-/regjsparser-0.1.5.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
       "from": "repeat-element@>=1.1.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/repeat-element/-/repeat-element-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.5.4",
       "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/repeat-string/-/repeat-string-1.5.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/repeat-string/-/repeat-string-1.5.4.tgz"
     },
     "repeating": {
       "version": "1.1.3",
       "from": "repeating@>=1.1.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/repeating/-/repeating-1.1.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/repeating/-/repeating-1.1.3.tgz"
     },
     "request": {
       "version": "2.72.0",
       "from": "request@>=2.51.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/request/-/request-2.72.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/request/-/request-2.72.0.tgz"
     },
     "request-progress": {
       "version": "2.0.1",
       "from": "request-progress@>=2.0.1 <2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/request-progress/-/request-progress-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/request-progress/-/request-progress-2.0.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.2",
@@ -3311,17 +3311,17 @@
     "requirejs": {
       "version": "2.2.0",
       "from": "requirejs@2.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/requirejs/-/requirejs-2.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/requirejs/-/requirejs-2.2.0.tgz"
     },
     "requires-port": {
       "version": "1.0.0",
       "from": "requires-port@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/requires-port/-/requires-port-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/requires-port/-/requires-port-1.0.0.tgz"
     },
     "requizzle": {
       "version": "0.2.1",
       "from": "requizzle@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/requizzle/-/requizzle-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/requizzle/-/requizzle-0.2.1.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
@@ -3333,7 +3333,7 @@
     "resolve": {
       "version": "1.1.7",
       "from": "resolve@>=1.1.0 <1.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/resolve/-/resolve-1.1.7.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/resolve/-/resolve-1.1.7.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -3343,27 +3343,27 @@
     "restore-cursor": {
       "version": "1.0.1",
       "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/restore-cursor/-/restore-cursor-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "rimraf": {
       "version": "2.5.2",
       "from": "rimraf@2.5.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rimraf/-/rimraf-2.5.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/rimraf/-/rimraf-2.5.2.tgz"
     },
     "run-async": {
       "version": "0.1.0",
       "from": "run-async@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/run-async/-/run-async-0.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
       "from": "rx-lite@>=3.1.2 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/rx-lite/-/rx-lite-3.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "samsam": {
       "version": "1.1.2",
       "from": "samsam@1.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/samsam/-/samsam-1.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/samsam/-/samsam-1.1.2.tgz"
     },
     "semver": {
       "version": "5.1.0",
@@ -3373,7 +3373,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "from": "shebang-regex@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/shebang-regex/-/shebang-regex-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/shebang-regex/-/shebang-regex-1.0.0.tgz"
     },
     "shelljs": {
       "version": "0.6.0",
@@ -3383,32 +3383,32 @@
     "shellwords": {
       "version": "0.1.0",
       "from": "shellwords@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/shellwords/-/shellwords-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/shellwords/-/shellwords-0.1.0.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
       "from": "sigmund@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sigmund/-/sigmund-1.0.1.tgz"
     },
     "signal-exit": {
       "version": "2.1.2",
       "from": "signal-exit@>=2.1.2 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/signal-exit/-/signal-exit-2.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/signal-exit/-/signal-exit-2.1.2.tgz"
     },
     "sinon": {
       "version": "1.17.4",
       "from": "sinon@1.17.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sinon/-/sinon-1.17.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sinon/-/sinon-1.17.4.tgz"
     },
     "sinon-chai": {
       "version": "2.8.0",
       "from": "sinon-chai@2.8.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sinon-chai/-/sinon-chai-2.8.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sinon-chai/-/sinon-chai-2.8.0.tgz"
     },
     "slash": {
       "version": "1.0.0",
       "from": "slash@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/slash/-/slash-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/slash/-/slash-1.0.0.tgz"
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -3418,17 +3418,17 @@
     "sntp": {
       "version": "1.0.9",
       "from": "sntp@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sntp/-/sntp-1.0.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sntp/-/sntp-1.0.9.tgz"
     },
     "socket.io": {
       "version": "1.4.6",
       "from": "socket.io@>=1.4.5 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/socket.io/-/socket.io-1.4.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/socket.io/-/socket.io-1.4.6.tgz"
     },
     "socket.io-adapter": {
       "version": "0.4.0",
       "from": "socket.io-adapter@0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3438,7 +3438,7 @@
         "socket.io-parser": {
           "version": "2.2.2",
           "from": "socket.io-parser@2.2.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "dependencies": {
             "debug": {
               "version": "0.7.4",
@@ -3452,19 +3452,19 @@
     "socket.io-client": {
       "version": "1.4.6",
       "from": "socket.io-client@1.4.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/socket.io-client/-/socket.io-client-1.4.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/socket.io-client/-/socket.io-client-1.4.6.tgz",
       "dependencies": {
         "component-emitter": {
           "version": "1.2.0",
           "from": "component-emitter@1.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/component-emitter/-/component-emitter-1.2.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/component-emitter/-/component-emitter-1.2.0.tgz"
         }
       }
     },
     "socket.io-parser": {
       "version": "2.2.6",
       "from": "socket.io-parser@2.2.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -3474,83 +3474,83 @@
         "json3": {
           "version": "3.3.2",
           "from": "json3@3.3.2",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/json3/-/json3-3.3.2.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/json3/-/json3-3.3.2.tgz"
         }
       }
     },
     "source-map": {
       "version": "0.5.6",
       "from": "source-map@>=0.5.0 <0.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.5.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-support": {
       "version": "0.2.10",
       "from": "source-map-support@>=0.2.10 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map-support/-/source-map-support-0.2.10.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/source-map-support/-/source-map-support-0.2.10.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.1.32",
           "from": "source-map@0.1.32",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/source-map/-/source-map-0.1.32.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/source-map/-/source-map-0.1.32.tgz"
         }
       }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "from": "spdx-correct@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/spdx-correct/-/spdx-correct-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
       "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.2",
       "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.1",
       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
       "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "sshpk": {
       "version": "1.8.3",
       "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/sshpk/-/sshpk-1.8.3.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/sshpk/-/sshpk-1.8.3.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
     "statuses": {
       "version": "1.3.0",
       "from": "statuses@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/statuses/-/statuses-1.3.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/statuses/-/statuses-1.3.0.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
       "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "string-width": {
       "version": "1.0.1",
       "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/string-width/-/string-width-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/string-width/-/string-width-1.0.1.tgz"
     },
     "stringstream": {
       "version": "0.0.5",
       "from": "stringstream@>=0.0.4 <0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/stringstream/-/stringstream-0.0.5.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/stringstream/-/stringstream-0.0.5.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -3560,22 +3560,22 @@
     "strip-bom": {
       "version": "2.0.0",
       "from": "strip-bom@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-bom/-/strip-bom-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
       "from": "strip-indent@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-indent/-/strip-indent-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
       "from": "strip-json-comments@>=1.0.1 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
       "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/supports-color/-/supports-color-2.0.0.tgz"
     },
     "table": {
       "version": "3.7.8",
@@ -3597,69 +3597,69 @@
     "text-table": {
       "version": "0.2.0",
       "from": "text-table@>=0.2.0 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/text-table/-/text-table-0.2.0.tgz"
     },
     "throttleit": {
       "version": "1.0.0",
       "from": "throttleit@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/throttleit/-/throttleit-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/throttleit/-/throttleit-1.0.0.tgz"
     },
     "through": {
       "version": "2.3.8",
       "from": "through@>=2.3.6 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/through/-/through-2.3.8.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/through/-/through-2.3.8.tgz"
     },
     "timers-ext": {
       "version": "0.1.0",
       "from": "timers-ext@>=0.1.0 <0.2.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/timers-ext/-/timers-ext-0.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/timers-ext/-/timers-ext-0.1.0.tgz"
     },
     "tiny-lr": {
       "version": "0.2.1",
       "from": "tiny-lr@>=0.2.1 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tiny-lr/-/tiny-lr-0.2.1.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/tiny-lr/-/tiny-lr-0.2.1.tgz",
       "dependencies": {
         "qs": {
           "version": "5.1.0",
           "from": "qs@>=5.1.0 <5.2.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/qs/-/qs-5.1.0.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/qs/-/qs-5.1.0.tgz"
         }
       }
     },
     "to-array": {
       "version": "0.1.4",
       "from": "to-array@0.1.4",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/to-array/-/to-array-0.1.4.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/to-array/-/to-array-0.1.4.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
       "from": "to-fast-properties@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "to-iso-string": {
       "version": "0.0.2",
       "from": "to-iso-string@0.0.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/to-iso-string/-/to-iso-string-0.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/to-iso-string/-/to-iso-string-0.0.2.tgz"
     },
     "tough-cookie": {
       "version": "2.2.2",
       "from": "tough-cookie@>=2.2.0 <2.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tough-cookie/-/tough-cookie-2.2.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/tough-cookie/-/tough-cookie-2.2.2.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
       "from": "trim-newlines@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/trim-newlines/-/trim-newlines-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.2",
       "from": "tryit@>=1.0.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tryit/-/tryit-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/tryit/-/tryit-1.0.2.tgz"
     },
     "tunnel-agent": {
       "version": "0.4.3",
       "from": "tunnel-agent@>=0.4.1 <0.5.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
     },
     "tv4": {
       "version": "1.2.7",
@@ -3669,17 +3669,17 @@
     "tweetnacl": {
       "version": "0.13.3",
       "from": "tweetnacl@>=0.13.0 <0.14.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/tweetnacl/-/tweetnacl-0.13.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/tweetnacl/-/tweetnacl-0.13.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
       "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "1.0.0",
       "from": "type-detect@>=1.0.0 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/type-detect/-/type-detect-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/type-detect/-/type-detect-1.0.0.tgz"
     },
     "type-is": {
       "version": "1.6.13",
@@ -3689,22 +3689,22 @@
     "typedarray": {
       "version": "0.0.6",
       "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz"
     },
     "ultron": {
       "version": "1.0.2",
       "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ultron/-/ultron-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ultron/-/ultron-1.0.2.tgz"
     },
     "underscore": {
       "version": "1.8.3",
       "from": "underscore@>=1.8.3 <1.9.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore/-/underscore-1.8.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/underscore/-/underscore-1.8.3.tgz"
     },
     "underscore-contrib": {
       "version": "0.3.0",
       "from": "underscore-contrib@>=0.3.0 <0.4.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
@@ -3716,64 +3716,64 @@
     "underscore.string": {
       "version": "3.2.3",
       "from": "underscore.string@>=3.2.3 <3.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/underscore.string/-/underscore.string-3.2.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/underscore.string/-/underscore.string-3.2.3.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
       "from": "unpipe@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/unpipe/-/unpipe-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/unpipe/-/unpipe-1.0.0.tgz"
     },
     "user-home": {
       "version": "1.1.1",
       "from": "user-home@>=1.1.1 <2.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/user-home/-/user-home-1.1.1.tgz"
     },
     "useragent": {
       "version": "2.1.9",
       "from": "useragent@>=2.1.6 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/useragent/-/useragent-2.1.9.tgz",
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/useragent/-/useragent-2.1.9.tgz",
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
           "from": "lru-cache@>=2.2.0 <2.3.0",
-          "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/lru-cache/-/lru-cache-2.2.4.tgz"
+          "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/lru-cache/-/lru-cache-2.2.4.tgz"
         }
       }
     },
     "utf8": {
       "version": "2.1.0",
       "from": "utf8@2.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/utf8/-/utf8-2.1.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/utf8/-/utf8-2.1.0.tgz"
     },
     "util": {
       "version": "0.10.3",
       "from": "util@>=0.10.3 <1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/util/-/util-0.10.3.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/util/-/util-0.10.3.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
       "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
       "from": "utils-merge@1.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/utils-merge/-/utils-merge-1.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "verror": {
       "version": "1.3.6",
       "from": "verror@1.3.6",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/verror/-/verror-1.3.6.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/verror/-/verror-1.3.6.tgz"
     },
     "void-elements": {
       "version": "2.0.1",
       "from": "void-elements@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/void-elements/-/void-elements-2.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/void-elements/-/void-elements-2.0.1.tgz"
     },
     "websocket-driver": {
       "version": "0.6.5",
@@ -3783,7 +3783,7 @@
     "websocket-extensions": {
       "version": "0.1.1",
       "from": "websocket-extensions@>=0.1.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
     },
     "which": {
       "version": "1.2.9",
@@ -3803,22 +3803,22 @@
     "wrench": {
       "version": "1.5.9",
       "from": "wrench@>=1.5.8 <1.6.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/wrench/-/wrench-1.5.9.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/wrench/-/wrench-1.5.9.tgz"
     },
     "write": {
       "version": "0.2.1",
       "from": "write@>=0.2.1 <0.3.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/write/-/write-0.2.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/write/-/write-0.2.1.tgz"
     },
     "ws": {
       "version": "1.0.1",
       "from": "ws@1.0.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/ws/-/ws-1.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/ws/-/ws-1.0.1.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
       "from": "xmlhttprequest-ssl@1.5.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
     },
     "xregexp": {
       "version": "3.1.1",
@@ -3828,22 +3828,22 @@
     "xtend": {
       "version": "4.0.1",
       "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/xtend/-/xtend-4.0.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/xtend/-/xtend-4.0.1.tgz"
     },
     "yallist": {
       "version": "2.0.0",
       "from": "yallist@>=2.0.0 <3.0.0",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/yallist/-/yallist-2.0.0.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/yallist/-/yallist-2.0.0.tgz"
     },
     "yauzl": {
       "version": "2.4.1",
       "from": "yauzl@2.4.1",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/yauzl/-/yauzl-2.4.1.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/yauzl/-/yauzl-2.4.1.tgz"
     },
     "yeast": {
       "version": "0.1.2",
       "from": "yeast@0.1.2",
-      "resolved": "http://maven.forgerock.org/repo/api/npm/npm-virtual/yeast/-/yeast-0.1.2.tgz"
+      "resolved": "https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/yeast/-/yeast-0.1.2.tgz"
     }
   }
 }

--- a/openam-ui/openam-ui-ria/pom.xml
+++ b/openam-ui/openam-ui-ria/pom.xml
@@ -285,8 +285,8 @@
                         <configuration>
                             <nodeVersion>v4.4.5</nodeVersion>
                             <npmVersion>3.9.3</npmVersion>
-                            <downloadRoot>http://maven.forgerock.org/repo/forgerock-third-party-virtual/</downloadRoot>
-                            <npmDownloadRoot>http://maven.forgerock.org/repo/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
+                            <downloadRoot>https://nodejs.org/dist/</downloadRoot>
+                            <npmDownloadRoot>https://wrensecurity.jfrog.io/wrensecurity/api/npm/npm-virtual/npm/-/</npmDownloadRoot>
                         </configuration>
                     </execution>
                     <execution>
@@ -298,7 +298,7 @@
                         <configuration>
                             <arguments>install</arguments>
                             <environmentVariables>
-                                <PHANTOMJS_CDNURL>http://maven.forgerock.org/repo/forgerock-third-party-virtual</PHANTOMJS_CDNURL>
+                                <PHANTOMJS_CDNURL>https://nodejs.org/dist</PHANTOMJS_CDNURL>
                             </environmentVariables>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Instead of relying on the FR NPM proxy and repo we should use our own WrenSecurity infrastructure. This PR  Closes #22.

I've added an npmjs proxy in our Artifactory instance. Which is one of the things `maven.forgerock.org`  provided. I also created a local repository called `npm-releases-third-party` in which I uploaded the `eslint-config-forgerock-1.1.1` artifact. I bound these two repo's together in a virtual repo called `npm-virtual`. This is about the same setup as FR used.

Unfortunately NPM doesn't offer signing of artifacts out of the box. This is something we will have to address in a different PR. Some food for thought: [Introducing pkgsign: package signing and verification for npm](https://medium.com/redpoint/introducing-pkgsign-package-signing-and-verification-for-npm-5b833e0ec2d4)

This particular PR just fixed the NPM part. I noticed there are some other place where `maven.forgerock.org` is used. Those places will be addressed in separate PR's.