### PR TITLE
Add SAAJ exports to fix RPC calls. #77

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV \
     --add-exports=java.base/sun.security.tools.keytool=ALL-UNNAMED \
     --add-exports=java.base/sun.security.x509=ALL-UNNAMED \
     --add-exports=java.management/sun.management=ALL-UNNAMED \
+    --add-exports=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED \
     --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
     --add-opens=java.base/java.net=ALL-UNNAMED \
     --add-opens=java.base/java.util.regex=ALL-UNNAMED \


### PR DESCRIPTION
This fixes IllegalAccessError when calling RPC requests (e.g. via ssoadm).

Example request that lead to the error:

```bash
curl -XPOST -H 'SOAPAction: ' -H 'Content-Type: text/xml' -d '<?xml version="1.0" encoding="UTF-8"?><env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:enc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:ns0="http://isp.com/types" xmlns:ns1="http://java.sun.com/jax-rpc-ri/internal" env:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><env:Header></env:Header><env:Body><ans1:checkForLocal xmlns:ans1="http://isp.com/wsdl"></ans1:checkForLocal></env:Body></env:Envelope>' http://localhost:9080/openam/jaxrpc/SMSObjectIF -v
```

Error that was produced during the call:

```
java.lang.IllegalAccessError: superclass access check failed: class com.sun.xml.messaging.saaj.soap.SOAPDocumentImpl (in unnamed module @0x749563d9) cannot access class com.sun.org.apache.xerces.internal.dom.DocumentImpl (in module java.xml) because module java.xml does not export com.sun.org.apache.xerces.internal.dom to unnamed module @0x749563d9
```

This was also preventing ssoadm tool to correctly locate server instances which lead to unresponsiveness.