### PR TITLE
Enforce EN locale for unit tests (#5).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
             --add-exports java.base/sun.security.x509=ALL-UNNAMED
             --add-exports java.base/jdk.internal.util=ALL-UNNAMED
             --add-exports java.base/jdk.internal.util.random=ALL-UNNAMED
+            -Duser.language=en -Duser.region=US
         </java.surefire.options>
 
         <!-- XXX BEGIN Configuration under consideration -->


### PR DESCRIPTION
I added enforcing of EN locale for unit tests because we have several tests that check result messages that are locale-specific (it expects EN locale). Examples:
https://github.com/WrenSecurity/wrenam/blob/6183f1662c075d7bef4628fbf94585a6f58a34b8/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/constraints/ConstraintValidatorImplTest.java#L114
https://github.com/WrenSecurity/wrenam/blob/6183f1662c075d7bef4628fbf94585a6f58a34b8/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/authn/http/AuthenticationServiceV1Test.java#L147
https://github.com/WrenSecurity/wrenam/blob/6183f1662c075d7bef4628fbf94585a6f58a34b8/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/constraints/ConstraintValidatorImplTest.java#L183