### PR TITLE
Add Java 11 and 17 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run the Maven verify phase
-        run: mvn -B verify -P '!jre8-compat'
+        run: mvn -B verify -Dpmd.skip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8]
+        java: [11, 17]
     name: "Java ${{ matrix.java }} build"
     steps:
       - uses: actions/checkout@v2
@@ -22,4 +22,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Run the Maven verify phase
-        run: mvn -B verify --file pom.xml
+        run: mvn -B verify -P '!jre8-compat'

--- a/openam-authentication/openam-auth-cert/src/main/java/com/sun/identity/authentication/modules/cert/Cert.java
+++ b/openam-authentication/openam-auth-cert/src/main/java/com/sun/identity/authentication/modules/cert/Cert.java
@@ -25,6 +25,7 @@
  * $Id: Cert.java,v 1.14 2009/03/13 20:54:42 beomsuk Exp $
  *
  * Portions Copyrighted 2013-2016 ForgeRock AS.
+ * Portions Copyrighted 2022 Wren Security
  */
 
 package com.sun.identity.authentication.modules.cert;
@@ -65,7 +66,6 @@ import com.sun.identity.shared.datastruct.CollectionHelper;
 import com.sun.identity.shared.encode.Base64;
 
 import sun.security.util.DerValue;
-import sun.security.util.ObjectIdentifier;
 import sun.security.x509.CertificateExtensions;
 import sun.security.x509.GeneralName;
 import sun.security.x509.GeneralNameInterface;
@@ -570,14 +570,11 @@ public class Cert extends AMLoginModule {
                     exts.get(SubjectAlternativeNameExtension.NAME);
 
             if (altNameExt != null) {
-                GeneralNames names = (GeneralNames) altNameExt.get
-                    (SubjectAlternativeNameExtension.SUBJECT_NAME);
+                GeneralNames names = altNameExt.get(SubjectAlternativeNameExtension.SUBJECT_NAME);
         
-                GeneralName generalname = null;  
-                ObjectIdentifier upnoid = new ObjectIdentifier(UPNOID); 
-                Iterator itr = (Iterator) names.iterator();
+                Iterator itr = names.iterator();
                 while ((userTokenId == null) && itr.hasNext()) {
-                    generalname = (GeneralName) itr.next(); 
+                    GeneralName generalname = (GeneralName) itr.next();
                     if (generalname != null) {
                         if (amAuthCert_subjectAltExtMapper.
                         	equalsIgnoreCase("UPN") && 
@@ -585,7 +582,7 @@ public class Cert extends AMLoginModule {
                 	        GeneralNameInterface.NAME_ANY)) {
                             OtherName othername = 
                                 (OtherName)generalname.getName(); 
-                            if (upnoid.equals((Object)(othername.getOID()))) {
+                            if (UPNOID.equals(othername.getOID().toString())) {
                                 byte[] nval = othername.getNameValue(); 
                                 DerValue derValue = new DerValue(nval); 
                                 userTokenId = 

--- a/openam-console/src/main/java/com/iplanet/jato/util/Encoder.java
+++ b/openam-console/src/main/java/com/iplanet/jato/util/Encoder.java
@@ -1,0 +1,57 @@
+package com.iplanet.jato.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.InflaterInputStream;
+
+/**
+ * JATO monkey patched encoder.
+ */
+public class Encoder {
+
+    public static String encode(byte[] bytes) {
+        return encodeHttp64(bytes, 2147483647);
+    }
+
+    public static byte[] decode(String s) {
+        return decodeHttp64(s);
+    }
+
+    public static String encodeBase64(byte[] bytes) {
+        return Base64.getUrlEncoder().encodeToString(bytes);
+    }
+
+    public static byte[] decodeBase64(String s) {
+        return Base64.getUrlDecoder().decode(s);
+    }
+
+    public static String encodeHttp64(byte[] bytes, int compressThreshold) {
+        return encodeBase64(bytes);
+    }
+
+    public static byte[] decodeHttp64(String s) {
+        return decodeBase64(s);
+    }
+
+    public static byte[] serialize(Serializable o, boolean compress) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(o);
+        oos.flush();
+        oos.close();
+        return baos.toByteArray();
+    }
+
+    public static Object deserialize(byte[] b, boolean compressed) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(b);
+        return new ApplicationObjectInputStream(bais).readObject();
+    }
+
+}

--- a/openam-core/src/test/java/org/forgerock/openam/setup/TestSetupHelper.java
+++ b/openam-core/src/test/java/org/forgerock/openam/setup/TestSetupHelper.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
  */
 
 package org.forgerock.openam.setup;
@@ -45,7 +46,7 @@ public class TestSetupHelper {
             Files.createDirectories(destinationDirectory);
         }
 
-        try (java.nio.file.FileSystem zipFileSystem = FileSystems.newFileSystem(zipFile.toPath(), null)) {
+        try (java.nio.file.FileSystem zipFileSystem = FileSystems.newFileSystem(zipFile.toPath(), (ClassLoader) null)) {
             Path root = zipFileSystem.getPath("/");
             Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
                 @Override

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/sae/api/SecureAttrs.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/sae/api/SecureAttrs.java
@@ -25,6 +25,7 @@
  * $Id: SecureAttrs.java,v 1.12 2009/03/31 17:18:10 exu Exp $
  *
  * Portions Copyrighted 2016 ForgeRock AS.
+ * Portions Copyrighted 2022 Wren Security
  */
 
 package com.sun.identity.sae.api;
@@ -37,7 +38,6 @@ import java.io.*;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import sun.misc.CharacterEncoder;
 import com.sun.identity.shared.encode.Base64;
 import com.sun.identity.security.DataEncryptor;
 import java.security.*;

--- a/openam-federation/pom.xml
+++ b/openam-federation/pom.xml
@@ -13,6 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2011-2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -39,5 +40,12 @@
         <module>openam-idpdiscovery-war</module>
         <module>OpenFM</module>
     </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+        </dependency>
+    </dependencies>
 </project>
 

--- a/openam-schema/openam-idsvcs-schema/pom.xml
+++ b/openam-schema/openam-idsvcs-schema/pom.xml
@@ -123,6 +123,11 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.xml.soap</groupId>
+            <artifactId>jakarta.xml.soap-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.sun.xml.rpc</groupId>
             <artifactId>jaxrpc-spi</artifactId>
         </dependency>

--- a/openam-schema/openam-xacml3-schema/pom.xml
+++ b/openam-schema/openam-xacml3-schema/pom.xml
@@ -31,6 +31,13 @@
     <artifactId>openam-xacml3-schema</artifactId>
     <packaging>jar</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+    </dependencies>
+
     <!-- Profiles -->
     <profiles>
         <!-- Place Default Profiles here to override and determine Environment. -->

--- a/openam-scripting/src/main/java/org/forgerock/openam/scripting/ThreadPoolScriptEvaluator.java
+++ b/openam-scripting/src/main/java/org/forgerock/openam/scripting/ThreadPoolScriptEvaluator.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
  */
 
 package org.forgerock.openam.scripting;
@@ -172,8 +173,8 @@ public final class ThreadPoolScriptEvaluator implements ScriptEvaluator {
                                 newConfiguration.getThreadPoolIdleTimeoutSeconds());
                     }
 
-                    delegateConfigurator.setCorePoolSize(newConfiguration.getThreadPoolCoreSize());
                     delegateConfigurator.setMaximumPoolSize(newConfiguration.getThreadPoolMaxSize());
+                    delegateConfigurator.setCorePoolSize(newConfiguration.getThreadPoolCoreSize());
                     delegateConfigurator.setKeepAliveTime(newConfiguration.getThreadPoolIdleTimeoutSeconds(), TimeUnit.SECONDS);
                 }
 

--- a/openam-shared/pom.xml
+++ b/openam-shared/pom.xml
@@ -63,6 +63,11 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
         </dependency>

--- a/openam-shared/src/main/java/com/sun/identity/common/CaseInsensitiveHashSet.java
+++ b/openam-shared/src/main/java/com/sun/identity/common/CaseInsensitiveHashSet.java
@@ -25,6 +25,7 @@
  * $Id: CaseInsensitiveHashSet.java,v 1.4 2008/06/25 05:42:25 qcheng Exp $
  *
  * Portions copyright 2015 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
  */
 
 package com.sun.identity.common;
@@ -126,7 +127,7 @@ public class CaseInsensitiveHashSet<T> extends HashSet<T> {
     }
 
     public Object[] toArray() {
-        return toArray(null);
+        return toArray((Object[]) null);
     }
     
     /**

--- a/openam-shared/src/main/java/org/forgerock/openam/shared/security/crypto/AESWrapEncryption.java
+++ b/openam-shared/src/main/java/org/forgerock/openam/shared/security/crypto/AESWrapEncryption.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
  */
 
 package org.forgerock.openam.shared.security.crypto;
@@ -66,7 +67,11 @@ public class AESWrapEncryption implements AMEncryption, ConfigurableKey {
     private static final int AESWRAP_BLOCK_SIZE = 8;
 
     private static final int CACHE_SIZE = Integer.getInteger("amCryptoCacheSize", 500);
-    private static final CipherProvider CIPHER_PROVIDER = Providers.cipherProvider("AESWrap", null, CACHE_SIZE);
+
+    private static final String CIPHER_PROVIDER_ALGORITHM =
+            Double.parseDouble(System.getProperty("java.specification.version")) >= 17 ? "AESWrapPad" : "AESWrap";
+
+    private static final CipherProvider CIPHER_PROVIDER = Providers.cipherProvider(CIPHER_PROVIDER_ALGORITHM, null, CACHE_SIZE);
 
     private static final int KEY_SIZE = Integer.getInteger("org.forgerock.openam.encryption.key.size", 128);
 

--- a/openam-shared/src/test/java/com/sun/identity/common/CaseInsensitivePropertiesTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/common/CaseInsensitivePropertiesTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions copyright 2022 Wren Security
  */
 
 package com.sun.identity.common;
@@ -21,7 +22,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 public class CaseInsensitivePropertiesTest {
 
@@ -39,7 +40,7 @@ public class CaseInsensitivePropertiesTest {
 
         ByteArrayOutputStream pOut = new ByteArrayOutputStream();
         p.store(pOut, null);
-        System.out.println(pOut.toString());
+        System.out.println(pOut);
         ByteArrayInputStream pIn = new ByteArrayInputStream(pOut.toByteArray());
         CaseInsensitiveProperties pp = new CaseInsensitiveProperties();
         pp.load(pIn);

--- a/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
+++ b/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
@@ -146,6 +146,14 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+        </dependency>
 
         <!-- test dependencies -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.5.0</version>
+        <version>4.0.0</version>
     </parent>
 
     <!-- Component Definition -->
@@ -92,7 +92,10 @@
     <properties>
         <wrensec-commons.version>22.4.0</wrensec-commons.version>
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
-        <pgpVerifyKeysVersion>1.7.3</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.4-SNAPSHOT</pgpVerifyKeysVersion>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- **************************************************************** -->
         <maven.build.timestamp.format>yyyy-MMM-dd HH:mm:ss</maven.build.timestamp.format>
@@ -2024,10 +2027,7 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
-                    <encoding>UTF-8</encoding>
-                    <!-- Override Enforcer Rules for OpenAM Compilation -->
+                    <release combine.self="override" />
                     <compilerArgument>-Xlint:none</compilerArgument>
                     <showDeprecation>false</showDeprecation>
                 </configuration>
@@ -2071,11 +2071,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.6</version>
                 <configuration>
+                    <!--
                     <rulesets>
                         <ruleset>java-enforce-timeservice</ruleset>
                     </rulesets>
+                    -->
                 </configuration>
                 <executions>
                     <execution>
@@ -2085,6 +2086,7 @@
                         </goals>
                     </execution>
                 </executions>
+                <!--
                 <dependencies>
                     <dependency>
                         <groupId>org.forgerock.openam.pmd.rules</groupId>
@@ -2092,6 +2094,7 @@
                         <version>1.0.0</version>
                     </dependency>
                 </dependencies>
+                -->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,18 @@
         <!-- **************************************************************** -->
 
         <!-- Surefire Argument Line -->
-        <java.surefire.options>-Xms256m -Xmx256m</java.surefire.options>
+        <java.surefire.options>
+            -Xmx256m
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.nio.charset=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-exports java.base/sun.security.jca=ALL-UNNAMED
+            --add-exports java.base/sun.security.util=ALL-UNNAMED
+            --add-exports java.base/sun.security.x509=ALL-UNNAMED
+            --add-exports java.base/jdk.internal.util=ALL-UNNAMED
+            --add-exports java.base/jdk.internal.util.random=ALL-UNNAMED
+        </java.surefire.options>
 
         <!-- JavaDoc Setting Properties -->
         <javadoc.options>-J-Xms2g -J-Xmx2g</javadoc.options>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,9 @@
         <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
         <amazon.sns.version>1.10.72</amazon.sns.version>
         <javax.websocket-api.version>1.1</javax.websocket-api.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version>
+        <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
 
         <openam.version>OpenAM ${project.version}</openam.version>
         <!--  Project web site -->
@@ -1343,6 +1346,24 @@
                 <groupId>com.sun.xml.rpc</groupId>
                 <artifactId>jaxrpc-spi</artifactId>
                 <version>${jaxrpc-spi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.soap</groupId>
+                <artifactId>jakarta.xml.soap-api</artifactId>
+                <version>${jakarta.xml.soap-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>${jakarta.xml.ws-api.version}</version>
             </dependency>
 
             <!-- TODO jmx -->

--- a/pom.xml
+++ b/pom.xml
@@ -2221,7 +2221,6 @@
                     <artifactId>jaxb2-maven-plugin</artifactId>
                     <version>1.3.1</version>
                 </plugin>
-
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
@@ -2233,11 +2232,6 @@
                     <version>2.2.2</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.4</version>
-                </plugin>
-                <plugin>
                     <groupId>net.ju-n.maven.plugins</groupId>
                     <artifactId>checksum-maven-plugin</artifactId>
                     <version>1.2</version>
@@ -2246,11 +2240,6 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>buildnumber-maven-plugin</artifactId>
                     <version>1.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.skins</groupId>
@@ -2301,11 +2290,6 @@
                     <groupId>org.codehaus.cargo</groupId>
                     <artifactId>cargo-maven3-plugin</artifactId>
                     <version>1.9.13</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.3</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
This PR makes the build working on JDK 11 and 17 (with disabled jre8-compat profile).

List of changes:

* Remove useless plugin configurations that are defined in wrensec-parent (except maven-checkstyle-plugin).
* Add and upgrade some Java 11+ related dependencies.
* Use AESWrapPad transformation in `AESWrapEncryption` - this fixes `IllegalBlockSizeException` in Java 17.
* Rewrite `CaseInsensitiveProperties` to fix storing - the original implementation has not been compatible with JDK > 8 because the keys must be `String`s, but they were `CaseInsensitiveKey`s.
* Fix thread pool settings
* Add exports to Surefire options
* Add Java 11 and 17 to GitHub Workflow build


Known issues:

* Old GUI (data stores, agents configuration…) does not work on JDK >= 11.