### PR TITLE
Fix date format constant for version check.

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/config/Options.java
+++ b/openam-core/src/main/java/com/sun/identity/config/Options.java
@@ -45,13 +45,15 @@ public class Options extends TemplatedPage {
     protected boolean upgradeCompleted = false;
     protected boolean isOpenDS1x = false;
     protected boolean debugOn = false;
-    
+
     private java.util.Locale configLocale = null;
-    
+
+    @Override
     protected String getTitle() {
         return isNewInstall() ? "configuration.options.title" : "upgrade.title";
     }
 
+    @Override
     public void doInit() {
         upgrade = !isNewInstall();
         upgradeCompleted = AMSetupServlet.isUpgradeCompleted();
@@ -68,9 +70,9 @@ public class Options extends TemplatedPage {
         if (isOpenDS1x) {
             addModel("odsdir", AMSetupServlet.getBaseDir());
         }
-        
+
         debugOn = getContext().getRequest().getParameter( "debug" ) != null;
-        
+
         if (debugOn) {
             AMSetupServlet.enableDebug();
         }

--- a/openam-core/src/main/java/org/forgerock/openam/upgrade/DirectoryContentUpgrader.java
+++ b/openam-core/src/main/java/org/forgerock/openam/upgrade/DirectoryContentUpgrader.java
@@ -89,7 +89,7 @@ public class DirectoryContentUpgrader {
 
     // Knowledge Based Authentication information container - the object class for kbaInfo
     private static final String KBA_INFO_OC = "kbaInfoContainer";
-    private static final int VERSION_1350 = 1350;
+    private static final String VERSION_1350 = "13.5.0";
 
     private final List<Upgrader> upgraders = new ArrayList<Upgrader>();
     private final ConnectionFactory<Connection> connFactory;

--- a/openam-core/src/main/java/org/forgerock/openam/upgrade/ParsedVersion.java
+++ b/openam-core/src/main/java/org/forgerock/openam/upgrade/ParsedVersion.java
@@ -1,0 +1,139 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security.
+ */
+package org.forgerock.openam.upgrade;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * Parsed version information value class.
+ *
+ * <p>
+ * This class holds information parsed from version string in the form
+ * <code>${PRODUCT} ${VERSION} Build ${REVISION} (${DATESTAMP})</code> (see
+ * openam-server-only/pom.xml file) and implements {@link Comparable} to allow
+ * comparing different product versions to assist upgrade process execution.
+ * </p>
+ *
+ * <p>
+ * Version parsing logic is deliberately lenient to allow processing of missing version
+ * and/or legacy version formats.
+ * </p>
+ *
+ * @since 15.0.0
+ */
+public final class ParsedVersion implements Comparable<ParsedVersion> {
+
+    /**
+     * Pattern to match serialized version with two capture groups (numeric version and build date).
+     *
+     * <p>
+     * Expected format is <code>${PRODUCT} ${VERSION} Build ${REVISION} (${DATESTAMP})</code>.
+     * </p>
+     */
+    private static final Pattern VERSION_FORMAT_PATTERN = Pattern.compile("^(?:.*?(\\d+\\.\\d+\\.?\\d*))?[^\\(]*(?:\\((.*)\\))?");
+
+    /**
+     * Build date time formatter that supports new ISO format and legacy UK format.
+     */
+    private static final DateTimeFormatter BUILD_DATE_FORMATTER = new DateTimeFormatterBuilder()
+            // Add normalized ISO date format
+            .appendOptional(DateTimeFormatter.ISO_DATE_TIME)
+            // Add legacy build date format
+            .appendOptional(DateTimeFormatter.ofPattern("yyyy-MMMM-dd HH:mm"))
+            // Define locale for legacy date format that uses month names
+            .toFormatter(Locale.UK)
+            .withZone(ZoneOffset.UTC);
+
+
+    private final int[] versionNumber;
+    private final Instant buildDate;
+
+    private ParsedVersion(int[] versionNumber, Instant buildDate) {
+        this.versionNumber = versionNumber;
+        this.buildDate = buildDate;
+    }
+
+    /**
+     * Get build date if defined.
+     *
+     * @return Build date or null if not defined.
+     */
+    public Instant getBuildDate() {
+        return buildDate;
+    }
+
+    /**
+     * Get version number (should be semantic version in <code>major.minor.patch</code> format).
+     *
+     * @return Version number or -1 if not defined.
+     */
+    public String getVersionNumber() {
+        return IntStream.of(versionNumber).mapToObj(String::valueOf).collect(Collectors.joining("."));
+    }
+
+    /**
+     * Parse version string in the form <code>${PRODUCT} ${VERSION} Build ${REVISION} (${DATESTAMP})</code>.
+     *
+     * <p>
+     * This method is deliberately lenient to allow processing of missing version
+     * and/or legacy version format. Callers have to handle <code>null</code> results.
+     * </p>
+     * @param value Full version string. Can be null.
+     * @return Version number and build date. Can be null if unable to parse.
+     */
+    public static ParsedVersion parse(String value) {
+        // This can happen if the version is not defined (ideally should be handled by the caller)
+        if (value == null) {
+            return null;
+        }
+        Matcher matcher = VERSION_FORMAT_PATTERN.matcher(value);
+        // We want to ignore invalid version string
+        if (!matcher.matches() || matcher.group(1) == null && matcher.group(2) == null) {
+            return null; // Missing both version number and build date
+        }
+        // Parse version number
+        int[] versionNumber = matcher.group(1) != null
+                ? Stream.of(matcher.group(1).split("\\.")).mapToInt(Integer::parseInt).toArray()
+                : new int[] { -1 };
+        // Parse build date
+        Instant buildDate = null;
+        try {
+            if (matcher.group(2) != null) {
+                buildDate = Instant.from(BUILD_DATE_FORMATTER.parse(matcher.group(2)));
+            }
+        } catch (DateTimeParseException e) { /* ignore invalid date */ }
+        return new ParsedVersion(versionNumber, buildDate);
+    }
+
+    @Override
+    public int compareTo(ParsedVersion o) {
+        int versionCompare = Arrays.compare(versionNumber, o.versionNumber);
+        return versionCompare == 0 && buildDate != null && o.buildDate != null ?
+                buildDate.compareTo(o.buildDate) : versionCompare;
+    }
+
+}

--- a/openam-core/src/main/java/org/forgerock/openam/upgrade/VersionUtils.java
+++ b/openam-core/src/main/java/org/forgerock/openam/upgrade/VersionUtils.java
@@ -29,17 +29,6 @@
  */
 package org.forgerock.openam.upgrade;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.format.DateTimeParseException;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.Locale;
-import java.util.Map.Entry;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.iplanet.am.util.SystemProperties;
 import com.sun.identity.common.configuration.ServerConfiguration;
 import com.sun.identity.shared.Constants;
@@ -54,109 +43,99 @@ public class VersionUtils {
 
     private static final Debug DEBUG = Debug.getInstance("amUpgrade");
 
-    // Pattern to match serialized version with two capture groups (numeric version and build date)
-    private static final Pattern VERSION_FORMAT_PATTERN = Pattern.compile("^(?:.*?(\\d+\\.\\d+\\.?\\d*).*)?\\((.*)\\)");
-    private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder().
-            appendOptional(DateTimeFormatter.ISO_DATE_TIME).
-            appendOptional(DateTimeFormatter.ofPattern("yyyy-MMMM-dd HH:mm")). // Legacy build date format
-            toFormatter(Locale.US).
-            withZone(ZoneOffset.UTC);;
-
-    private static volatile boolean evaluatedUpgradeVersion = false;
-    private static boolean isVersionNewer = false;
-
+    /**
+     * Cached result of version evaluation.
+     */
+    private static Boolean isVersionNewer;
 
     /**
-     * @see #isVersionNewer(String, String).
+     * @see #isVersionNewer(String, String)
      */
     public static boolean isVersionNewer() {
-        if (!evaluatedUpgradeVersion) {
+        if (isVersionNewer == null) {
             // Cache result to avoid repeated evaluations
             isVersionNewer = isVersionNewer(getCurrentVersion(), getWarFileVersion());
-            evaluatedUpgradeVersion = true;
         }
         return isVersionNewer;
     }
 
     /**
-     * Check whether version of the war file is newer than the one currently deployed.
-     * @param currentValue Serialized version of the currently deployed instance. Can be null.
-     * @param warValue Serialized version of WAR file. Can be null.
-     * @return true when version is newer, false otherwise.
+     * Check whether version of the WAR file is newer than the one currently installed.
+     *
+     * @param currentValue Serialized version of the currently installed instance. Can be null.
+     * @param warValue Serialized version of the WAR file. Can be null.
+     * @return true when the WAR file version is newer than the currently installed version, false otherwise.
      */
     public static boolean isVersionNewer(String currentValue, String warValue) {
-        // Ignore version check when upgrade is globally disabled
+        // Ignore version check when the upgrade is globally disabled
         if (SystemProperties.get("org.forgerock.donotupgrade") != null) {
             return false;
         }
-        // Parsed serialized values
-        Entry<Integer, ZonedDateTime> current = parseVersion(currentValue);
-        Entry<Integer, ZonedDateTime> war = parseVersion(warValue);
-        if (current == null || war == null) {
+        // Parse serialized version values
+        ParsedVersion currentVersion = ParsedVersion.parse(currentValue);
+        ParsedVersion warVersion = ParsedVersion.parse(warValue);
+        if (currentVersion == null || warVersion == null) {
+            DEBUG.warning("Unable to determine versions for upgrade; current: {}, war: {}",
+                    currentValue, warValue);
             return false;
         }
-        // Compare numeric versions when different
-        if (!current.getKey().equals(war.getKey())) {
-            return current.getKey() < war.getKey();
-        }
-        // Compare build dates
-        return current.getValue() != null && war.getValue() != null && war.getValue().isAfter(current.getValue());
+        // Compare version numbers
+        return currentVersion.compareTo(warVersion) < 0;
     }
 
+    /**
+     * Get version string for the current installation.
+     *
+     * @return Version string. Can be null if unable to retrieve.
+     */
     public static String getCurrentVersion() {
         return SystemProperties.get(Constants.AM_VERSION);
     }
 
+    /**
+     * Get version from the deployed WAR file.
+     *
+     * @return Version string. Can be null in unable to retrieve.
+     */
     public static String getWarFileVersion() {
         return ServerConfiguration.getWarFileVersion();
     }
 
     /**
-     * Check if the currently deployed Wren:AM has the same version number as the expected version number.
-     * @param expectedVersion Expected version to check. Never null.
-     * @return <code>false</code> if the version number cannot be detected or if the local version does not match,
-     * <code>true</code> otherwise.
+     * Check if the currently installed version has the same version as the expected version number.
+     *
+     * @param version Version number to check. Never null.
+     * @return True if the current version is the same as the installed one, false otherwise.
      */
-    public static boolean isCurrentVersionEqualTo(Integer expectedVersion) {
-        Entry<Integer, ZonedDateTime> current = parseVersion(getCurrentVersion());
-        if (current == null) {
+    public static boolean isCurrentVersionEqualTo(String version) {
+        ParsedVersion currentVersion = ParsedVersion.parse(getCurrentVersion());
+        if (currentVersion == null) {
             return false;
         }
-        return expectedVersion.equals(current.getKey());
+        ParsedVersion compareVersion = ParsedVersion.parse(version);
+        if (compareVersion == null) {
+            return false;
+        }
+        return currentVersion.compareTo(compareVersion) == 0;
     }
 
     /**
-     * Check if the currently deployed Wren:AM version is less than the specified version.
-     * @param version Version to check.
-     * @param notParsed The value to return if the current version cannot be parsed.
+     * Check if the currently installed version is less than the specified version.
+     *
+     * @param version Version number to check. Never null.
+     * @param fallback Fallback value to return if the current version cannot be determined.
+     * @return True if the current version is less than the given one, false otherwise.
      */
-    public static boolean isCurrentVersionLessThan(int version, boolean notParsed) {
-        Entry<Integer, ZonedDateTime> current = parseVersion(getCurrentVersion());
-        if (current == null) {
-            return notParsed;
+    public static boolean isCurrentVersionLessThan(String version, boolean fallback) {
+        ParsedVersion currentVersion = ParsedVersion.parse(getCurrentVersion());
+        if (currentVersion == null) {
+            return fallback;
         }
-        return current.getKey() < version;
-    }
-
-    /**
-     * Extract version represented as integer value (e.g. '15.0.0' -> 1500 ) and build date from the specified serialized value.
-     */
-    private static Entry<Integer, ZonedDateTime> parseVersion(String value) {
-        if (value == null) {
-            return null;
+        ParsedVersion compareVersion = ParsedVersion.parse(version);
+        if (compareVersion == null) {
+            return fallback;
         }
-        Matcher matcher = VERSION_FORMAT_PATTERN.matcher(value);
-        if (!matcher.matches()) {
-            return null;
-        }
-        Integer version = matcher.group(1) != null ? Integer.valueOf(matcher.group(1).replace(".", "")) : -1;
-        ZonedDateTime buildDate = null;
-        try {
-            buildDate = ZonedDateTime.parse(matcher.group(2), DATE_FORMATTER);
-        } catch (DateTimeParseException e) {
-            DEBUG.error("Failed to parse build date: '" + value + "' during version check.", e);
-        }
-        return new SimpleEntry<>(version, buildDate);
+        return currentVersion.compareTo(compareVersion) < 0;
     }
 
 }

--- a/openam-core/src/test/java/org/forgerock/openam/upgrade/ParsedVersionTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/upgrade/ParsedVersionTest.java
@@ -1,0 +1,91 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security.
+ */
+package org.forgerock.openam.upgrade;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.time.Instant;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * {@link ParsedVersion} test case.
+ */
+public class ParsedVersionTest {
+
+    @DataProvider(name = "parse")
+    public Object[] getParseData() {
+        return new Object[][] {
+            { "invalid", null, null },
+            { "Wren:AM 15.0.0", "15.0.0", null },
+            { "Wren:AM 15.0.0-SNAPSHOT", "15.0.0", null },
+            { "Wren:AM 15.0.0 (2023-01-01T00:00:00Z)", "15.0.0", Instant.parse("2023-01-01T00:00:00Z") },
+            { "Wren:AM 15.0.0 Build foobar (2023-01-01T00:00:00Z)", "15.0.0", Instant.parse("2023-01-01T00:00:00Z") },
+            { "OpenAM 13.0.0 Build foobar (2023-January-01 00:00)", "13.0.0", Instant.parse("2023-01-01T00:00:00Z") },
+        };
+    }
+
+    @Test(dataProvider =  "parse")
+    public void testParse(String value, String versionNumber, Instant buildDate) {
+        ParsedVersion version = ParsedVersion.parse(value);
+        if (version == null) {
+            assertNull(versionNumber);
+        } else {
+            assertEquals(version.getVersionNumber(), versionNumber);
+            assertEquals(version.getBuildDate(), buildDate);
+        }
+    }
+
+    @DataProvider(name = "compare")
+    public Object[][] getCompareData() {
+        return new Object[][] {
+            // Different version, with version specifier, missing revision number, with legacy date format
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 9.5.5-RC1 (2012-March-05 03:13)", 1 },
+            // Different version, invalid version specifier, with revision number, with legacy date format
+            { "9.5.3_RC1 Build 753 (2011-May-06 10:55)", "OpenAM 10.0.0 (2012-April-13 10:24)", -1 },
+            // Same version, with version specifier, missing revision number, with legacy date format
+            { "OpenAM 10.0.0-EA (2012-February-07 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", -1 },
+            // Different version numbers
+            { "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", "Wren:AM 15.0.1-SNAPSHOT (2023-06-17T10:24:44Z)", -1 },
+            // Same version, different dates
+            { "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", "Wren:AM 15.0.0 (2023-06-17T10:24:44Z)", -1 },
+            // Different product names
+            { "OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "Wren:AM 15.0.0-M2 Build 5dba72a2f9 (2023-02-22T13:35:15Z)", -1},
+            // Invalid version string
+            { "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", "", null },
+            // Invalid build date
+            { "Wren:AM 15.0.1 (Foo)", "Wren:AM 15.0.0 (Bar)", 1 },
+            { "Wren:AM 15.0.0 (Foo)", "Wren:AM 15.0.0 (Bar)", 0 },
+            // Equal versions
+            { "Wren:AM 15.0.0-M2 Build 5dba72a2f9 (2023-02-22T13:35:15Z)", "Wren:AM 15.0.0-M2 Build 5dba72a2f9 (2023-02-22T13:35:15Z)", 0 },
+            { "Wren:AM 15.0.0", "Wren:AM 15.0.0", 0 },
+        };
+    }
+
+    @Test(dataProvider = "compare")
+    public void testVersionCompare(String first, String second, Integer result) {
+        ParsedVersion firstVersion = ParsedVersion.parse(first);
+        ParsedVersion secondVersion = ParsedVersion.parse(second);
+        if (firstVersion == null || secondVersion == null) {
+            assertNull(result, "unparsable version expected");
+        } else {
+            assertEquals(Integer.signum(firstVersion.compareTo(secondVersion)), result.intValue());
+            assertEquals(Integer.signum(secondVersion.compareTo(firstVersion)), -result.intValue());
+        }
+    }
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/Constants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/Constants.java
@@ -1184,9 +1184,6 @@ public interface Constants {
     static final String CLIENT_IP_ADDR_HEADER =
             "com.sun.identity.authentication.client.ipAddressHeader";
 
-    static final String VERSION_DATE_FORMAT =
-            "yyyy-MMMM-dd HH:mm";
-
     /**
      * Switch to allow for a generic Authentication Exception rather than
      * the more specific InvalidPassword Exception from the SOAP and REST API
@@ -1376,7 +1373,7 @@ public interface Constants {
 
     /** Service name for the REST APIs service. */
     String REST_APIS_SERVICE_NAME = "RestApisService";
-    
+
     /** Service version for the REST APIs service. */
     String REST_APIS_SERVICE_VERSION = "1.0";
 

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/AuthServiceHelper.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/helpers/AuthServiceHelper.java
@@ -91,7 +91,7 @@ public class AuthServiceHelper extends AbstractUpgradeHelper {
             return existingAttr.getI18NKey() != null && !existingAttr.getI18NKey().isEmpty() ? newAttr : null;
         }
         if (HMAC_SHARED_SECRET.equals(newAttr.getName())) {
-            if (VersionUtils.isCurrentVersionEqualTo(1300)) {
+            if (VersionUtils.isCurrentVersionEqualTo("13.0.0")) {
                 if (CollectionUtils.isEmpty(existingAttr.getDefaultValues())) {
                     return newAttr;
                 } else {
@@ -131,7 +131,7 @@ public class AuthServiceHelper extends AbstractUpgradeHelper {
         } else if (XUI_ADMIN_CONSOLE_ENABLED.equals(newAttr.getName())) {
             // XUI admin console should not be default for upgraded systems
             newAttr = updateDefaultValues(newAttr, asSet("false"));
-        } else if (newAttr.getName().equals(XUI_REVERSE_PROXY_SUPPORT) && VersionUtils.isCurrentVersionEqualTo(1200)) {
+        } else if (newAttr.getName().equals(XUI_REVERSE_PROXY_SUPPORT) && VersionUtils.isCurrentVersionEqualTo("12.0.0")) {
             newAttr = updateDefaultValues(newAttr, asSet("false"));
         }
 

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/CopyJavaCryptoExtKeyStoreStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/CopyJavaCryptoExtKeyStoreStep.java
@@ -59,7 +59,7 @@ public final class CopyJavaCryptoExtKeyStoreStep extends AbstractUpgradeStep {
     private final static String AUDIT_SUCCESS = "upgrade.copy.keystore.to.configuration.success";
     private final static String AUDIT_FAILURE = "upgrade.copy.keystore.to.configuration.failure";
 
-    private static final int AM_13_5 = 1350;
+    private static final String AM_13_5 = "13.5.0";
 
     private static final String KEYSTORE_NAME = "keystore.jceks";
     private static final String KEYSTORE_PATH = "/WEB-INF/template/keystore/" + KEYSTORE_NAME;

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/MakeExplicitDefaultKeyStoreTypeStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/MakeExplicitDefaultKeyStoreTypeStep.java
@@ -60,7 +60,7 @@ public final class MakeExplicitDefaultKeyStoreTypeStep extends AbstractUpgradeSt
     private final static String AUDIT_FAILURE = "upgrade.assign.default.keystore.type.failure";
 
     private static final String KEYSTORE_TYPE = "com.sun.identity.saml.xmlsig.storetype";
-    private static final int AM_13_5 = 1350;
+    private static final String AM_13_5 = "13.5.0";
 
     private boolean applicability;
 

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveNetscapeLDAPStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveNetscapeLDAPStep.java
@@ -114,7 +114,7 @@ public class RemoveNetscapeLDAPStep extends AbstractUpgradeStep {
             "sun-idrepo-ldapv3-config-service-attributes"
     );
 
-    private static final int AM_13 = 1300;
+    private static final String AM_13 = "13.0.0";
     public static final String NETSCAPE_LDAP_V3 = "NetscapeLDAPv3";
 
     private final Map<String, Set<String>> subSchemaIds = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveRedundantDefaultApplication.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveRedundantDefaultApplication.java
@@ -55,7 +55,7 @@ public final class RemoveRedundantDefaultApplication extends AbstractEntitlement
     private final static String AUDIT_REMOVAL_FAILURE = "upgrade.policy.applications.removal.failure";
     private final static String AUDIT_APPLICATION_REMOVAL_REPORT = "upgrade.policy.applications.removal.report";
 
-    private final static int AM_13 = 1300;
+    private final static String AM_13 = "13.0.0";
     private final static String DEFAULT_REALM = "/";
 
     private final Set<String> removedDefaultApplications;

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveReferralsStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/RemoveReferralsStep.java
@@ -88,7 +88,7 @@ public final class RemoveReferralsStep extends AbstractUpgradeStep {
 
     private final static String REFERRAL_SEARCH_FILTER
             = "(&(ou:dn:=sunEntitlementIndexes)(ou:dn:=referrals)(sunserviceID=indexes))";
-    private final static int AM_13 = 1300;
+    private final static String AM_13 = "13.0.0";
 
     private final ObjectMapper mapper = new ObjectMapper();
 

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/ResavePoliciesStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/ResavePoliciesStep.java
@@ -60,7 +60,7 @@ import java.util.Set;
 @UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.RemoveReferralsStep")
 public class ResavePoliciesStep extends AbstractUpgradeStep {
 
-    private static final int AM_14 = 1400;
+    private static final String AM_14 = "14.0.0";
     private static final String POLICY_DATA = "%POLICY_DATA%";
 
     private final Map<String, Set<String>> policyMap = new HashMap<>();
@@ -71,10 +71,12 @@ public class ResavePoliciesStep extends AbstractUpgradeStep {
         super(adminTokenAction, connectionFactory);
     }
 
+    @Override
     public boolean isApplicable() {
         return !policyMap.isEmpty();
     }
 
+    @Override
     public void initialize() throws UpgradeException {
         DEBUG.message("Initializing ResavePoliciesStep");
         if (isCurrentVersionLessThan(AM_14, true)) {
@@ -100,6 +102,7 @@ public class ResavePoliciesStep extends AbstractUpgradeStep {
         }
     }
 
+    @Override
     public void perform() throws UpgradeException {
         Subject adminSubject = getAdminSubject();
 
@@ -128,6 +131,7 @@ public class ResavePoliciesStep extends AbstractUpgradeStep {
         }
     }
 
+    @Override
     public String getShortReport(String delimiter) {
         int policyCount = 0;
         for (Set<String> policyNames : policyMap.values()) {
@@ -141,6 +145,7 @@ public class ResavePoliciesStep extends AbstractUpgradeStep {
         return sb.toString();
     }
 
+    @Override
     public String getDetailedReport(String delimiter) {
         Map<String, String> tags = new HashMap<String, String>();
         tags.put(LF, delimiter);

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/SchemaXmlAttributeUpgradeStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/SchemaXmlAttributeUpgradeStep.java
@@ -63,7 +63,7 @@ import com.sun.identity.sm.ServiceSchemaManager;
 public class SchemaXmlAttributeUpgradeStep extends AbstractUpgradeStep {
 
     private static final String PROGRESS = "upgrade.schema.xml.attributes.progress";
-    private static final int AM_14 = 1400;
+    private static final String AM_14 = "14.0.0";
 
     private Map<String, Function<Document, Boolean, XPathExpressionException>> serviceModifications;
     private XPath xpath = XPathFactory.newInstance().newXPath();

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UmaApplicationSubjectsStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UmaApplicationSubjectsStep.java
@@ -63,7 +63,7 @@ import com.sun.identity.shared.datastruct.CollectionHelper;
 @UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.UpgradeEntitlementsStep")
 public class UmaApplicationSubjectsStep extends AbstractUpgradeStep {
 
-    private final static int AM_13 = 1300;
+    private final static String AM_13 = "13.0.0";
     private static final Set<String> SUBJECT_TYPES = asSet(getSubjectTypeName(JwtClaimSubject.class));
     private final Map<String, Set<Application>> needUpgrade = new HashMap<>();
     private final AMIdentityRepositoryFactory idRepoFactory;

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeCTSMaxConnectionsConfigurationStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeCTSMaxConnectionsConfigurationStep.java
@@ -80,7 +80,7 @@ public class UpgradeCTSMaxConnectionsConfigurationStep extends AbstractUpgradeSt
     private static final String DETAIL_REPORT_SUMMARY = "upgrade.ctsmaxconnections.detail.summary";
     private static final String DETAIL_REPORT_SERVER = "upgrade.ctsmaxconnections.detail.server";
     private static final String DETAIL_REPORT = "upgrade.ctsmaxconnections.detail";
-    private static final int AM_13 = 1300;
+    private static final String AM_13 = "13.0.0";
 
     private final ConnectionCount connectionCount;
     private final Helper helper;

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeOAuth2ClientStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/UpgradeOAuth2ClientStep.java
@@ -71,8 +71,8 @@ public class UpgradeOAuth2ClientStep extends AbstractUpgradeStep {
     private static final Pattern pattern = Pattern.compile("\\[\\d+\\]=.*");
     private final Map<String, Map<AgentType, Map<String, Set<String>>>> upgradableConfigs =
             new HashMap<String, Map<AgentType, Map<String, Set<String>>>>();
-    private static final int AM_13 = 1300;
-    
+    private static final String AM_13 = "13.0.0";
+
     @Inject
     public UpgradeOAuth2ClientStep(final PrivilegedAction<SSOToken> adminTokenAction,
             @DataLayer(ConnectionType.DATA_LAYER) final ConnectionFactory factory) {
@@ -128,7 +128,7 @@ public class UpgradeOAuth2ClientStep extends AbstractUpgradeStep {
             for (Map.Entry<String, Set<String>> entry : attrs.entrySet()) {
                 final String attrName = entry.getKey();
                 if (CHANGED_PROPERTIES.contains(attrName)) {
-                    
+
                     // Check if single string scopes are included in the Scope(s) or Default Scope(s).
                     Set<String> scopes = attrs.get(attrName);
                     if (VersionUtils.isCurrentVersionLessThan(AM_13, true) && (SCOPES.equals(attrName) || DEFAULT_SCOPES.equals(attrName))) {
@@ -139,7 +139,7 @@ public class UpgradeOAuth2ClientStep extends AbstractUpgradeStep {
                             }
                         }
                     }
-                    
+
                     String value = CollectionHelper.getMapAttr(attrs, attrName);
                     if (value == null) {
                         //this doesn't prove anything, let's advance to the next property
@@ -203,12 +203,12 @@ public class UpgradeOAuth2ClientStep extends AbstractUpgradeStep {
                         for (String attrName : subConfig.getValue()) {
                             if (CHANGED_PROPERTIES.contains(attrName)) {
                                 Set<String> values = attrs.get(attrName);
-                                
+
                                 // If single string scopes are included in the Scope(s) or Default Scope(s), then apend a pipe.
                                 if (VersionUtils.isCurrentVersionLessThan(AM_13, true) && (SCOPES.equals(attrName) || DEFAULT_SCOPES.equals(attrName))) {
                                     addScopesWithPipe(attrs, attrName, values);
                                 }
-                                
+
                                 String value = CollectionHelper.getMapAttr(attrs, attrName);
                                 if (value != null) {
                                     if (!pattern.matcher(value).matches()) {

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/policy/UpgradeResourceTypeStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/policy/UpgradeResourceTypeStep.java
@@ -79,7 +79,7 @@ import com.sun.identity.sm.ServiceConfigManager;
 @UpgradeStepInfo(dependsOn = "org.forgerock.openam.upgrade.steps.UpgradeEntitlementSubConfigsStep")
 public class UpgradeResourceTypeStep extends AbstractEntitlementUpgradeStep {
 
-    private final static int AM_13 = 1300;
+    private final static String AM_13 = "13.0.0";
 
     private static final String RESOURCES_TYPE_NAME_SUFFIX = "ResourceType";
     private static final String RESOURCE_TYPE_DESCRIPTION = "This resource type was created during upgrade for ";

--- a/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/policy/conditions/OldPolicyConditionMigrationUpgradeStep.java
+++ b/openam-upgrade/src/main/java/org/forgerock/openam/upgrade/steps/policy/conditions/OldPolicyConditionMigrationUpgradeStep.java
@@ -92,7 +92,7 @@ public class OldPolicyConditionMigrationUpgradeStep extends AbstractUpgradeStep 
      */
     @Override
     public void initialize() throws UpgradeException {
-        if (!isCurrentVersionLessThan(1300, true)) {
+        if (!isCurrentVersionLessThan("13.0.0", true)) {
             return;
         }
         try {

--- a/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/UpgradeDetectionTest.java
+++ b/openam-upgrade/src/test/java/org/forgerock/openam/upgrade/UpgradeDetectionTest.java
@@ -12,11 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.openam.upgrade;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,31 +26,39 @@ public class UpgradeDetectionTest {
 
     @DataProvider(name = "versions")
     public Object[][] getVersions() {
-        return new Object[][]{
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 9.5.5-RC1 (2012-March-05 03:13)", false},
-            {"OpenAM 9.5.5-RC1 (2012-March-05 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"Snapshot Build 9.5.1_RC1(2010-June-30 20:23)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"Snapshot Build 9.5.1_RC2(2010-September-16 12:02)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"Release 9.5.1 Build 9.5.1(2010-November-04 13:03)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"Release 9.5.2_RC1 Build 563 (2011-February-03 20:48)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"(2011-March-02 18:42)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "(2011-March-02 18:42)", false},
-            {"9.5.3_RC1 Build 753 (2011-May-06 10:55)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"9.5.3 Build 934 (2011-July-29 00:15)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"9.5.4_RC1 Build 1419 (2011-November-11 09:53)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"9.5.4 Build 1516 (2011-December-07 09:55)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"OpenAM 10.0.0-EA (2012-February-07 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", true},
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 10.0.0-EA (2012-February-07 00:14)", false},
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 11.0.0-EA (2012-July-04 00:14)", true},
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 10.0.1 (2012-May-04 00:14)", true},
-            {"OpenAM 10.0.1 (2012-May-04 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", false},
-            {"OpenAM 11.0.0 (2012-July-05 00:12)", "OpenAM 10.0.0 (2012-April-13 10:24)", false},
-            {"OpenAM 9.5.5 Build 3685 (2012-November-23 14:23)", "OpenAM 11.0.0 (2013-November-08 10:40)", true},
-            {"OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 11.0.0 (2013-November-08 10:40)", true},
-            {"OpenAM 11.0.0 (2013-November-08 10:40)", "OpenAM 10.0.2 (2013-December-08 18:52)", false},
-            // SVN revision number should not count in comparisons:
-            {"OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "OpenAM 12.0.1-SNAPSHOT Build 1000 (2013-March-13 08:43)", true},
-            {"OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "OpenAM 12.0.0-SNAPSHOT Build 1000 (2013-March-13 08:43)", false}
+        return new Object[][] {
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 9.5.5-RC1 (2012-March-05 03:13)", false },
+            { "OpenAM 9.5.5-RC1 (2012-March-05 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "Snapshot Build 9.5.1_RC1(2010-June-30 20:23)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "Snapshot Build 9.5.1_RC2(2010-September-16 12:02)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "Release 9.5.1 Build 9.5.1(2010-November-04 13:03)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "Release 9.5.2_RC1 Build 563 (2011-February-03 20:48)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "(2011-March-02 18:42)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "(2011-March-02 18:42)", false },
+            { "9.5.3_RC1 Build 753 (2011-May-06 10:55)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "9.5.3 Build 934 (2011-July-29 00:15)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "9.5.4_RC1 Build 1419 (2011-November-11 09:53)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "9.5.4 Build 1516 (2011-December-07 09:55)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "OpenAM 10.0.0-EA (2012-February-07 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", true },
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 10.0.0-EA (2012-February-07 00:14)", false },
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 11.0.0-EA (2012-July-04 00:14)", true },
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 10.0.1 (2012-May-04 00:14)", true },
+            { "OpenAM 10.0.1 (2012-May-04 00:14)", "OpenAM 10.0.0 (2012-April-13 10:24)", false },
+            { "OpenAM 11.0.0 (2012-July-05 00:12)", "OpenAM 10.0.0 (2012-April-13 10:24)", false },
+            { "OpenAM 9.5.5 Build 3685 (2012-November-23 14:23)", "OpenAM 11.0.0 (2013-November-08 10:40)", true },
+            { "OpenAM 10.0.0 (2012-April-13 10:24)", "OpenAM 11.0.0 (2013-November-08 10:40)", true },
+            { "OpenAM 11.0.0 (2013-November-08 10:40)", "OpenAM 10.0.2 (2013-December-08 18:52)", false },
+            { "OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "OpenAM 12.0.1-SNAPSHOT Build 1000 (2013-March-13 08:43)", true },
+            { "OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "OpenAM 12.0.0-SNAPSHOT Build 1000 (2013-March-13 08:43)", false },
+            { "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", "Wren:AM 15.0.1-SNAPSHOT (2023-06-17T10:24:44Z)", true },
+            { "Wren:AM 15.0.1 (2023-04-13T10:24:21Z)", "Wren:AM 15.0.0 (2023-06-17T10:24:44Z)", false },
+            { "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", "Wren:AM 15.0.0 (2023-06-17T10:24:44Z)", true },
+            { "Wren:AM 15.0.2-SNAPSHOT (2023-06-17T10:24:44Z)", "Wren:AM 15.0.3 (2023-04-13T10:24:21Z)", true },
+            { "Wren:AM 15.0.0 (2023-06-17T10:24:44Z)", "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", false },
+            { "Wren:AM 15.0.2-SNAPSHOT (2023-06-17T10:24:44Z)", "Wren:AM 16.0.0 (2023-04-13T10:24:21Z)", true },
+            { "9.5.4 Build 1516 (2011-December-07 09:55)", "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", true },
+            { "OpenAM 12.0.0-SNAPSHOT Build 2000 (2013-March-13 08:43)", "Wren:AM 15.0.0 (2023-04-13T10:24:21Z)", true },
+            { "Wren:AM 15.0.1 (Foo)", "Wren:AM 15.0.0 (Bar)", false }
         };
     }
 


### PR DESCRIPTION
Change `VERSION_DATE_FORMAT` constant in order to prevent version check raising an exception: `java.text.ParseException: Unparseable date: "2023-02-22T13:35:15Z"`