### PR TITLE
[13.5] Upgrade to `wrensec-parent` 2.2.0 from 2.0.6

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,2 @@
+export MAVEN_PACKAGE="openam"
+export QT_QPA_PLATFORM="offscreen"

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 *
 * Copyright (c) 2011-2016 ForgeRock AS. All Rights Reserved
+* Portions Copyright 2018 Wren Security.
 *
 * The contents of this file are subject to the terms
 * of the Common Development and Distribution License
@@ -450,6 +451,21 @@
 
             <releases>
                 <enabled>true</enabled>
+            </releases>
+        </repository>
+        
+        <!-- Needed to retrieve parent POM -->
+        <repository>
+            <id>wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
             </releases>
         </repository>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
 
     <!-- Parent Project -->
     <parent>
-        <groupId>org.forgerock</groupId>
-        <artifactId>forgerock-parent</artifactId>
-        <version>2.0.6</version>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>2.2.0</version>
     </parent>
 
     <!-- Component Definition -->

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,8 @@
         <forgerock.license.artifactId>cddl-license</forgerock.license.artifactId>
         <forgerock.license.version>1.0.0</forgerock.license.version>
         <checkstyleFailOnError>false</checkstyleFailOnError>
+
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.1.0</pgpWhitelistArtifact>
     </properties>
 
     <!-- Profiles -->


### PR DESCRIPTION
The new version has significantly better GPG signature management, and newer dependencies.