### PR TITLE
[CVE-2017-14394] [CVE-2017-14395] Fix validation of OAuth2 redirect URI.

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/AuthorizationCodeRequestValidatorImpl.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/AuthorizationCodeRequestValidatorImpl.java
@@ -12,18 +12,19 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.oauth2.core;
 
+import static org.forgerock.openam.oauth2.OAuth2Constants.Params.CODE;
+import static org.forgerock.openam.oauth2.OAuth2Constants.Params.REDIRECT_URI;
+
+import javax.inject.Inject;
 import org.forgerock.oauth2.core.exceptions.InvalidClientException;
 import org.forgerock.oauth2.core.exceptions.InvalidRequestException;
 import org.forgerock.oauth2.core.exceptions.RedirectUriMismatchException;
 import org.forgerock.util.Reject;
-
-import javax.inject.Inject;
-
-import static org.forgerock.oauth2.core.Utils.isEmpty;
 
 /**
  * Implementation of the AuthorizationCodeRequestValidator for OAuth2 request validation.
@@ -55,9 +56,9 @@ public class AuthorizationCodeRequestValidatorImpl implements AuthorizationCodeR
                     "exchange request. Scope parameter should be supplied to the authorize request.");
         }
 
-        Reject.ifTrue(Utils.isEmpty(request.<String>getParameter("code")), "Missing parameter, 'code'");
-        Reject.ifTrue(Utils.isEmpty(request.<String>getParameter("redirect_uri")), "Missing parameter, 'redirect_uri'");
+        Reject.ifTrue(Utils.isEmpty(request.<String>getParameter(CODE)), "Missing parameter, 'code'");
+        Reject.ifTrue(Utils.isEmpty(request.<String>getParameter(REDIRECT_URI)), "Missing parameter, 'redirect_uri'");
 
-        redirectUriValidator.validate(clientRegistration, request.<String>getParameter("redirect_uri"));
+        redirectUriValidator.validate(clientRegistration, request.<String>getParameter(REDIRECT_URI), null);
     }
 }

--- a/openam-oauth2/src/test/java/org/forgerock/oauth2/core/RedirectUriValidatorTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/oauth2/core/RedirectUriValidatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Portions Copyright 2023 Wren Security.
+ */
+
+package org.forgerock.oauth2.core;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
+import java.util.Set;
+import org.forgerock.oauth2.core.exceptions.InvalidRequestException;
+import org.forgerock.oauth2.core.exceptions.RedirectUriMismatchException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RedirectUriValidatorTest {
+
+    private static final String VALID_URL = "https://wrensecurity.org";
+    private static final String INVALID_URL = "https://foo.bar";
+
+    private RedirectUriValidator validator;
+    private ClientRegistration clientRegistration;
+
+    @BeforeMethod
+    public void setup() {
+        validator = new RedirectUriValidator();
+        clientRegistration = mock(ClientRegistration.class);
+        given(clientRegistration.getRedirectUris()).willReturn(Set.of(URI.create(VALID_URL)));
+    }
+
+    @Test
+    public void testValidateValidRedirectUrl() throws Exception {
+        validator.validate(clientRegistration, VALID_URL, null);
+    }
+
+    @Test(expectedExceptions = { RedirectUriMismatchException.class })
+    public void testValidateInvalidRedirectUrl() throws Exception {
+        validator.validate(clientRegistration, INVALID_URL, null);
+    }
+
+    @Test(expectedExceptions = { InvalidRequestException.class }, expectedExceptionsMessageRegExp = "Missing parameter: redirect_uri")
+    public void testValidateMissingRedirectUrlWithoutUserCode() throws Exception {
+        given(clientRegistration.getRedirectUris()).willReturn(Set.of(URI.create(VALID_URL), URI.create("http://wrensecurity.org")));
+        validator.validate(clientRegistration, null, null);
+    }
+
+    @Test()
+    public void testValidateMissingRedirectUrlWithUserCode() throws Exception {
+        validator.validate(clientRegistration, null, "foobar");
+    }
+
+}


### PR DESCRIPTION
This PR enhances the validation of `redirect_uri` during OAuth2 authorization process  to resolve the security vulnerabilities published as a [CVE-2017-14394](https://nvd.nist.gov/vuln/detail/CVE-2017-14394) and [CVE-2017-14395](https://nvd.nist.gov/vuln/detail/CVE-2017-14395).

I was able to reproduce the exploit using the current version built with JDK 17. 