### PR TITLE
Add simple Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Ignore build-related folders
+**/target
+**/node_modules
+
+# Ignore git files
+.git
+.gitignore
+
+# Ignore Docker files
+.dockerignore
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM maven:3.8.6-eclipse-temurin-17 AS project-build
+
+# FIXME bzip2 is for PhantomJS that is deprecated
+
+# Install build dependencies
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends bzip2 unzip
+
+# Copy project files
+WORKDIR /project
+COPY . .
+
+# Perform actual Wren:AM build
+RUN \
+  --mount=type=cache,target=/root/.m2 \
+  --mount=type=cache,target=/root/.npm \
+  mvn package -Dpmd.skip
+
+# Copy built artifacts into target directory
+RUN \
+  mkdir /build && \
+  mvn -Dexpression=project.version -q -DforceStdout help:evaluate > /build/version.txt && \
+  unzip openam-server/target/OpenAM-$(cat /build/version.txt).war -d /build/wrenam
+
+
+FROM tomcat:9-jdk17-temurin
+
+# Set environment variables
+ENV \
+  WRENAM_HOME="/srv/wrenam" \
+  JAVA_OPTS=" \
+    --add-exports=java.base/sun.security.tools.keytool=ALL-UNNAMED \
+    --add-exports=java.base/sun.security.x509=ALL-UNNAMED \
+    --add-exports=java.management/sun.management=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.net=ALL-UNNAMED \
+    --add-opens=java.base/java.util.regex=ALL-UNNAMED \
+    -Dcom.sun.identity.configuration.directory=/srv/wrenam \
+  " \
+  CATALINA_OPTS="-server -Xmx2g -XX:MetaspaceSize=256m -XX:MaxMetaspaceSize=256m"
+
+# Create wrenam user
+ARG WRENAM_UID=1000
+ARG WRENAM_GID=1000
+RUN addgroup --gid ${WRENAM_GID} wrenam && \
+    adduser --uid ${WRENAM_UID} --gid ${WRENAM_GID} --system --home=${WRENAM_HOME} wrenam
+
+# Deploy wrenam project
+ARG WRENAM_CONTEXT=auth
+COPY --chown=wrenam:root --from=project-build /build/wrenam /usr/local/tomcat/webapps/${WRENAM_CONTEXT}
+
+USER ${WRENAM_UID}
+WORKDIR ${WRENAM_HOME}
+
+# Prepare Wren:AM configuration directory
+RUN mkdir -p $WRENAM_HOME
+VOLUME $WRENAM_HOME
+
+CMD ["catalina.sh", "run"]


### PR DESCRIPTION
This PR adds simple multistage dockerfile for building Wren:AM docker image.

Built image does not contain tools other than Wren:AM itself. I want to add stuff (e.g. SSOAdminTool) later on.