### PR TITLE
Fix NPE when API has not yet been defined.

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRequestHandler.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRequestHandler.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2022 Wren Security
+ * Portions copyright 2022-2023 Wren Security
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -829,7 +830,7 @@ public class SmsRequestHandler implements RequestHandler, SMSObjectListener, Ser
         this.api = routeTree.handleApiRequest(
                 new UriRouterContext(new RootContext(), "", "", Collections.<String, String>emptyMap()),
                 newApiRequest(ResourcePath.empty()));
-        if (!oldApi.equals(api)) {
+        if (!Objects.equals(oldApi, this.api)) {
             for (Listener listener : apiListeners) {
                 listener.notifyDescriptorChange();
             }


### PR DESCRIPTION
I have fixed the `NullPointerException` in `SmsRequestHandler` when the _api_ is not defined yet. Related stacktrace:

```
ERROR: SMSNotificationManager.objectChanged Exception for class: org.forgerock.openam.core.rest.sms.SmsRequestHandler
java.lang.NullPointerException: Cannot invoke "org.forgerock.api.models.ApiDescription.equals(Object)" because "oldApi" is null
	at org.forgerock.openam.core.rest.sms.SmsRequestHandler.notifyDescriptorChange(SmsRequestHandler.java:832)
	at org.forgerock.openam.core.rest.sms.SmsRequestHandler.refreshServiceRoute(SmsRequestHandler.java:355)
	at org.forgerock.openam.core.rest.sms.SmsRequestHandler.objectChanged(SmsRequestHandler.java:324)
	at com.sun.identity.sm.SMSNotificationManager.sendNotifications(SMSNotificationManager.java:294)
	at com.sun.identity.sm.SMSNotificationManager$LocalChangeNotifcationTask.run(SMSNotificationManager.java:370)
	at org.forgerock.openam.audit.context.AuditRequestContextPropagatingRunnable.run(AuditRequestContextPropagatingRunnable.java:42)
	at com.iplanet.am.util.ThreadPool$WorkerThread.run(ThreadPool.java:314)
```