### PR TITLE
Update default debug log format. #51

### DIFF
--- a/openam-core-rest/src/test/resources/record/debugconfig.properties
+++ b/openam-core-rest/src/test/resources/record/debugconfig.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 package com.sun.identity.shared.debug;
 
@@ -41,7 +42,7 @@ public final class DebugConstants {
 
     public static final String CONFIG_DEBUG_LOGFILE_MAX_SIZE = "org.forgerock.openam.debug.rotation.maxsize";
 
-    public static final String DEFAULT_DEBUG_SUFFIX_FORMAT = "-MM.dd.yyyy-kk.mm";
+    public static final String DEFAULT_DEBUG_SUFFIX_FORMAT = "-yyyy.MM.dd-HH.mm.ss";
 
     public static final String CONFIG_DEBUG_LEVEL = "com.iplanet.services.debug.level";
 

--- a/openam-shared/src/test/java/com/sun/identity/shared/debug/DebugConfigurationFromPropertiesTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/debug/DebugConfigurationFromPropertiesTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2022 Wren Security
  */
 
 package com.sun.identity.shared.debug;
@@ -37,7 +38,7 @@ public class DebugConfigurationFromPropertiesTest {
         DebugConfigurationFromProperties debugConfigurationFromProperties = new DebugConfigurationFromProperties
                 (DEBUG_CONFIG_DIRECTORY + "valid/basicconfig.properties");
         Assert.assertTrue(debugConfigurationFromProperties.getDebugPrefix().isEmpty(), "Debug prefix should be empty");
-        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-MM.dd.yyyy-HH.mm");
+        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-yyyy.MM.dd-HH.mm.ss");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationInterval(), -1, "Debug rotation should be " +
                 "empty");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationFileSizeInByte(), -1, "Debug file size " +
@@ -61,7 +62,7 @@ public class DebugConfigurationFromPropertiesTest {
         DebugConfigurationFromProperties debugConfigurationFromProperties = new DebugConfigurationFromProperties
                 (DEBUG_CONFIG_DIRECTORY + "valid/timeRotationConfig.properties");
         Assert.assertTrue(debugConfigurationFromProperties.getDebugPrefix().isEmpty(), "Debug prefix should be empty");
-        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-MM.dd.yyyy-HH.mm");
+        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-yyyy.MM.dd-HH.mm.ss");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationInterval(), 3);
         Assert.assertEquals(debugConfigurationFromProperties.getRotationFileSizeInByte(), -1, "Debug file size " +
                 "rotation should be empty");
@@ -72,7 +73,7 @@ public class DebugConfigurationFromPropertiesTest {
         DebugConfigurationFromProperties debugConfigurationFromProperties = new DebugConfigurationFromProperties
                 (DEBUG_CONFIG_DIRECTORY + "valid/sizeRotationConfig.properties");
         Assert.assertTrue(debugConfigurationFromProperties.getDebugPrefix().isEmpty(), "Debug prefix should be empty");
-        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-MM.dd.yyyy-HH.mm.ss.SSS");
+        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-yyyy.MM.dd-HH.mm.ss.SSS");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationInterval(), -1, "Debug rotation should be " +
                 "empty");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationFileSizeInByte(), 2 << 20);
@@ -83,7 +84,7 @@ public class DebugConfigurationFromPropertiesTest {
         DebugConfigurationFromProperties debugConfigurationFromProperties = new DebugConfigurationFromProperties
                 (DEBUG_CONFIG_DIRECTORY + "valid/sizeAndTimeRotationConfig.properties");
         Assert.assertTrue(debugConfigurationFromProperties.getDebugPrefix().isEmpty(), "Debug prefix should be empty");
-        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-MM.dd.yyyy-HH.mm.ss.SSS");
+        Assert.assertEquals(debugConfigurationFromProperties.getDebugSuffix(), "-yyyy.MM.dd-HH.mm.ss.SSS");
         Assert.assertEquals(debugConfigurationFromProperties.getRotationInterval(), 3);
         Assert.assertEquals(debugConfigurationFromProperties.getRotationFileSizeInByte(), 2 << 20);
     }

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/cantParseSuffix.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/cantParseSuffix.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.ww
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.ww
 org.forgerock.openam.debug.rotation=3

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/negativeSizeRotation.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/negativeSizeRotation.properties
@@ -12,8 +12,9 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm.ss.SSS
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=
 org.forgerock.openam.debug.rotation.maxsize=-2

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/negativeTimeRotation.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/negativeTimeRotation.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH
 org.forgerock.openam.debug.rotation=-3

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/suffixNotCompatibleWithFileSizeRotationEnable.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/suffixNotCompatibleWithFileSizeRotationEnable.properties
@@ -12,8 +12,9 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH
 org.forgerock.openam.debug.rotation=
 org.forgerock.openam.debug.rotation.maxsize=2

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/timeRotationNotCompatibleWithSuffix.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/invalid/timeRotationNotCompatibleWithSuffix.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH
 org.forgerock.openam.debug.rotation=3

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/valid/basicconfig.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/valid/basicconfig.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/valid/sizeAndTimeRotationConfig.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/valid/sizeAndTimeRotationConfig.properties
@@ -12,8 +12,9 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm.ss.SSS
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss.SSS
 org.forgerock.openam.debug.rotation=3
 org.forgerock.openam.debug.rotation.maxsize=2

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/valid/sizeRotationConfig.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/valid/sizeRotationConfig.properties
@@ -12,8 +12,9 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm.ss.SSS
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss.SSS
 org.forgerock.openam.debug.rotation=
 org.forgerock.openam.debug.rotation.maxsize=2

--- a/openam-shared/src/test/resources/debug_config_test/config_validation/valid/timeRotationConfig.properties
+++ b/openam-shared/src/test/resources/debug_config_test/config_validation/valid/timeRotationConfig.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=3

--- a/openam-shared/src/test/resources/debug_config_test/debugconfig.properties
+++ b/openam-shared/src/test/resources/debug_config_test/debugconfig.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=

--- a/openam-shared/src/test/resources/debug_config_test/debugconfigRotation.properties
+++ b/openam-shared/src/test/resources/debug_config_test/debugconfigRotation.properties
@@ -12,7 +12,8 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss
 org.forgerock.openam.debug.rotation=3

--- a/openam-shared/src/test/resources/debug_config_test/debugconfigSizeRotation.properties
+++ b/openam-shared/src/test/resources/debug_config_test/debugconfigSizeRotation.properties
@@ -12,8 +12,9 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2015-2016 ForgeRock AS.
+# Portions Copyright 2022 Wren Security
 #
 org.forgerock.openam.debug.prefix=
-org.forgerock.openam.debug.suffix=-MM.dd.yyyy-HH.mm.ss.SSS
+org.forgerock.openam.debug.suffix=-yyyy.MM.dd-HH.mm.ss.SSS
 org.forgerock.openam.debug.rotation=
 org.forgerock.openam.debug.rotation.maxsize=2


### PR DESCRIPTION
This changes default rotated file suffix to `-yyyyMMdd-HHmm`.