### PR TITLE
Fix realm creation using CLI #77

### DIFF
--- a/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/CliGuiceModule.java
+++ b/openam-cli/openam-cli-impl/src/main/java/com/sun/identity/cli/CliGuiceModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 package com.sun.identity.cli;
@@ -28,6 +29,7 @@ import org.forgerock.openam.entitlement.service.EntitlementConfigurationFactory;
 import org.forgerock.openam.entitlement.service.ResourceTypeService;
 import org.forgerock.openam.entitlement.service.ResourceTypeServiceImpl;
 import org.forgerock.openam.entitlement.utils.NullNotificationBroker;
+import org.forgerock.openam.notifications.LocalOnly;
 import org.forgerock.openam.notifications.NotificationBroker;
 import org.forgerock.openam.session.SessionCache;
 import org.forgerock.openam.shared.guice.CloseableHttpClientProvider;
@@ -51,6 +53,7 @@ public class CliGuiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(NotificationBroker.class).to(NullNotificationBroker.class);
+        bind(NotificationBroker.class).annotatedWith(LocalOnly.class).to(NullNotificationBroker.class);
         bind(ResourceTypeConfiguration.class).to(ResourceTypeConfigurationImpl.class);
         bind(ResourceTypeService.class).to(ResourceTypeServiceImpl.class);
         bind(ConstraintValidator.class).to(ConstraintValidatorImpl.class);

--- a/openam-notifications-integration/src/main/java/org/forgerock/openam/notifications/integration/brokers/CTSNotificationBroker.java
+++ b/openam-notifications-integration/src/main/java/org/forgerock/openam/notifications/integration/brokers/CTSNotificationBroker.java
@@ -52,6 +52,7 @@ import org.forgerock.openam.cts.continuous.ChangeType;
 import org.forgerock.openam.cts.continuous.ContinuousQueryListener;
 import org.forgerock.openam.cts.exceptions.CoreTokenException;
 import org.forgerock.openam.notifications.Consumer;
+import org.forgerock.openam.notifications.LocalOnly;
 import org.forgerock.openam.notifications.NotificationBroker;
 import org.forgerock.openam.notifications.Subscription;
 import org.forgerock.openam.notifications.Topic;
@@ -105,7 +106,7 @@ public final class CTSNotificationBroker implements NotificationBroker {
      */
     @Inject
     public CTSNotificationBroker(CTSPersistentStore store,
-            @Named("localBroker") NotificationBroker localBroker,
+            @LocalOnly NotificationBroker localBroker,
             @Named("ctsQueueSize") int queueSize,
             @Named("tokenExpirySeconds") long tokenExpirySeconds,
             @Named("publishFrequencyMilliseconds") long publishFrequencyMilliseconds,


### PR DESCRIPTION
Adds missing binding of `@LocalOnly NullNotificationBroker` that was causing `com.google.inject.ConfigurationException` while realm creation using `ssoadm create-realm` command.

The change in `CTSNotificationBroker` is about fixing a forgotten modification in cab13b6e.

Fixes #77.