### PR TITLE
[13.5.x] Upgrade parent and fix dependencies. (#45)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8]
+    name: "Java ${{ matrix.java }} build"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run the Maven verify phase
+        run: mvn -B verify --file pom.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+bin/
 dependency-reduced-pom.xml
 
 # Versions maven plugin 
@@ -7,3 +8,8 @@ dependency-reduced-pom.xml
 # Editor generated files
 *.iml
 .idea/
+
+# Eclipse IDE files
+.project
+.classpath
+.settings

--- a/openam-schema/openam-mib-schema/pom.xml
+++ b/openam-schema/openam-mib-schema/pom.xml
@@ -46,6 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>generate-sun-mib-source</id>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>2.2.0</version>
+        <version>3.2.1</version>
     </parent>
 
     <!-- Component Definition -->
@@ -197,7 +197,7 @@
         <forgerock.license.version>1.0.0</forgerock.license.version>
         <checkstyleFailOnError>false</checkstyleFailOnError>
 
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.1.0</pgpWhitelistArtifact>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.5</pgpWhitelistArtifact>
     </properties>
 
     <!-- Profiles -->
@@ -455,7 +455,7 @@
                 <enabled>true</enabled>
             </releases>
         </repository>
-        
+
         <!-- Needed to retrieve parent POM -->
         <repository>
             <id>wrensecurity-snapshots</id>
@@ -536,17 +536,17 @@
                 <version>${project.version}</version>
             </dependency>
 
-	        <dependency>
-	        	<groupId>org.forgerock.openam</groupId>
-	        	<artifactId>openam-radius-common</artifactId>
-	        	<version>${project.version}</version>
-	        </dependency>
+            <dependency>
+                <groupId>org.forgerock.openam</groupId>
+                <artifactId>openam-radius-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-	        <dependency>
-	        	<groupId>org.forgerock.openam</groupId>
-	        	<artifactId>openam-radius-server</artifactId>
-	        	<version>${project.version}</version>
-	        </dependency>
+            <dependency>
+                <groupId>org.forgerock.openam</groupId>
+                <artifactId>openam-radius-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.forgerock.openam</groupId>


### PR DESCRIPTION
I have upgraded parent to the current version which no longer uses bintray repositories. 

Changes made:
* Antrun version forcefully lowered because the current one no longer uses `sourceRoot` option  - proper solution is to replace it with build-helper-maven-plugin
* Added forgerock public repo https://maven.forgerock.org/repo/openam-dependencies
Libraries located there:
  * `com.iplanet.jato:jato:jar:2005-05-04`
  * `com.sun.web.ui:cc:jar:2008-08-08`
  * `external:esapiport:jar:2013-12-04`