### PR TITLE
Improve ssoconf artifact name.

### DIFF
--- a/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/config/README
+++ b/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/config/README
@@ -28,6 +28,7 @@
 
 <!--
     Portions Copyrighted 2011-2013 ForgeRock AS
+    Portions Copyrighted 2023 Wren Security.
 -->
 
 OpenAM: openam-distribution-ssoconfiguratortools-${project.version}.zip
@@ -54,10 +55,10 @@ Before setting up ssoConfiguratorTools.zip, JAVA_HOME environment variable
 needs to be initialized to a path of a compatible Java Runtime.
 
 If you want to setup OpenAM then run the following command:
-        \${JAVA_HOME}/bin/java -jar openam-configurator-tool-${project.version}.jar -f <configuration file>
+        \${JAVA_HOME}/bin/java -jar openam-configurator-tool.jar -f <configuration file>
 
 If you have already deployed OpenAM and want to upgrade run the following command:
-        \${JAVA_HOME}/bin/java -jar openam-upgrade-tool-${project.version}.jar -f <upgrade file>
+        \${JAVA_HOME}/bin/java -jar openam-upgrade-tool.jar -f <upgrade file>
 
 3. What does this package contain?
 ----------------------------------
@@ -65,9 +66,9 @@ If you have already deployed OpenAM and want to upgrade run the following comman
 |
 |----README (this file)
 |
-|----openam-configurator-tool-${project.version}.jar (binaries needed for the configuration tool)
+|----openam-configurator-tool.jar (binaries needed for the configuration tool)
 |
-|----openam-upgrade-tool-${project.version}.jar (binaries needed for the upgrade tool)
+|----openam-upgrade-tool.jar (binaries needed for the upgrade tool)
 |
 |----legal-notices/ (folder containing license files)
 |

--- a/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
+++ b/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
@@ -52,6 +52,7 @@
         </dependencySet>
 
         <dependencySet>
+            <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
             <outputDirectory></outputDirectory>
 
             <includes>


### PR DESCRIPTION
I have removed the version from the `ssoconf` binaries (`openam-configurator-tool`, `openam-upgrade-tool`) in the target archive. A newly built archive will have the following structure:

```
├── SSOConfiguratorTools-15.0.0-M3.zip
│   ├── openam-configurator-tool.jar
│   ├── openam-upgrade-tool.jar
│   ├── lib/
│   ├── ...
```

Old archive has the following structure:

```
├── SSOConfiguratorTools-15.0.0-M3.zip
│   ├── openam-configurator-tool-15.0.0-M3.jar
│   ├── openam-upgrade-tool-15.0.0-M3.jar
│   ├── lib/
│   ├── ...
```

The main advantage is that you can use the same artifact name when running the `java -jar {ARTIFACT}` command.