### PR TITLE
Invalidate OAuth2 scope and claim cache during config change (#37).

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.oauth2.core;
@@ -971,6 +972,8 @@ public class RealmOAuth2ProviderSettings implements OAuth2ProviderSettings {
                     attributeCache.clear();
                     jwks.clear();
                     loginUrlTemplate = null;
+                    supportedScopesWithoutTranslations = null;
+                    supportedClaimsWithoutTranslations = null;
                 }
             } else {
                 if (logger.messageEnabled()) {


### PR DESCRIPTION
Currently, if the OAuth2 service scope / claim configuration is changed, you must restart the server for the changes to take effect. I have added invalidating the OAuth2 scope / claim cache during config change to immediately apply requested changes.