### PR TITLE
Remove obsolete Maven FR repository declarations

### DIFF
--- a/openam-http-client/pom.xml
+++ b/openam-http-client/pom.xml
@@ -48,26 +48,7 @@ Copyright 2014-2015 ForgeRock AS.
         <connection>scm:svn:https://svn.forgerock.org/commons/forgerock-http-client/trunk</connection>
         <developerConnection>scm:svn:https://svn.forgerock.org/commons/forgerock-http-client/trunk</developerConnection>
       <tag>13.5.0</tag>
-  </scm>
-
-    <repositories>
-        <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
+    </scm>
 
     <dependencies>
         <dependency>

--- a/openam-samples/custom-authentication-module/pom.xml
+++ b/openam-samples/custom-authentication-module/pom.xml
@@ -34,18 +34,7 @@
         <openam.version>13.5.0-SNAPSHOT</openam.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-
-     <repositories>
-        <repository>
-            <id>forgerock-releases</id>
-            <url>http://maven.forgerock.org/repo/releases</url>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots</id>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-        </repository>
-    </repositories>
-
+    
     <dependencies>
         <dependency>
             <groupId>org.forgerock.openam</groupId>

--- a/openam-samples/policy-evaluation-plugin/pom.xml
+++ b/openam-samples/policy-evaluation-plugin/pom.xml
@@ -38,17 +38,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-     <repositories>
-        <repository>
-            <id>forgerock-releases</id>
-            <url>http://maven.forgerock.org/repo/releases</url>
-        </repository>
-        <repository>
-            <id>forgerock-snapshots</id>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.forgerock.openam</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -234,13 +234,6 @@
             <properties>
                 <generate.clientsdk.sources>true</generate.clientsdk.sources>
             </properties>
-            <repositories>
-                <repository>
-                    <id>forgerock-internal</id>
-                    <name>Forgerock Internal Repository</name>
-                    <url>http://maven.forgerock.org/repo/internal</url>
-                </repository>
-            </repositories>
             <dependencyManagement>
                 <dependencies>
                     <!-- Don't include the authapi*.jar in the war for a release build -->
@@ -252,35 +245,6 @@
                     </dependency>
                 </dependencies>
             </dependencyManagement>
-        </profile>
-
-        <!-- When building an Enterprise binary download, include the correct binary license terms. -->
-        <profile>
-            <!-- Overrides the default CDDL license with the Forgerock binary license. Only available from Forgerock internal repository. -->
-            <id>binary-licensing</id>
-            <repositories>
-                <repository>
-                    <id>forgerock-internal</id>
-                    <name>Forgerock Internal Repository</name>
-                    <url>http://maven.forgerock.org/repo/internal</url>
-                </repository>
-            </repositories>
-            <properties>
-                <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
-                <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
-                <forgerock.license.version>1.0.0</forgerock.license.version>
-            </properties>
-        </profile>
-
-        <profile>
-            <id>development</id>
-            <repositories>
-                <repository>
-                    <id>forgerock-internal</id>
-                    <name>Forgerock Internal Repository</name>
-                    <url>http://maven.forgerock.org/repo/internal</url>
-                </repository>
-            </repositories>
         </profile>
 
         <profile>


### PR DESCRIPTION
This commit cleanes up Maven POM's by removing FR repo's which WrenSecurity doesn't use. After this commit no FR repo's should be left in Maven POM's.

Also removed some Maven profiles which were used for building specially FR licensed products.