### PR TITLE
Disable polling in ssoadm tool (#116)

### DIFF
--- a/openam-federation/OpenFM/src/main/scripts/bin/ssoadm
+++ b/openam-federation/OpenFM/src/main/scripts/bin/ssoadm
@@ -26,9 +26,10 @@
 #
 
 # Portions Copyrighted 2010-2016 ForgeRock AS.
+# Portions Copyrighted 2023 Wren Security.
 
 if [ -z "$JAVA_HOME" ] ; then
-        JAVA_HOME="\@JAVA_HOME@"
+    JAVA_HOME="\@JAVA_HOME@"
 fi
 
 TOOLS_HOME="@TOOLS_HOME@"
@@ -70,4 +71,5 @@ $JAVA_HOME/bin/java -Xms256m -Xmx512m -cp "$CLASSPATH" \
     -D"am.version.expected=@AM_VERSION@" \
     -D"com.iplanet.am.sdk.package=com.iplanet.am.sdk.remote" \
     -D"com.sun.identity.idm.remote.notification.enabled=false" \
+    -D"com.iplanet.am.sdk.remote.pollingTime=0" \
     com.sun.identity.cli.CommandManager "$@"

--- a/openam-federation/OpenFM/src/main/scripts/bin/ssoadm.bat
+++ b/openam-federation/OpenFM/src/main/scripts/bin/ssoadm.bat
@@ -27,11 +27,12 @@
 :
 
 : Portions Copyrighted 2010-2016 ForgeRock AS.
+: Portions Copyrighted 2023 Wren Security.
 
 setlocal enabledelayedexpansion
 
 IF NOT DEFINED JAVA_HOME (
-	set JAVA_HOME="\@JAVA_HOME@"
+    set JAVA_HOME="\@JAVA_HOME@"
 )
 
 set TOOLS_HOME=@TOOLS_HOME@
@@ -40,10 +41,29 @@ set CLASSPATH=@CONFIG_DIR@
 set CLASSPATH=%CLASSPATH%;%TOOLS_HOME%/classes;%TOOLS_HOME%/resources;%TOOLS_HOME%/lib/*
 
 IF DEFINED ORIG_CLASSPATH (
-	set CLASSPATH=%ORIG_CLASSPATH%;%CLASSPATH%
+    set CLASSPATH=%ORIG_CLASSPATH%;%CLASSPATH%
 )
 
-"%JAVA_HOME%/bin/java.exe" -Xms256m -Xmx512m -cp %CLASSPATH% -D"sun.net.client.defaultConnectTimeout=3000" -D"openam.naming.sitemonitor.disabled=true" -D"com.iplanet.am.serverMode=false" -D"com.sun.identity.sm.notification.enabled=false" -D"bootstrap.dir=@CONFIG_DIR@" -D"com.iplanet.services.debug.directory=@DEBUG_DIR@" -D"com.sun.identity.log.dir=@LOG_DIR@" -D"definitionFiles=com.sun.identity.cli.AccessManager,com.sun.identity.federation.cli.FederationManager" -D"commandName=ssoadm" -D"amconfig=AMConfig" -D"java.version.current=java.vm.version" -D"java.version.expected=1.4+" -D"am.version.current=com.iplanet.am.version" -D"am.version.expected=@AM_VERSION@" -D"com.iplanet.am.sdk.package=com.iplanet.am.sdk.remote" -D"com.sun.identity.idm.remote.notification.enabled=false" com.sun.identity.cli.CommandManager %*
+"%JAVA_HOME%/bin/java.exe" -Xms256m -Xmx512m -cp %CLASSPATH% ^
+    -D"sun.net.client.defaultConnectTimeout=3000" ^
+    -D"openam.naming.sitemonitor.disabled=true" ^
+    -D"com.iplanet.am.serverMode=false" ^
+    -D"com.sun.identity.sm.notification.enabled=false" ^
+    -D"bootstrap.dir=@CONFIG_DIR@" ^
+    -D"com.iplanet.services.debug.directory=@DEBUG_DIR@" ^
+    -D"com.sun.identity.log.dir=@LOG_DIR@" ^
+    -D"definitionFiles=com.sun.identity.cli.AccessManager,com.sun.identity.federation.cli.FederationManager" ^
+    -D"commandName=ssoadm" ^
+    -D"amconfig=AMConfig" ^
+    -D"java.version.current=java.vm.version" ^
+    -D"java.version.expected=1.4+" ^
+    -D"am.version.current=com.iplanet.am.version" ^
+    -D"am.version.expected=@AM_VERSION@" ^
+    -D"com.iplanet.am.sdk.package=com.iplanet.am.sdk.remote" ^
+    -D"com.sun.identity.idm.remote.notification.enabled=false" ^
+    -D"com.iplanet.am.sdk.remote.pollingTime=0" ^
+    com.sun.identity.cli.CommandManager %*
+
 endlocal
 :END
 


### PR DESCRIPTION
This PR disables SMS polling within ssoadm tool to prevent race conditions when the tool exits before `IdUtils` finishes initialization.