### PR TITLE
Revert "OPENAM-9849 Ensure isActive false takes precedence on multiple datastores"

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/idm/server/IdServicesImpl.java
+++ b/openam-core/src/main/java/com/sun/identity/idm/server/IdServicesImpl.java
@@ -1152,7 +1152,7 @@ public class IdServicesImpl implements IdServices {
                } else {
                    active = idRepo.isActive(token, type, name);
                }
-               if (!active) {
+               if (active) {
                    break;
                }
            } catch (IdRepoFatalException idf) {


### PR DESCRIPTION
As a workaround for https://github.com/WrenSecurity/wrenam/issues/92 I reverted the commit that introduced requirement of the active account in all configured user data stores.