### PR TITLE
Fix Jato patch to support compression

### DIFF
--- a/openam-console/src/main/java/com/iplanet/jato/util/Encoder.java
+++ b/openam-console/src/main/java/com/iplanet/jato/util/Encoder.java
@@ -40,18 +40,18 @@ public class Encoder {
         return decodeBase64(s);
     }
 
-    public static byte[] serialize(Serializable o, boolean compress) throws IOException {
+    public static byte[] serialize(Serializable object, boolean compress) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
-        ObjectOutputStream oos = new ObjectOutputStream(baos);
-        oos.writeObject(o);
+        ObjectOutputStream oos = new ObjectOutputStream(compress ? new DeflaterOutputStream(baos) : baos);
+        oos.writeObject(object);
         oos.flush();
         oos.close();
         return baos.toByteArray();
     }
 
-    public static Object deserialize(byte[] b, boolean compressed) throws IOException, ClassNotFoundException {
-        ByteArrayInputStream bais = new ByteArrayInputStream(b);
-        return new ApplicationObjectInputStream(bais).readObject();
+    public static Object deserialize(byte[] data, boolean compressed) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream input = new ByteArrayInputStream(data);
+        return new ApplicationObjectInputStream(compressed ? new InflaterInputStream(input) : input).readObject();
     }
 
 }

--- a/openam-console/src/test/java/com/iplanet/jato/util/EncoderTest.java
+++ b/openam-console/src/test/java/com/iplanet/jato/util/EncoderTest.java
@@ -1,0 +1,27 @@
+package com.iplanet.jato.util;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class EncoderTest {
+
+    @DataProvider(name = "compression")
+    public Object[][] compressionToggle() {
+       return new Object[][] {
+           { false },
+           { true },
+       };
+    }
+
+    @Test(dataProvider = "compression")
+    public void testSerialize(boolean compressed) throws ClassNotFoundException, IOException {
+        final String value = "HELLO WORLD";
+
+        assertEquals(Encoder.deserialize(Encoder.serialize(value, compressed), compressed), value);
+    }
+
+}


### PR DESCRIPTION
When I made Jato Encoder monkey patch I thought I could get away with dropping compression handling. Turns out another part of the codebase is working with this parameter independently of Jato's class - https://github.com/WrenSecurity/wrenam/blob/7cd9d4c69fa6089d89767a4913f1cafe7a82edab/openam-console/src/main/java/com/sun/identity/console/components/view/html/SerializedField.java#L122 .