### PR TITLE
[CVE-2021-37154] Escape SAML request inResponseTo attribute.

### DIFF
--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSAssertion.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSAssertion.java
@@ -25,9 +25,8 @@
  * $Id: FSAssertion.java,v 1.2 2008/06/25 05:46:43 qcheng Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
-
-
 package com.sun.identity.federation.message;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -69,39 +68,39 @@ import org.w3c.dom.NodeList;
  */
 @Deprecated
 public class FSAssertion extends Assertion {
-    
+
     /**
      * The Document Element of this object.
      */
     private Element domElement;
-    
+
     /**
      * The <code>SAMLConstants</code> object.
      */
     static SAMLConstants sc;
-    
+
     /**
      * The value of the <code>id</code> attribute in the <code>Assertion</code>.
      */
     protected String id;
-    
+
     /**
      * The value of the <code>MinorVersion</Version> attribute in
      * the <code>Assertion</code>.
      */
     protected int minorVersion = IFSConstants.FF_11_ASSERTION_MINOR_VERSION;
-    
+
     /**
      * List of Security <code>Assertions</code>.
      */
     private List securityAssertions;
-    
+
     /**
      * The value of the <code>InResponseTo</code> attribute in the
      * <code>Assertion</code>.
      */
     protected String inResponseTo ;
-    
+
     /**
      * Constructor to create an <code>FSAssertion</code> object
      * from the Document Element.
@@ -296,7 +295,7 @@ public class FSAssertion extends Assertion {
         }
         FSUtils.debug.message("FSAssertion(Element): leaving");
     }
-    
+
     /**
      * Constructor to create <code>FSAssertion</code> object.
      *
@@ -318,7 +317,7 @@ public class FSAssertion extends Assertion {
         super(assertionID, issuer, issueInstant, statements);
         this.inResponseTo = inResponseTo;
     }
-    
+
     /**
      * Constructor to create <code>FSAssertion</code> object.
      *
@@ -341,7 +340,7 @@ public class FSAssertion extends Assertion {
         super(assertionID, issuer, issueInstant, conditions, statements);
         this.inResponseTo = inResponseTo;
     }
-    
+
     /**
      * Constructor to create an <code>FSAssertion</code> object.
      *
@@ -366,7 +365,7 @@ public class FSAssertion extends Assertion {
         super(assertionID, issuer, issueInstant,conditions, advice, statements);
         this.inResponseTo = inResponseTo;
     }
-    
+
     /**
      * Returns value of <code>id</code> attribute.
      *
@@ -376,7 +375,7 @@ public class FSAssertion extends Assertion {
     public String getID(){
         return id;
     }
-    
+
     /**
      * Sets  value of <code>id<code> attribute.
      *
@@ -386,7 +385,7 @@ public class FSAssertion extends Assertion {
     public void setID(String id){
         this.id = id;
     }
-    
+
     /**
      * Returns the <code>MinorVersion</code> attribute.
      *
@@ -396,7 +395,7 @@ public class FSAssertion extends Assertion {
     public int getMinorVersion() {
         return minorVersion;
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code> attribute.
      *
@@ -406,7 +405,7 @@ public class FSAssertion extends Assertion {
     public void setMinorVersion(int version) {
         minorVersion = version;
     }
-    
+
     /**
      * Returns the Document Element for this object.
      *
@@ -415,7 +414,7 @@ public class FSAssertion extends Assertion {
     public Element getDOMElement() {
         return domElement;
     }
-    
+
     /**
      * Returns the value of <code>InResponseTo</code> attribute.
      *
@@ -425,7 +424,7 @@ public class FSAssertion extends Assertion {
     public String getInResponseTo() {
         return inResponseTo;
     }
-    
+
     /**
      * Sets the value of <code>InResponseTo</code> attribute.
      *
@@ -435,7 +434,7 @@ public class FSAssertion extends Assertion {
     public void setInResponseTo(String inResponseTo) {
         this.inResponseTo = inResponseTo;
     }
-    
+
     /**
      * Returns Signed XML String.
      *
@@ -444,7 +443,7 @@ public class FSAssertion extends Assertion {
     public String getSignedXMLString(){
         return xmlString;
     }
-    
+
     /**
      * Returns the <code>Signature</code> string.
      *
@@ -453,7 +452,7 @@ public class FSAssertion extends Assertion {
     public String getSignatureString(){
         return signatureString;
     }
-    
+
     /**
      * Checks validity of time in the assertion.
      *
@@ -468,7 +467,7 @@ public class FSAssertion extends Assertion {
         }
         return isTimeValid;
     }
-    
+
     /**
      * Adds the <code>Statement</code> object to the
      * Statment's object Set.
@@ -484,7 +483,7 @@ public class FSAssertion extends Assertion {
         }
         return addedStmt;
     }
-    
+
     /**
      * Returns a <code>XML</code> String representation of this object.
      *
@@ -492,11 +491,11 @@ public class FSAssertion extends Assertion {
      * @throws FSMsgException if there is an error creating
      *         the <code>XML</code> string.
      */
-    
+
     public String toXMLString() throws FSMsgException {
         return this.toXMLString(true, true);
     }
-    
+
     /**
      * Returns a <code>XML</code> String representation of this object.
      *
@@ -508,7 +507,7 @@ public class FSAssertion extends Assertion {
      * @throws FSMsgException if there is an error creating
      *         the <code>XML</code> string.
      */
-    
+
     public java.lang.String toXMLString(boolean includeNS,boolean declareNS)
     throws FSMsgException {
         StringBuffer xml = new StringBuffer(3000);
@@ -542,7 +541,7 @@ public class FSAssertion extends Assertion {
         .append(NS).append(IFSConstants.SPACE).append(uriXSI)
         .append(IFSConstants.SPACE).append(libNS)
         .append(IFSConstants.SPACE);
-        
+
         if (minorVersion == IFSConstants.FF_11_ASSERTION_MINOR_VERSION &&
                 id != null && !(id.length() == 0)) {
             xml.append(IFSConstants.SPACE).append(IFSConstants.ID)
@@ -567,21 +566,21 @@ public class FSAssertion extends Assertion {
         .append(dateStr).append(IFSConstants.QUOTE)
         .append(IFSConstants.SPACE).append(IFSConstants.IN_RESPONSE_TO)
         .append(IFSConstants.EQUAL_TO).append(IFSConstants.QUOTE)
-        .append(inResponseTo).append(IFSConstants.QUOTE)
+        .append(XMLUtils.escapeSpecialCharacters(inResponseTo)).append(IFSConstants.QUOTE)
         .append(IFSConstants.SPACE)
         .append(IFSConstants.XSI_TYPE)
         .append(IFSConstants.EQUAL_TO).append(IFSConstants.QUOTE)
         .append(libAppendNS)
         .append(IFSConstants.ASSERTION_TYPE).append(IFSConstants.QUOTE)
         .append(IFSConstants.RIGHT_ANGLE).append(sc.NL);
-        
+
         if (getConditions() != null) {
             xml.append(getConditions().toString(includeNS, false));
         }
         if (getAdvice() != null) {
             xml.append(getAdvice().toString(includeNS, false));
         }
-        
+
         Iterator i = getStatement().iterator();
         while (i.hasNext()) {
             Statement st = (Statement)i.next();
@@ -604,10 +603,10 @@ public class FSAssertion extends Assertion {
         .append(appendNS).append(IFSConstants.ASSERTION)
         .append(IFSConstants.RIGHT_ANGLE)
         .append(IFSConstants.NL);
-        
+
         return xml.toString();
     }
-    
+
     /**
      * Signs the <code>Assertion</code>.
      *
@@ -629,7 +628,7 @@ public class FSAssertion extends Assertion {
             throw new SAMLResponderException(FSUtils.BUNDLE_NAME,
                     "cannotFindCertAlias",null);
         }
-        
+
         try {
             XMLSignatureManager manager = XMLSignatureManager.getInstance();
             if (minorVersion == IFSConstants.FF_11_ASSERTION_MINOR_VERSION) {
@@ -660,7 +659,7 @@ public class FSAssertion extends Assertion {
             throw new SAMLResponderException(e);
         }
     }
-    
+
     /**
      * Sets the <code>Element's</code> signature.
      *
@@ -671,7 +670,7 @@ public class FSAssertion extends Assertion {
         signatureString = XMLUtils.print(elem);
         return super.setSignature(elem);
     }
-    
+
     /**
      * Parses the advice element to extract the Security <code>Assertion</code>.
      *
@@ -703,7 +702,7 @@ public class FSAssertion extends Assertion {
             _advice = new Advice(null, securityAssertions, null);
         }
     }
-    
+
     /**
      * Returns the discovery service credentials from the boot strap.
      *

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSAuthnResponse.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSAuthnResponse.java
@@ -25,9 +25,8 @@
  * $Id: FSAuthnResponse.java,v 1.2 2008/06/25 05:46:43 qcheng Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
-
-
 package com.sun.identity.federation.message;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -72,9 +71,9 @@ public class FSAuthnResponse extends Response {
     protected String    relayState      = null;
     protected String consentURI = null;
     protected int minorVersion = 0;
-    protected String id = null; 
+    protected String id = null;
     protected Element domElement = null;
-    
+
 
    /**
     * Constructor to create <code>FSAuthnResponse</code> object.
@@ -164,9 +163,9 @@ public class FSAuthnResponse extends Response {
             if (FSUtils.debug.messageEnabled()) {
                 FSUtils.debug.message("FSAuthnResponse(Element): "
                     + "AuthnResponse doesn't have InResponseTo attribute");
-            }            
+            }
         }
-        
+
         // Attribute IssueInstant
         String instantString = root.getAttribute(IFSConstants.ISSUE_INSTANT);
 
@@ -187,9 +186,9 @@ public class FSAuthnResponse extends Response {
 
         parseMajorVersion(root.getAttribute(IFSConstants.MAJOR_VERSION));
         parseMinorVersion(root.getAttribute(IFSConstants.MINOR_VERSION));
-        
+
         setRecipient(root.getAttribute(IFSConstants.RECIPIENT));
- 
+
         NodeList nl = root.getChildNodes();
         Node child;
         String childName;
@@ -217,7 +216,7 @@ public class FSAuthnResponse extends Response {
                         if (FSUtils.debug.messageEnabled()) {
                             FSUtils.debug.message("FSAuthnResponse(Element): "
                                 + "should contain only one RelayState.");
-                        } 
+                        }
                         throw new FSMsgException("wrongInput",null);
                     }
                     relayState = XMLUtils.getElementValue((Element) child);
@@ -226,7 +225,7 @@ public class FSAuthnResponse extends Response {
                         if (FSUtils.debug.messageEnabled()) {
                             FSUtils.debug.message("FSAuthnResponse(Element): "
                                 + "should contain only one ProviderID.");
-                        } 
+                        }
                         throw new FSMsgException("wrongInput",null);
                     }
                     providerId = XMLUtils.getElementValue((Element) child);
@@ -261,7 +260,7 @@ public class FSAuthnResponse extends Response {
                     + "included more than one Signature element.");
             }
             throw new FSMsgException("moreElement",null);
-        }        
+        }
         //end check for signature
     }
 
@@ -274,7 +273,7 @@ public class FSAuthnResponse extends Response {
     public String getID() {
         return id;
     }
-    
+
     /**
      * Sets the value of the <code>id</code> attribute.
      *
@@ -283,8 +282,8 @@ public class FSAuthnResponse extends Response {
      */
     public void setID(String id) {
         this.id = id;
-    }    
-    
+    }
+
    /**
     * Returns the <code>ProviderID</code> attribute value.
     *
@@ -294,7 +293,7 @@ public class FSAuthnResponse extends Response {
     public String getProviderId() {
        return providerId;
     }
-   
+
     /**
      * Sets the <code>ProviderID</code> attribute value.
      *
@@ -304,7 +303,7 @@ public class FSAuthnResponse extends Response {
     public void setProviderId(String provId) {
        providerId = provId;
     }
-   
+
    /**
     * Returns a signed XML Representation of this object.
     *
@@ -313,7 +312,7 @@ public class FSAuthnResponse extends Response {
     public String getSignedXMLString(){
        return xmlString;
     }
-   
+
    /**
     * Returns the Signature string.
     *
@@ -380,7 +379,7 @@ public class FSAuthnResponse extends Response {
      * @throws FSMsgException on error.
      * @throws SAMLException if the version is incorrect.
      */
-    private void parseMajorVersion(String majorVer) 
+    private void parseMajorVersion(String majorVer)
                  throws SAMLException, FSMsgException {
         try {
             majorVersion = Integer.parseInt(majorVer);
@@ -477,8 +476,8 @@ public class FSAuthnResponse extends Response {
      * @param declareNS : Determines whether or not the namespace is declared
      *          within the Element.
      * @return A string containing the valid XML for this element
-     */   
-    public String toXMLString(boolean includeNS, boolean declareNS) 
+     */
+    public String toXMLString(boolean includeNS, boolean declareNS)
            throws FSMsgException {
         return toXMLString(includeNS, declareNS, false);
     }
@@ -493,18 +492,18 @@ public class FSAuthnResponse extends Response {
      * @param includeHeader  Determines whether the output include the xml
      *                declaration header.
      * @return A string containing the valid XML for this element
-     */   
+     */
     public String toXMLString(boolean includeNS,
                         boolean declareNS,
                         boolean includeHeader)  throws FSMsgException {
         FSUtils.debug.message("FSAuthnResponse.toXMLString(3): Called");
-        
+
         if((providerId == null) || (providerId.length() == 0)){
             FSUtils.debug.error("FSAuthnResponse.toXMLString: "
                 + "providerId is null ");
                 throw new FSMsgException("nullProviderID",null);
         }
-        
+
         StringBuffer xml = new StringBuffer(300);
         if (includeHeader) {
             xml.append(IFSConstants.XML_PREFIX)
@@ -522,14 +521,14 @@ public class FSAuthnResponse extends Response {
         String uriLIB = "";
         String uriDS="";
         String uriXSI="";
-        
+
         if (includeNS) {
             prefixLIB = IFSConstants.LIB_PREFIX;
             prefixSAML = IFSConstants.ASSERTION_PREFIX;
-            prefixSAML_PROTOCOL = IFSConstants.PROTOCOL_PREFIX; 
+            prefixSAML_PROTOCOL = IFSConstants.PROTOCOL_PREFIX;
         }
         if (declareNS) {
-            if(minorVersion == IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) { 
+            if(minorVersion == IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) {
                uriLIB = IFSConstants.LIB_12_NAMESPACE_STRING;
             } else {
                uriLIB = IFSConstants.LIB_NAMESPACE_STRING;
@@ -560,16 +559,16 @@ public class FSAuthnResponse extends Response {
                .append(responseID)
                .append(IFSConstants.QUOTE)
                .append(IFSConstants.SPACE);
-               
+
                 if ((inResponseTo != null) && (inResponseTo.length() != 0)) {
                     xml.append(IFSConstants.SPACE)
                        .append(IFSConstants.IN_RESPONSE_TO)
                        .append(IFSConstants.EQUAL_TO)
                        .append(IFSConstants.QUOTE)
-                       .append(inResponseTo)
+                       .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
                        .append(IFSConstants.QUOTE);
                 }
-                if (minorVersion == IFSConstants.FF_11_PROTOCOL_MINOR_VERSION && 
+                if (minorVersion == IFSConstants.FF_11_PROTOCOL_MINOR_VERSION &&
                     id != null && (id.length() > 0)) {
                         xml.append(IFSConstants.SPACE)
                            .append(IFSConstants.ID)
@@ -579,13 +578,13 @@ public class FSAuthnResponse extends Response {
                            .append(IFSConstants.QUOTE);
                 }
                 xml.append(IFSConstants.SPACE)
-                   .append(IFSConstants.MAJOR_VERSION) 
+                   .append(IFSConstants.MAJOR_VERSION)
                    .append(IFSConstants.EQUAL_TO)
                    .append(IFSConstants.QUOTE)
                    .append(majorVersion)
                    .append(IFSConstants.QUOTE)
                    .append(IFSConstants.SPACE)
-                   .append(IFSConstants.MINOR_VERSION) 
+                   .append(IFSConstants.MINOR_VERSION)
                    .append(IFSConstants.EQUAL_TO)
                    .append(IFSConstants.QUOTE)
                    .append(minorVersion)
@@ -626,11 +625,11 @@ public class FSAuthnResponse extends Response {
                 xml.append(signatureString);
             }
         }
-        
+
         if (status != null) {
             xml.append(status.toString(includeNS, false));
         }
-        
+
         if ((assertions != null) && (assertions != Collections.EMPTY_LIST)) {
             Iterator j = assertions.iterator();
             while (j.hasNext()) {
@@ -638,7 +637,7 @@ public class FSAuthnResponse extends Response {
                                 .toXMLString(true,declareNS));
             }
         }
-        
+
         xml.append(IFSConstants.LEFT_ANGLE)
            .append(prefixLIB)
            .append(IFSConstants.PROVIDER_ID)
@@ -648,7 +647,7 @@ public class FSAuthnResponse extends Response {
            .append(prefixLIB)
            .append(IFSConstants.PROVIDER_ID)
            .append(IFSConstants.RIGHT_ANGLE);
-        
+
         if (relayState != null && relayState.length() != 0) {
             xml.append(IFSConstants.LEFT_ANGLE)
                .append(prefixLIB)
@@ -659,7 +658,7 @@ public class FSAuthnResponse extends Response {
                .append(prefixLIB)
                .append(IFSConstants.RELAY_STATE)
                .append(IFSConstants.RIGHT_ANGLE);
-        }     
+        }
 
         xml.append(IFSConstants.START_END_ELEMENT)
            .append(prefixLIB)
@@ -669,9 +668,9 @@ public class FSAuthnResponse extends Response {
 
         return xml.toString();
     }
-    
+
    /**
-    * Returns <code>FSAutnResponse</code> object by parsing a 
+    * Returns <code>FSAutnResponse</code> object by parsing a
     * <code>Base64</code> encoding XML string.
     *
     *
@@ -681,7 +680,7 @@ public class FSAuthnResponse extends Response {
     *         the <code>Base64</code> encoded string.
     * @throws SAMLException if there is an error creating
     *         the <code>FSAuthnResponse</code> object.
-    */    
+    */
     public static FSAuthnResponse parseBASE64EncodedString(String encodedRes)
                                   throws FSMsgException, SAMLException {
         FSUtils.debug.message(
@@ -704,7 +703,7 @@ public class FSAuthnResponse extends Response {
                 throw new FSMsgException("nullInput",null);
         }
     }
-    
+
    /**
     * Returns a <code>Base64</code> encoded string representing this
     * object.
@@ -725,8 +724,8 @@ public class FSAuthnResponse extends Response {
             }
         }
         return Base64.encode(this.toXMLString(true, true).getBytes());
-    } 
-    
+    }
+
     /**
      * Signs the <code>Response</code>.
      *
@@ -752,33 +751,33 @@ public class FSAuthnResponse extends Response {
         try{
             XMLSignatureManager manager = XMLSignatureManager.getInstance();
             if (minorVersion == IFSConstants.FF_11_PROTOCOL_MINOR_VERSION) {
-                signatureString = manager.signXML(this.toXMLString(true, true), 
-                                          certAlias, 
-                                          IFSConstants.DEF_SIG_ALGO, 
-                                          IFSConstants.ID, 
+                signatureString = manager.signXML(this.toXMLString(true, true),
+                                          certAlias,
+                                          IFSConstants.DEF_SIG_ALGO,
+                                          IFSConstants.ID,
                                           this.id, false);
-            } else if (minorVersion == 
+            } else if (minorVersion ==
                           IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) {
                   signatureString = manager.signXML(
-                                         this.toXMLString(true, true), 
+                                         this.toXMLString(true, true),
                                          certAlias, IFSConstants.DEF_SIG_ALGO,
-                                         IFSConstants.RESPONSE_ID, 
+                                         IFSConstants.RESPONSE_ID,
                                          this.getResponseID(), false);
-            } else { 
-                if (FSUtils.debug.messageEnabled()) { 
-                    FSUtils.debug.message("invalid minor version.");                 
+            } else {
+                if (FSUtils.debug.messageEnabled()) {
+                    FSUtils.debug.message("invalid minor version.");
                 }
-            }  
+            }
             signature = XMLUtils.toDOMDocument(signatureString, FSUtils.debug)
                                                .getDocumentElement();
             signed = true;
-            xmlString = this.toXMLString(true, true);      
+            xmlString = this.toXMLString(true, true);
         } catch(Exception e) {
             throw new SAMLResponderException(FSUtils.BUNDLE_NAME,
                                              "signFailed",null);
         }
     }
-    
+
    /**
     * Sets the <code>Element</code> signature.
     *
@@ -786,7 +785,7 @@ public class FSAuthnResponse extends Response {
     * @return true if signature is set otherwise false
     */
     public boolean setSignature(Element elem) {
-        signatureString = XMLUtils.print(elem); 
-        return super.setSignature(elem); 
+        signatureString = XMLUtils.print(elem);
+        return super.setSignature(elem);
     }
 }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSLogoutResponse.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSLogoutResponse.java
@@ -25,8 +25,8 @@
  * $Id: FSLogoutResponse.java,v 1.4 2008/06/25 05:46:44 qcheng Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
-
 package com.sun.identity.federation.message;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -81,7 +81,7 @@ public class FSLogoutResponse extends AbstractResponse {
     protected String signatureString;
     protected String id;
     private String inResponseTo;
-    
+
     /**
      * Default Constructor.
      */
@@ -95,9 +95,9 @@ public class FSLogoutResponse extends AbstractResponse {
         } catch (SAMLException e){
             FSUtils.debug.error("FSLogoutResponse.constructor:", e);
         }
-        
+
     }
-    
+
     /**
      * Constructor creates <code>FSLogoutResponse</code> object.
      *
@@ -122,7 +122,7 @@ public class FSLogoutResponse extends AbstractResponse {
         } else {
             this.responseID = responseID;
         }
-        
+
         if (inResponseTo == null) {
             FSUtils.debug.message("Response: inResponseTo is null.");
             throw new FSMsgException("nullInput",null);
@@ -137,7 +137,7 @@ public class FSLogoutResponse extends AbstractResponse {
         this.relayState = relayState;
         setIssueInstant(newDate());
     }
-    
+
     /**
      * Constructor creates <code>FSLogoutResponse</code> object from
      * a Document element.
@@ -157,9 +157,9 @@ public class FSLogoutResponse extends AbstractResponse {
             FSUtils.debug.message("FSLogoutResponse.parseXML: wrong input.");
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         id = root.getAttribute(IFSConstants.ID);
-        
+
         // Attribute ResponseID
         responseID = root.getAttribute(IFSConstants.RESPONSE_ID);
         if ((responseID == null) || (responseID.length() == 0)) {
@@ -201,7 +201,7 @@ public class FSLogoutResponse extends AbstractResponse {
                 throw new FSMsgException("wrongInput", null);
             }
         }
-        
+
         NodeList nl = root.getChildNodes();
         Node child;
         String childName;
@@ -241,18 +241,18 @@ public class FSLogoutResponse extends AbstractResponse {
                 }
             } // end if childName != null
         } // end for loop
-        
+
         if (status == null) {
             FSUtils.debug.message("FSLogoutResponse:missing element <Status>.");
             throw new FSMsgException("oneElement",null);
         }
-        
+
         if (providerId == null) {
             FSUtils.debug.message(
                     "FSLogoutResponse: missing element providerId.");
             throw new FSMsgException("oneElement",null);
         }
-        
+
         //check for signature
         List signs = XMLUtils.getElementsByTagNameNS1(root,
                 SAMLConstants.XMLSIG_NAMESPACE_URI,
@@ -272,7 +272,7 @@ public class FSLogoutResponse extends AbstractResponse {
             throw new FSMsgException("moreElement",null);
         }
     }
-    
+
     /**
      * Returns the value of <code>RelayState</code> attribute.
      *
@@ -282,7 +282,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public String getRelayState(){
         return relayState;
     }
-    
+
     /**
      * Set the value of <code>RelayState</code> attribute.
      *
@@ -292,7 +292,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setRelayState(String relayState){
         this.relayState = relayState;
     }
-    
+
     /**
      * Returns the value of <code>InResponseTo</code> attribute.
      *
@@ -302,7 +302,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public String getResponseTo(){
         return inResponseTo;
     }
-    
+
     /**
      * Sets the value of <code>InResponseTo</code> attribute.
      *
@@ -312,7 +312,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setResponseTo(String inResponseTo){
         this.inResponseTo = inResponseTo;
     }
-    
+
     /**
      * Returns the value of <code>id</code> attribute.
      *
@@ -322,7 +322,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public String getID(){
         return id;
     }
-    
+
     /**
      * Sets the value of <code>id</code> attribute.
      *
@@ -332,18 +332,18 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setID(String id){
         this.id = id;
     }
-    
+
     /**
      * Returns the value of <code>ProviderID</code> attribute.
      *
      * @return the value of <code>ProviderID</code> attribute.
      * @see #setProviderId(String).
      */
-    
+
     public String getProviderId(){
         return providerId;
     }
-    
+
     /**
      * Sets the value of  <code>ProviderID</code> attribute.
      *
@@ -353,7 +353,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setProviderId(String providerId){
         this.providerId = providerId;
     }
-    
+
     /**
      * Returns the Signed <code>LogoutResponse</code> string.
      *
@@ -362,7 +362,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public String getSignatureString(){
         return signatureString;
     }
-    
+
     /**
      * Returns the value of <code>MinorVersion</code> attribute.
      *
@@ -372,7 +372,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public int getMinorVersion() {
         return minorVersion;
     }
-    
+
     /**
      * Sets the value of <code>MinorVersion</code> attribute.
      *
@@ -382,7 +382,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setMinorVersion(int version) {
         minorVersion = version;
     }
-    
+
     /**
      * Returns the Logout <code>Status</code>.
      *
@@ -393,7 +393,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public Status getStatus() {
         return status;
     }
-    
+
     /**
      * Sets the Logout <code>Status</code>.
      *
@@ -411,7 +411,7 @@ public class FSLogoutResponse extends AbstractResponse {
             }
         }
     }
-    
+
     /**
      * Sets the Logout <code>Status</code>.
      *
@@ -421,7 +421,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public void setStatus(Status status) {
         this.status=status;
     }
-    
+
     /**
      * Sets the <code>MajorVersion</code> by parsing the version string.
      *
@@ -441,7 +441,7 @@ public class FSLogoutResponse extends AbstractResponse {
             }
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
             if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
                 if (FSUtils.debug.messageEnabled()) {
@@ -460,7 +460,7 @@ public class FSLogoutResponse extends AbstractResponse {
             }
         }
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code> by parsing the version string.
      *
@@ -491,7 +491,7 @@ public class FSLogoutResponse extends AbstractResponse {
                         "responseVersionTooLow",null);
         }
     }
-    
+
     /**
      * Returns the <code>FSLogoutResponse</code> object.
      *
@@ -500,7 +500,7 @@ public class FSLogoutResponse extends AbstractResponse {
      * @throws FSMsgException if there is
      *         error creating the object.
      */
-    
+
     public static FSLogoutResponse parseXML(String xml) throws FSMsgException {
         FSLogoutResponse logoutResponse = null;
         try{
@@ -516,7 +516,7 @@ public class FSLogoutResponse extends AbstractResponse {
         }
         return logoutResponse;
     }
-    
+
     /**
      * Returns a String representation of the <code>LogoutResponse</code>
      * object. This method translates the response to an XML string.
@@ -526,7 +526,7 @@ public class FSLogoutResponse extends AbstractResponse {
     public String toXMLString()  throws FSMsgException {
         return this.toXMLString(true, true);
     }
-    
+
     /**
      * Returns a String representation of the <code>LogoutResponse</code>
      * object.
@@ -539,7 +539,7 @@ public class FSLogoutResponse extends AbstractResponse {
     throws FSMsgException {
         return toXMLString(includeNS, declareNS, false);
     }
-    
+
     /**
      * Returns a String representation of the <code>LogoutResponse</code>
      * object.
@@ -554,7 +554,7 @@ public class FSLogoutResponse extends AbstractResponse {
      * @throws FSMsgException if there is an error converting
      *         this object ot a string.
      */
-    
+
     public String toXMLString(boolean includeNS, boolean declareNS,
             boolean includeHeader)  throws FSMsgException {
         StringBuffer xml = new StringBuffer(300);
@@ -572,7 +572,7 @@ public class FSLogoutResponse extends AbstractResponse {
         if (includeNS) {
             prefixLIB = IFSConstants.LIB_PREFIX;
         }
-        
+
         if (declareNS) {
             if(minorVersion == IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) {
                 uriLIB = IFSConstants.LIB_12_NAMESPACE_STRING;
@@ -580,9 +580,9 @@ public class FSLogoutResponse extends AbstractResponse {
                 uriLIB = IFSConstants.LIB_NAMESPACE_STRING;
             }
         }
-        
+
         String instantString = DateUtils.toUTCDateFormat(issueInstant);
-        
+
         if((providerId == null) || (providerId.length() == 0)){
             FSUtils.debug.error("FSLogoutResponse.toXMLString: "
                     + "providerId is null in the response with responseId:"
@@ -590,13 +590,13 @@ public class FSLogoutResponse extends AbstractResponse {
             String[] args = { responseID };
             throw new FSMsgException("nullProviderIdWResponseId",args);
         }
-        
+
         xml.append(IFSConstants.LEFT_ANGLE)
         .append(prefixLIB)
         .append(IFSConstants.LOGOUT_RESPONSE)
         .append(uriLIB)
         .append(IFSConstants.SPACE);
-        
+
         if (minorVersion == IFSConstants.FF_11_PROTOCOL_MINOR_VERSION &&
                 id != null && !(id.length() == 0)) {
             xml.append(IFSConstants.ID)
@@ -607,7 +607,7 @@ public class FSLogoutResponse extends AbstractResponse {
             .append(IFSConstants.SPACE)
             .append(IFSConstants.SPACE);
         }
-        
+
         if (responseID != null) {
             xml.append(IFSConstants.RESPONSE_ID)
             .append(IFSConstants.EQUAL_TO)
@@ -617,17 +617,17 @@ public class FSLogoutResponse extends AbstractResponse {
             .append(IFSConstants.SPACE)
             .append(IFSConstants.SPACE);
         }
-        
+
         if (inResponseTo != null) {
             xml.append(IFSConstants.IN_RESPONSE_TO)
             .append(IFSConstants.EQUAL_TO)
             .append(IFSConstants.QUOTE)
-            .append(inResponseTo)
+            .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
             .append(IFSConstants.QUOTE)
             .append(IFSConstants.SPACE)
             .append(IFSConstants.SPACE);
         }
-        
+
         xml.append(IFSConstants.MAJOR_VERSION)
         .append(IFSConstants.EQUAL_TO)
         .append(IFSConstants.QUOTE)
@@ -657,7 +657,7 @@ public class FSLogoutResponse extends AbstractResponse {
                 xml.append(signatureString);
             }
         }
-        
+
         if (providerId != null) {
             xml.append(IFSConstants.LEFT_ANGLE)
             .append(prefixLIB)
@@ -669,11 +669,11 @@ public class FSLogoutResponse extends AbstractResponse {
             .append(IFSConstants.PROVIDER_ID)
             .append(IFSConstants.RIGHT_ANGLE);
         }
-        
+
         if (status != null) {
             xml.append(status.toString(includeNS, true));
         }
-        
+
         if (relayState != null) {
             xml.append(IFSConstants.LEFT_ANGLE)
             .append(prefixLIB)
@@ -685,15 +685,15 @@ public class FSLogoutResponse extends AbstractResponse {
             .append(IFSConstants.RELAY_STATE)
             .append(IFSConstants.RIGHT_ANGLE);
         }
-        
+
         xml.append(IFSConstants.START_END_ELEMENT)
         .append(prefixLIB)
         .append(IFSConstants.LOGOUT_RESPONSE)
         .append(IFSConstants.RIGHT_ANGLE);
-        
+
         return xml.toString();
     }
-    
+
     /**
      * Returns <code>FSLogoutResponse</code> object. The object
      * is created by parsing an Base64 encode authentication
@@ -722,7 +722,7 @@ public class FSLogoutResponse extends AbstractResponse {
             throw new FSMsgException("nullInput",null);
         }
     }
-    
+
     /**
      * Returns a Base64 Encoded String.
      *
@@ -740,13 +740,13 @@ public class FSLogoutResponse extends AbstractResponse {
         }
         return Base64.encode(this.toXMLString().getBytes());
     }
-    
+
     /**
      * Unsupported operation.
      */
     public void signXML() {
     }
-    
+
     /**
      * Signs the <code>LogoutResponse</code>.
      *
@@ -787,10 +787,10 @@ public class FSLogoutResponse extends AbstractResponse {
                     FSUtils.debug.message("invalid minor version.");
                 }
             }
-            
+
             signature = XMLUtils.toDOMDocument(signatureString, FSUtils.debug)
             .getDocumentElement();
-            
+
             signed = true;
             xmlString = this.toXMLString(true, true);
         } catch (Exception e) {
@@ -798,7 +798,7 @@ public class FSLogoutResponse extends AbstractResponse {
                     "signFailed",null);
         }
     }
-    
+
     /**
      * Sets the Signature.
      *
@@ -809,7 +809,7 @@ public class FSLogoutResponse extends AbstractResponse {
         signatureString = XMLUtils.print(elem);
         return super.setSignature(elem);
     }
-    
+
     /**
      * Returns an URL Encoded String.
      *
@@ -832,13 +832,13 @@ public class FSLogoutResponse extends AbstractResponse {
                 throw new FSMsgException("errorGenerateID",null);
             }
         }
-        
+
         StringBuffer urlEncodedAuthnReq = new StringBuffer(300);
         urlEncodedAuthnReq.append(IFSConstants.RESPONSE_ID)
         .append(IFSConstants.EQUAL_TO)
         .append(URLEncDec.encode(responseID))
         .append(IFSConstants.AMPERSAND);
-        
+
         if((inResponseTo != null) && (inResponseTo.length() > 0)) {
             urlEncodedAuthnReq.append(IFSConstants.IN_RESPONSE_TO)
             .append(IFSConstants.EQUAL_TO)
@@ -853,7 +853,7 @@ public class FSLogoutResponse extends AbstractResponse {
         .append(IFSConstants.EQUAL_TO)
         .append(minorVersion)
         .append(IFSConstants.AMPERSAND);
-        
+
         if (issueInstant != null) {
             urlEncodedAuthnReq.append(IFSConstants.ISSUE_INSTANT)
             .append(IFSConstants.EQUAL_TO)
@@ -872,14 +872,14 @@ public class FSLogoutResponse extends AbstractResponse {
                 .append(URLEncDec.encode(providerId))
                 .append(IFSConstants.AMPERSAND);
             }
-            
+
             if(relayState != null && relayState.length() != 0) {
                 urlEncodedAuthnReq.append(IFSConstants.RELAY_STATE)
                 .append(IFSConstants.EQUAL_TO)
                 .append(URLEncDec.encode(relayState))
                 .append(IFSConstants.AMPERSAND);
             }
-            
+
             if (status != null) {
                 urlEncodedAuthnReq.append(IFSConstants.VALUE)
                 .append(IFSConstants.EQUAL_TO)
@@ -889,8 +889,8 @@ public class FSLogoutResponse extends AbstractResponse {
             }
             return urlEncodedAuthnReq.toString();
         }
-        
-        
+
+
         /**
          * Returns <code>FSLogoutResponse</code> object. The
          * object is creating by parsing the <code>HttpServletRequest</code>
@@ -915,7 +915,7 @@ public class FSLogoutResponse extends AbstractResponse {
             } catch(NumberFormatException ex){
                 throw new FSMsgException("invalidNumber",null);
             }
-            
+
             String requestID = request.getParameter(IFSConstants.RESPONSE_ID);
             if (requestID != null) {
                 retLogoutResponse.responseID = requestID ;
@@ -925,7 +925,7 @@ public class FSLogoutResponse extends AbstractResponse {
             }
             retLogoutResponse.inResponseTo =
                     request.getParameter(IFSConstants.IN_RESPONSE_TO);
-            
+
             String instantString =
                     request.getParameter(IFSConstants.ISSUE_INSTANT);
             if (instantString == null || instantString.length() == 0) {
@@ -953,7 +953,7 @@ public class FSLogoutResponse extends AbstractResponse {
                 }
                 throw new FSMsgException("missingElement",null);
             }
-            
+
             String relayState = request.getParameter(IFSConstants.RELAY_STATE);
             if (relayState != null) {
                 retLogoutResponse.relayState = relayState;
@@ -962,7 +962,7 @@ public class FSLogoutResponse extends AbstractResponse {
                             + retLogoutResponse.relayState);
                 }
             }
-            
+
             String value = request.getParameter(IFSConstants.VALUE);
             if (value != null){
                 if (FSUtils.debug.messageEnabled()) {
@@ -976,7 +976,7 @@ public class FSLogoutResponse extends AbstractResponse {
                 }
                 throw new FSMsgException("missingElement",null);
             }
-            
+
             FSUtils.debug.message("Returning Logout response Object");
             return retLogoutResponse;
         }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSNameIdentifierMappingResponse.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSNameIdentifierMappingResponse.java
@@ -25,8 +25,8 @@
  * $Id: FSNameIdentifierMappingResponse.java,v 1.2 2008/06/25 05:46:44 qcheng Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
-
 package com.sun.identity.federation.message;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -69,13 +69,13 @@ import org.w3c.dom.NodeList;
  */
 @Deprecated
 public class FSNameIdentifierMappingResponse extends AbstractResponse {
-    
+
     private String providerID;
     private Status status;
     private NameIdentifier nameIdentifier;
     private int minorVersion = IFSConstants.FF_12_PROTOCOL_MINOR_VERSION;
     private String signatureString;
-    
+
     /**
      * Constructor to create <code>FSNameIdentifierMappingResponse</code> object.
      *
@@ -96,7 +96,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
         this.responseID = FSUtils.generateID();
         setIssueInstant(newDate());
     }
-    
+
     /**
      * Constructor to create <code>FSNameIdentifierMappingResponse</code> object.
      * This object is created from the Document Element.
@@ -119,7 +119,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
                     "FSNameIdentifierMappingRequest: wrong input");
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         // get IssueInstant
         String instantString = root.getAttribute(IFSConstants.ISSUE_INSTANT);
         if (instantString==null || instantString.length()==0) {
@@ -136,7 +136,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
                 throw new FSMsgException("wrongInput",null);
             }
         }
-        
+
         // get ResponseID
         responseID = root.getAttribute(IFSConstants.RESPONSE_ID);
         if ((responseID == null) || (responseID.length() < 1)) {
@@ -145,7 +145,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             String[] args = { IFSConstants.RESPONSE_ID };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         // get InResponseTo
         inResponseTo = root.getAttribute(IFSConstants.IN_RESPONSE_TO);
         if (inResponseTo == null) {
@@ -154,11 +154,11 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             String[] args = { IFSConstants.IN_RESPONSE_TO };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         // get and check versions
         parseMajorVersion(root.getAttribute(IFSConstants.MAJOR_VERSION));
         parseMinorVersion(root.getAttribute(IFSConstants.MINOR_VERSION));
-        
+
         // get ProviderID, Status & NameIdentifier
         NodeList nl = root.getChildNodes();
         Node child;
@@ -190,7 +190,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
                 }
             }
         }
-        
+
         // get signature
         List signs = XMLUtils.getElementsByTagNameNS1(
                 root,
@@ -207,7 +207,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             throw new FSMsgException("moreElement",null);
         }
     }
-    
+
     /**
      * Creates <code>FSNameIdentifierMappingResponse</code> object.
      * This object is created by parsing the <code>XML</code> string.
@@ -228,7 +228,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
         Element root = doc.getDocumentElement();
         return new FSNameIdentifierMappingResponse(root);
     }
-    
+
     /**
      * Returns the value of <code>ProviderID</code> attribute.
      *
@@ -237,7 +237,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
     public String getProviderID() {
         return providerID;
     }
-    
+
     /**
      * Returns the <code>Status</code>.
      *
@@ -246,7 +246,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
     public Status getStatus() {
         return status;
     }
-    
+
     /**
      * Returns the <code>NameIdentifier</code> object. This is the resulting
      * mapped name identifier for the desired identity federation.
@@ -257,7 +257,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
     public NameIdentifier getNameIdentifier() {
         return nameIdentifier;
     }
-    
+
     /**
      * Sets the <code>MajorVersion</code> by parsing the version string.
      *
@@ -275,7 +275,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             }
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
             if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
                 if (FSUtils.debug.messageEnabled()) {
@@ -292,7 +292,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             }
         }
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code> by parsing the version string.
      *
@@ -324,7 +324,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
             throw new FSMsgException("requestVersionTooLow",null);
         }
     }
-    
+
     /**
      * Signs the XML document representing
      * <code>NameIdentifierMappingResponse</code> using the certificate
@@ -339,7 +339,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
                 Constants.SAML_XMLSIG_CERT_ALIAS);
         signXML(certAlias);
     }
-    
+
     /**
      * Signs the <code>XML</code> document representing
      * <code>NameIdentifierMappingResponse</code> using the specified
@@ -385,7 +385,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
                     FSUtils.BUNDLE_NAME,"signFailed",null);
         }
     }
-    
+
     /**
      * Returns the string representation of this object.
      *
@@ -395,7 +395,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
     public String toXMLString()  throws FSMsgException {
         return toXMLString(true, true);
     }
-    
+
     /**
      * Returns a String representation of this object.
      *
@@ -407,12 +407,12 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
      * @throws FSMsgException if there is an error converting
      *         this object ot a string.
      */
-    
+
     public String toXMLString(boolean includeNS, boolean declareNS)
     throws FSMsgException {
         return toXMLString(includeNS, declareNS, false);
     }
-    
+
     /**
      * Returns a String representation of this object.
      *
@@ -428,7 +428,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
      */
     public String toXMLString(boolean includeNS, boolean declareNS,
             boolean includeHeader) throws FSMsgException {
-        
+
         String prefixLIB = "";
         String uriLIB = "";
         String uriSAML = "";
@@ -471,7 +471,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
         .append(IFSConstants.IN_RESPONSE_TO)
         .append(IFSConstants.EQUAL_TO)
         .append(IFSConstants.QUOTE)
-        .append(inResponseTo)
+        .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
         .append(IFSConstants.QUOTE)
         .append(IFSConstants.SPACE)
         .append(IFSConstants.SPACE)
@@ -514,7 +514,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
         .append(IFSConstants.PROVIDER_ID)
         .append(IFSConstants.RIGHT_ANGLE)
         .append(status.toString(includeNS, true));
-        
+
         if (nameIdentifier != null) {
             xml.append(nameIdentifier.toString());
         }
@@ -522,7 +522,7 @@ public class FSNameIdentifierMappingResponse extends AbstractResponse {
         .append(prefixLIB)
         .append(IFSConstants.NAMEID_MAPPING_RESPONSE)
         .append(IFSConstants.RIGHT_ANGLE);
-        
+
         return xml.toString();
     }
 }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSNameRegistrationResponse.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSNameRegistrationResponse.java
@@ -25,8 +25,8 @@
  * $Id: FSNameRegistrationResponse.java,v 1.3 2008/06/25 05:46:45 qcheng Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
-
 package com.sun.identity.federation.message;
 
 import static org.forgerock.openam.utils.Time.*;
@@ -72,7 +72,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     protected String signatureString        = null;
     protected String id = null;
     protected int minorVersion = 0;
-    
+
     /**
      * Default Constructor.
      */
@@ -85,7 +85,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             FSUtils.debug.error("FSNameRegistrationResponse.Constructor", e);
         }
     }
-    
+
     /**
      * Returns the value of <code>RelayState</code> attribute.
      *
@@ -95,7 +95,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public String getRelayState(){
         return relayState;
     }
-    
+
     /**
      * Set the value of <code>RelayState</code> attribute.
      *
@@ -105,18 +105,18 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public void setRelayState(String relayState){
         this.relayState = relayState;
     }
-    
+
     /**
      * Returns the value of <code>id</code> attribute.
      *
      * @return the value of <code>id</code> attribute.
      * @see #setID(String)
      */
-    
+
     public String getID(){
         return id;
     }
-    
+
     /**
      * Sets the value of <code>id</code> attribute.
      *
@@ -126,7 +126,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public void setID(String id){
         this.id = id;
     }
-    
+
     /**
      * Returns the value of <code>ProviderID</code> attribute.
      *
@@ -136,7 +136,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public String getProviderId(){
         return providerId;
     }
-    
+
     /**
      * Sets the value of providerID attribute.
      *
@@ -146,7 +146,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public void setProviderId(String providerId){
         this.providerId = providerId;
     }
-    
+
     /**
      * Returns signed <code>XML</code> representation of this
      * object.
@@ -157,7 +157,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public String getSignedXMLString(){
         return xmlString;
     }
-    
+
     /**
      * Returns the signed <code>NameRegistrationResponse</code> string.
      *
@@ -167,7 +167,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public String getSignatureString(){
         return signatureString;
     }
-    
+
     /**
      * Constructor creates the <code>FSNameRegistrationResponse</code> object.
      *
@@ -203,7 +203,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         this.relayState = relayState;
         setIssueInstant(newDate());
     }
-    
+
     /**
      * Constructor creates the <code>FSNameRegistrationResponse</code> object
      * from Document Element.
@@ -226,9 +226,9 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     " input.");
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         id = root.getAttribute("id");
-        
+
         // Attribute ResponseID
         responseID = root.getAttribute("ResponseID");
         if ((responseID == null) || (responseID.length() == 0)) {
@@ -237,10 +237,10 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             String[] args = { IFSConstants.RESPONSE_ID };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         parseMajorVersion(root.getAttribute("MajorVersion"));
         parseMinorVersion(root.getAttribute("MinorVersion"));
-        
+
         // Attribute InResponseTo
         inResponseTo = root.getAttribute("InResponseTo");
         if (inResponseTo == null) {
@@ -266,7 +266,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                 throw new FSMsgException("wrongInput",null);
             }
         }
-        
+
         NodeList nl = root.getChildNodes();
         Node child;
         String childName;
@@ -298,19 +298,19 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                 }
             } // end if childName != null
         } // end for loop
-        
+
         if (status == null) {
             FSUtils.debug.message(
                     "FSNameRegistrationResponse: missing element <Status>.");
             throw new FSMsgException("oneElement",null);
         }
-        
+
         if (providerId == null) {
             FSUtils.debug.message(
                     "FSNameRegistrationResponse: missing element providerId.");
             throw new FSMsgException("oneElement",null);
         }
-        
+
         //check for signature
         List signs = XMLUtils.getElementsByTagNameNS1(root,
                 SAMLConstants.XMLSIG_NAMESPACE_URI,
@@ -327,7 +327,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             throw new FSMsgException("moreElement",null);
         }
     }
-    
+
     /**
      * Returns the <code>MinorVersion</code>.
      *
@@ -337,18 +337,18 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public int getMinorVersion() {
         return minorVersion;
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code>.
      *
      * @param version the <code>MinorVersion</code>.
      * @see #getMinorVersion()
      */
-    
+
     public void setMinorVersion(int version) {
         minorVersion = version;
     }
-    
+
     /**
      * Returns the Response <code>Status</code>.
      *
@@ -358,8 +358,8 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public Status getStatus() {
         return status;
     }
-    
-    
+
+
     /**
      * Sets the Response <code>Status</code>.
      *
@@ -369,7 +369,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public void setStatus(Status status) {
         this.status=status;
     }
-    
+
     /**
      * Sets the <code>MajorVersion</code> by parsing the version string.
      *
@@ -387,7 +387,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             FSUtils.debug.error("Response(Element): invalid MajorVersion", e);
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
             if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
                 if (FSUtils.debug.messageEnabled()) {
@@ -406,7 +406,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             }
         }
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code> by parsing the version string.
      *
@@ -425,7 +425,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             }
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (minorVersion > IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) {
             FSUtils.debug.error("FSRegisResp(Element):MinorVersion of"
                     + " the Response is too high.");
@@ -435,9 +435,9 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     + " the Response is too low.");
             throw new FSMsgException("responseVersionTooLow",null);
         }
-        
+
     }
-    
+
     /**
      * Returns the <code>FSNameRegistrationResponse</code> object.
      *
@@ -459,9 +459,9 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             }
             throw new FSMsgException("parseError", null, ex);
         }
-        
+
     }
-    
+
     /**
      * Returns the string representation of this object.
      * This method translates the response to an XML string.
@@ -472,7 +472,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     public String toXMLString()  throws FSMsgException {
         return this.toXMLString(true, true);
     }
-    
+
     /**
      * Returns a String representation of the Logout Response.
      *
@@ -488,7 +488,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
     throws FSMsgException {
         return toXMLString(includeNS, declareNS, false);
     }
-    
+
     /**
      * Returns a String representation of the Logout Response.
      *
@@ -514,7 +514,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         if (includeNS) {
             prefixLIB = IFSConstants.LIB_PREFIX;
         }
-        
+
         if (declareNS) {
             if (minorVersion == IFSConstants.FF_12_PROTOCOL_MINOR_VERSION) {
                 uriLIB = IFSConstants.LIB_12_NAMESPACE_STRING;
@@ -522,16 +522,16 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                 uriLIB = IFSConstants.LIB_NAMESPACE_STRING;
             }
         }
-        
+
         String instantString = DateUtils.toUTCDateFormat(issueInstant);
-        
+
         if ((providerId == null) || (providerId.length() == 0)){
             FSUtils.debug.error("FSNameRegistrationResponse.toXMLString: "
                     + "providerId is null in the response with responseId:"
                     + responseID);
             throw new FSMsgException("nullProviderID",null);
         }
-        
+
         if ((responseID != null) && (inResponseTo != null)){
             xml.append("<").append(prefixLIB).
                     append("RegisterNameIdentifierResponse").append(uriLIB);
@@ -540,7 +540,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                 xml.append(" id=\"").append(id).append("\" ");
             }
             xml.append(" ResponseID=\"").append(responseID).append("\" ").
-                    append(" InResponseTo=\"").append(inResponseTo).
+                    append(" InResponseTo=\"").append(XMLUtils.escapeSpecialCharacters(inResponseTo)).
                     append("\" ").
                     append(" MajorVersion=\"").append(majorVersion).
                     append("\" ").
@@ -550,7 +550,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     append("\" ").
                     append(">");
         }
-        
+
         if (signed) {
             if (signatureString != null) {
                 xml.append(signatureString);
@@ -559,30 +559,30 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                 xml.append(signatureString);
             }
         }
-        
+
         if (providerId != null) {
             xml.append("<").append(prefixLIB).append("ProviderID").append(">").
                     append(providerId).
                     append("</").append(prefixLIB).append("ProviderID").
                     append(">");
         }
-        
+
         if (status != null) {
             xml.append(status.toString(includeNS, true));
         }
-        
+
         if (relayState != null) {
             xml.append("<").append(prefixLIB).append("RelayState").
                     append(">").append(relayState).
                     append("</").append(prefixLIB).
                     append("RelayState").append(">");
         }
-        
+
         xml.append("</").append(prefixLIB).
                 append("RegisterNameIdentifierResponse>");
         return xml.toString();
     }
-    
+
     /**
      * Returns <code>FSNameRegistrationResponse</code> object. The object
      * is created by parsing an Base64 encode Name Registration Response
@@ -613,7 +613,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             throw new FSMsgException("nullInput",null);
         }
     }
-    
+
     /**
      * Returns a Base64 Encoded String.
      *
@@ -633,7 +633,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         }
         return Base64.encode(this.toXMLString().getBytes());
     }
-    
+
     /**
      * Signs the Name Registration Response.
      *
@@ -674,7 +674,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             signature =
                     XMLUtils.toDOMDocument(signatureString, FSUtils.debug)
                     .getDocumentElement();
-            
+
             signed = true;
             xmlString = this.toXMLString(true, true);
         }catch(Exception e){
@@ -682,7 +682,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                                              "signError",null);
         }
     }
-    
+
     /**
      * Unsupported operation.
      */
@@ -690,7 +690,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         throw new SAMLException(FSUtils.BUNDLE_NAME,
                                "unsupportedOperation",null);
     }
-    
+
     /**
      * Sets the Signature.
      *
@@ -701,7 +701,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         signatureString = XMLUtils.print(elem);
         return super.setSignature(elem);
     }
-    
+
     /**
      * Returns an URL Encoded String.
      *
@@ -735,7 +735,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
         urlEncodedAuthnReq.append("InResponseTo=").
                 append(URLEncDec.encode(inResponseTo)).
                 append(IFSConstants.AMPERSAND);
-        
+
         if (issueInstant != null){
             urlEncodedAuthnReq.append("IssueInstant=")
             .append(URLEncDec.encode(
@@ -752,24 +752,24 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     append(URLEncDec.encode(providerId)).
                     append(IFSConstants.AMPERSAND);
         }
-        
+
         if (relayState != null && relayState.length() > 0) {
             urlEncodedAuthnReq.append("RelayState=").
                     append(URLEncDec.encode(relayState)).
                     append(IFSConstants.AMPERSAND);
         }
-        
+
         if (status != null) {
             urlEncodedAuthnReq.append("Value=");
             urlEncodedAuthnReq.append(
                     URLEncDec.encode(status.getStatusCode().getValue())).
                     append(IFSConstants.AMPERSAND);
         }
-        
+
         return urlEncodedAuthnReq.toString();
     }
-    
-    
+
+
     /**
      * Returns <code>FSNameRegistrationLogoutResponse</code> object. The
      * object is creating by parsing the <code>HttpServletRequest</code>
@@ -794,7 +794,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     "EncodedRequest: version parsing error:" + ex);
             throw new FSMsgException("invalidNumber",null);
         }
-        
+
         if (request.getParameter("ResponseID")!= null) {
             retNameRegistrationResponse.responseID =
                     request.getParameter("ResponseID");
@@ -804,7 +804,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             String[] args = { IFSConstants.RESPONSE_ID };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         String instantString = request.getParameter("IssueInstant");
         if (instantString == null || instantString.length() == 0) {
             FSUtils.debug.error("FSNameRegistrationResponse.parseURL" +
@@ -828,7 +828,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     "EncodedRequest: Provider ID is null " );
             throw new FSMsgException("missingElement",null);
         }
-        
+
         if (request.getParameter("RelayState")!= null){
             retNameRegistrationResponse.relayState =
                     request.getParameter("RelayState");
@@ -837,7 +837,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
             retNameRegistrationResponse.inResponseTo =
                     request.getParameter("InResponseTo");
         }
-        
+
         if (request.getParameter("Value") != null){
             FSUtils.debug.message("Status : " + request.getParameter("Value"));
             StatusCode statusCode =
@@ -848,7 +848,7 @@ public class FSNameRegistrationResponse extends AbstractResponse {
                     "EncodedRequest: Status Value is  null " );
             throw new FSMsgException("missingElement",null);
         }
-        
+
         FSUtils.debug.message("Returning registration response Object");
         return retNameRegistrationResponse;
     }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSResponse.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/federation/message/FSResponse.java
@@ -24,8 +24,8 @@
  *
  * $Id: FSResponse.java,v 1.2 2008/06/25 05:46:45 qcheng Exp $
  * Portions Copyrighted 2014 ForgeRock AS
+ * Portions Copyrighted 2023 Wren Security
  */
-
 package com.sun.identity.federation.message;
 
 import java.text.ParseException;
@@ -66,7 +66,7 @@ import com.sun.identity.federation.common.IFSConstants;
 @Deprecated
 public class FSResponse extends Response {
     protected String id = null;
-    
+
     /**
      * Returns the value of <code>id</code> attribute.
      *
@@ -76,7 +76,7 @@ public class FSResponse extends Response {
     public String getID() {
         return id;
     }
-    
+
     /**
      * Sets the value of <code>id</code> attribute.
      *
@@ -86,7 +86,7 @@ public class FSResponse extends Response {
     public void setID(String id) {
         this.id = id;
     }
-    
+
     /**
      * Returns the signed <code>XML</code> string.
      *
@@ -95,18 +95,18 @@ public class FSResponse extends Response {
     public String getSignatureString(){
         return signatureString;
     }
-    
+
     /**
      * Returns the <code>MinorVersion</code>.
      *
      * @return the <code>MinorVersion</code>.
      * @see #setMinorVersion(int)
      */
-    
+
     public int getMinorVersion() {
         return minorVersion;
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code>.
      *
@@ -116,7 +116,7 @@ public class FSResponse extends Response {
     public void setMinorVersion(int version) {
         minorVersion = version;
     }
-    
+
     /**
      * Constructor creates <code>FSResponse</code> object.
      *
@@ -133,7 +133,7 @@ public class FSResponse extends Response {
             List contents) throws SAMLException, FSMsgException {
         super( responseID, inResponseTo, status, contents);
     }
-    
+
     public static FSResponse parseResponseXML(
             String xml
             ) throws SAMLException, FSMsgException {
@@ -149,7 +149,7 @@ public class FSResponse extends Response {
         root = doc.getDocumentElement();
         return new FSResponse(root);
     }
-    
+
     /**
      * Constructor creates <code>FSResponse</code> object form
      * a Document Element.
@@ -182,7 +182,7 @@ public class FSResponse extends Response {
             String[] args = { IFSConstants.RESPONSE_ID };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         inResponseTo = root.getAttribute("InResponseTo");
         if (inResponseTo == null) {
             if (FSUtils.debug.messageEnabled()) {
@@ -192,7 +192,7 @@ public class FSResponse extends Response {
             String[] args = { IFSConstants.IN_RESPONSE_TO };
             throw new FSMsgException("missingAttribute",args);
         }
-        
+
         // Attribute IssueInstant
         String instantString = root.getAttribute("IssueInstant");
         if ((instantString == null) || (instantString.length() == 0)) {
@@ -245,13 +245,13 @@ public class FSResponse extends Response {
                 }
             } // end if childName != null
         } // end for loop
-        
+
         if (status == null) {
             FSUtils.debug.message(
                     "FSResponse(Element): missing element <Status>.");
             throw new FSMsgException("missingElement",null);
         }
-        
+
         //check for signature
         List signs = XMLUtils.getElementsByTagNameNS1(root,
                 SAMLConstants.XMLSIG_NAMESPACE_URI,
@@ -271,7 +271,7 @@ public class FSResponse extends Response {
         }
         //end check for signature
     }
-    
+
     /**
      * Sets the <code>MajorVersion</code> by parsing the version string.
      *
@@ -291,7 +291,7 @@ public class FSResponse extends Response {
             }
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
             if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
                 if (FSUtils.debug.messageEnabled()) {
@@ -310,7 +310,7 @@ public class FSResponse extends Response {
             }
         }
     }
-    
+
     /**
      * Sets the <code>MinorVersion</code> by parsing the version string.
      *
@@ -331,7 +331,7 @@ public class FSResponse extends Response {
             }
             throw new FSMsgException("wrongInput",null);
         }
-        
+
         if (minorVersion > IFSConstants.FF_12_SAML_PROTOCOL_MINOR_VERSION) {
             FSUtils.debug.error("FSResponse(Element):MinorVersion of"
                     + " the Response is too high.");
@@ -345,7 +345,7 @@ public class FSResponse extends Response {
                     "responseVersionTooLow",null);
         }
     }
-    
+
     /**
      * Returns a String representation of the Logout Response.
      *
@@ -356,7 +356,7 @@ public class FSResponse extends Response {
     public String toXMLString() throws FSMsgException {
         return this.toXMLString(true, true);
     }
-    
+
     /**
      * Returns a String representation of the Logout Response.
      *
@@ -368,12 +368,12 @@ public class FSResponse extends Response {
      * @throws FSMsgException if there is an error converting
      *         this object ot a string.
      */
-    
+
     public String toXMLString(boolean includeNS, boolean declareNS)
     throws FSMsgException {
         return toXMLString(includeNS, declareNS, false);
     }
-    
+
     public String toXMLString(boolean includeNS,boolean declareNS,
             boolean includeHeader)  throws FSMsgException {
         FSUtils.debug.message("FSResponse.toXMLString(3): Called");
@@ -390,7 +390,7 @@ public class FSResponse extends Response {
         String uriLIB = "";
         String uriDS="";
         String uriXSI="";
-        
+
         if (includeNS) {
             prefixLIB = IFSConstants.LIB_PREFIX;
             prefixSAML = IFSConstants.ASSERTION_PREFIX;
@@ -407,9 +407,9 @@ public class FSResponse extends Response {
             uriDS = IFSConstants.DSSAMLNameSpace;
             uriXSI = IFSConstants.XSI_NAMESPACE_STRING;
         }
-        
+
         String instantString = DateUtils.toUTCDateFormat(issueInstant);
-        
+
         if((responseID != null) && (inResponseTo != null)){
             xml.append("<").append(prefixSAML_PROTOCOL).append("Response").
                     append(uriLIB).
@@ -418,8 +418,9 @@ public class FSResponse extends Response {
                     append(" ").append(uriXSI).append(" ResponseID=\"").
                     append(responseID).append("\" ");
             if ((inResponseTo != null) && (inResponseTo.length() != 0)) {
-                xml.append(" InResponseTo=\"").append(inResponseTo).
-                        append("\" ");
+                xml.append(" InResponseTo=\"")
+                        .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
+                        .append("\" ");
             }
             if (minorVersion == IFSConstants.FF_11_PROTOCOL_MINOR_VERSION &&
                     id != null && !(id.length() == 0)){
@@ -436,7 +437,7 @@ public class FSResponse extends Response {
             }
             xml.append(">");
         }
-        
+
         if (signed) {
             if (signatureString != null) {
                 xml.append(signatureString);
@@ -445,10 +446,10 @@ public class FSResponse extends Response {
                 xml.append(signatureString);
             }
         }
-        
+
         if(status != null)
             xml.append(status.toString(includeNS, false));
-        
+
         if ((assertions != null) && (assertions != Collections.EMPTY_LIST)) {
             Iterator j = assertions.iterator();
             while (j.hasNext()) {
@@ -456,11 +457,11 @@ public class FSResponse extends Response {
                         toXMLString(true,declareNS));
             }
         }
-        
+
         xml.append("</").append(prefixSAML_PROTOCOL).append("Response>");
         return xml.toString();
     }
-    
+
     /**
      * Returns <code>FSResponse</code> object. The object
      * is created by parsing an Base64 encoded response string.
@@ -490,7 +491,7 @@ public class FSResponse extends Response {
             throw new FSMsgException("nullInput",null);
         }
     }
-    
+
     /**
      * Returns a Base64 Encoded String.
      *
@@ -509,7 +510,7 @@ public class FSResponse extends Response {
         }
         return Base64.encode(this.toXMLString().getBytes());
     }
-    
+
     /**
      * Signs the Response.
      *
@@ -551,11 +552,11 @@ public class FSResponse extends Response {
                     FSUtils.debug.message("invalid minor version.");
                 }
             }
-            
+
             signature =
                     XMLUtils.toDOMDocument(signatureString, FSUtils.debug)
                     .getDocumentElement();
-            
+
             signed = true;
             xmlString = this.toXMLString(true, true);
         } catch(Exception e){
@@ -563,7 +564,7 @@ public class FSResponse extends Response {
                     "signFailed",null);
         }
     }
-    
+
     /**
      * Unsupported operation.
      */

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml/protocol/Response.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml/protocol/Response.java
@@ -25,13 +25,14 @@
  * $Id: Response.java,v 1.3 2009/02/13 04:05:10 bina Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
 package com.sun.identity.saml.protocol;
 
 import static org.forgerock.openam.utils.Time.*;
 
 import com.sun.identity.common.SystemConfigurationUtil;
-import com.sun.identity.shared.xml.XMLUtils; 
+import com.sun.identity.shared.xml.XMLUtils;
 
 import com.sun.identity.shared.DateUtils;
 
@@ -76,26 +77,26 @@ public class Response extends AbstractResponse {
     protected List	assertions	= Collections.EMPTY_LIST;
     protected String	xmlString	= null;
     protected String	signatureString	= null;
-    protected String    issuer 		= null; 
+    protected String    issuer 		= null;
 
     // Response ID attribute name
     private static final String RESPONSE_ID_ATTRIBUTE = "ResponseID";
 
     /** default constructor */
     protected Response() {}
-    
+
      /**
      * Return whether the signature on the object is valid or not.
      * @return true if the signature on the object is valid; false otherwise.
      */
     public boolean isSignatureValid() {
         if (signed & ! validationDone) {
-	    valid = SAMLUtils.checkSignatureValid(
-	    	xmlString, RESPONSE_ID_ATTRIBUTE, issuer); 
-	     	
+        valid = SAMLUtils.checkSignatureValid(
+            xmlString, RESPONSE_ID_ATTRIBUTE, issuer);
+
             validationDone = true;
         }
-	return valid; 
+    return valid;
     }
 
     /**
@@ -104,26 +105,26 @@ public class Response extends AbstractResponse {
      * @exception SAMLException if could not sign the Response.
      */
     public void signXML() throws SAMLException {
-	if (signed) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response.signXML: the response is "
-		    + "already signed.");
-	    }
-	    throw new SAMLException(
-		SAMLUtils.bundle.getString("alreadySigned"));
-	}
-        String certAlias =    
+    if (signed) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response.signXML: the response is "
+            + "already signed.");
+        }
+        throw new SAMLException(
+        SAMLUtils.bundle.getString("alreadySigned"));
+    }
+        String certAlias =
             SystemConfigurationUtil.getProperty(
             "com.sun.identity.saml.xmlsig.certalias");
-	if (certAlias == null) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response.signXML: couldn't obtain "
-		    + "this site's cert alias.");
-	    }
-	    throw new SAMLResponderException(
-		SAMLUtils.bundle.getString("cannotFindCertAlias"));
-	}
-	XMLSignatureManager manager = XMLSignatureManager.getInstance();
+    if (certAlias == null) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response.signXML: couldn't obtain "
+            + "this site's cert alias.");
+        }
+        throw new SAMLResponderException(
+        SAMLUtils.bundle.getString("cannotFindCertAlias"));
+    }
+    XMLSignatureManager manager = XMLSignatureManager.getInstance();
         if ((majorVersion == 1) && (minorVersion == 0)) {
             SAMLUtils.debug.message("Request.signXML: sign with version 1.0");
             signatureString = manager.signXML(this.toString(true, true),
@@ -141,56 +142,56 @@ public class Response extends AbstractResponse {
                 RESPONSE_ID_ATTRIBUTE, getResponseID(), true, null);
             signatureString = XMLUtils.print(signature);
         }
-	signed = true;
-	xmlString = this.toString(true, true);
+    signed = true;
+    xmlString = this.toString(true, true);
     }
 
     private void buildResponse(String responseID,
-		    String inResponseTo,
-		    Status status,
-		    String recipient,
-		    List contents) throws SAMLException
+            String inResponseTo,
+            Status status,
+            String recipient,
+            List contents) throws SAMLException
     {
-	if ((responseID == null) || (responseID.length() == 0)) {
-	    // generate one
-	    this.responseID = SAMLUtils.generateID();
-	    if (this.responseID == null) {
-		throw new SAMLRequesterException(
-			SAMLUtils.bundle.getString("errorGenerateID"));
-	    }
-	} else {
-	    this.responseID = responseID;
-	}
+    if ((responseID == null) || (responseID.length() == 0)) {
+        // generate one
+        this.responseID = SAMLUtils.generateID();
+        if (this.responseID == null) {
+        throw new SAMLRequesterException(
+            SAMLUtils.bundle.getString("errorGenerateID"));
+        }
+    } else {
+        this.responseID = responseID;
+    }
 
-	this.inResponseTo = inResponseTo;
+    this.inResponseTo = inResponseTo;
 
-	this.recipient = recipient;
+    this.recipient = recipient;
 
-		issueInstant = newDate();
+        issueInstant = newDate();
 
-	if (status == null) {
-	    SAMLUtils.debug.message("Response: missing <Status>.");
-	    throw new SAMLRequesterException(
-			SAMLUtils.bundle.getString("missingElement"));
-	}
-	this.status = status;
+    if (status == null) {
+        SAMLUtils.debug.message("Response: missing <Status>.");
+        throw new SAMLRequesterException(
+            SAMLUtils.bundle.getString("missingElement"));
+    }
+    this.status = status;
 
-	if ((contents != null) &&
-	    (contents != Collections.EMPTY_LIST)) {
-	    int length = contents.size();
-	    for (int i = 0; i < length; i++) {
-		Object temp = contents.get(i);
-		if (!(temp instanceof Assertion)) {
-		    if (SAMLUtils.debug.messageEnabled()) {
-			SAMLUtils.debug.message("Response: Wrong input "
-				+ "for Assertion.");
-		    }
-		    throw new SAMLRequesterException(
-				SAMLUtils.bundle.getString("wrongInput"));
-		}
-	    }
-	    assertions = contents;
-	}
+    if ((contents != null) &&
+        (contents != Collections.EMPTY_LIST)) {
+        int length = contents.size();
+        for (int i = 0; i < length; i++) {
+        Object temp = contents.get(i);
+        if (!(temp instanceof Assertion)) {
+            if (SAMLUtils.debug.messageEnabled()) {
+            SAMLUtils.debug.message("Response: Wrong input "
+                + "for Assertion.");
+            }
+            throw new SAMLRequesterException(
+                SAMLUtils.bundle.getString("wrongInput"));
+        }
+        }
+        assertions = contents;
+    }
     }
 
     /**
@@ -209,11 +210,11 @@ public class Response extends AbstractResponse {
      * @throws SAMLException if error occurs.
      */
     public Response(String responseID,
-		    String inResponseTo,
-		    Status status,
-		    List contents) throws SAMLException
+            String inResponseTo,
+            Status status,
+            List contents) throws SAMLException
     {
-	buildResponse(responseID, inResponseTo, status, null, contents);
+    buildResponse(responseID, inResponseTo, status, null, contents);
     }
 
     /**
@@ -234,12 +235,12 @@ public class Response extends AbstractResponse {
      * @throws SAMLException if error occurs.
      */
     public Response(String responseID,
-		    String inResponseTo,
-		    Status status,
-		    String recipient,
-		    List contents) throws SAMLException
+            String inResponseTo,
+            Status status,
+            String recipient,
+            List contents) throws SAMLException
     {
-	buildResponse(responseID, inResponseTo, status, recipient, contents);
+    buildResponse(responseID, inResponseTo, status, recipient, contents);
     }
 
     /**
@@ -258,11 +259,11 @@ public class Response extends AbstractResponse {
      * @throws SAMLException if error occurs.
      */
     public Response(String responseID,
-		    Status status,
-		    String recipient,
-		    List contents) throws SAMLException
+            Status status,
+            String recipient,
+            List contents) throws SAMLException
     {
-	buildResponse(responseID, null, status, recipient, contents);
+    buildResponse(responseID, null, status, recipient, contents);
     }
 
     /**
@@ -279,10 +280,10 @@ public class Response extends AbstractResponse {
      * @throws SAMLException if error occurs.
      */
     public Response(String responseID,
-		    Status status,
-		    List contents) throws SAMLException
+            Status status,
+            List contents) throws SAMLException
     {
-	buildResponse(responseID, null, status, null, contents);
+    buildResponse(responseID, null, status, null, contents);
     }
 
     /**
@@ -297,11 +298,11 @@ public class Response extends AbstractResponse {
      * @exception SAMLException if XML parsing failed
      */
     public static Response parseXML(String xml) throws SAMLException {
-	// parse the xml string
-	Document doc = XMLUtils.toDOMDocument(xml, SAMLUtils.debug);
-	Element root = doc.getDocumentElement();
+    // parse the xml string
+    Document doc = XMLUtils.toDOMDocument(xml, SAMLUtils.debug);
+    Element root = doc.getDocumentElement();
 
-	return new Response(root);
+    return new Response(root);
     }
 
     /**
@@ -310,17 +311,17 @@ public class Response extends AbstractResponse {
      * document is describe above.
      *
      * @param is The Response XML <code>InputStream</code>.
-     *         NOTE: The <code>InputStream</code> contains a complete 
+     *         NOTE: The <code>InputStream</code> contains a complete
      *         SAML response with
      *         <code>ResponseID</code>, <code>MajorVersion</code>, etc.
      * @return Response object based on the XML document received from server.
      * @exception SAMLException if XML parsing failed
      */
     public static Response parseXML(InputStream is) throws SAMLException {
-	Document doc = XMLUtils.toDOMDocument(is, SAMLUtils.debug);
-	Element root = doc.getDocumentElement();
+    Document doc = XMLUtils.toDOMDocument(is, SAMLUtils.debug);
+    Element root = doc.getDocumentElement();
 
-	return new Response(root);
+    return new Response(root);
     }
 
     /**
@@ -330,101 +331,101 @@ public class Response extends AbstractResponse {
      * @throws SAMLException if error occurs.
      */
     public Response(Element root) throws SAMLException {
-	// Make sure this is a Response
-	if (root == null) {
-	    SAMLUtils.debug.message("Response(Element): null input.");
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("nullInput"));
-	}
-	String tag = null;
-	if (((tag = root.getLocalName()) == null) ||
-	    (!tag.equals("Response"))) {
-	    SAMLUtils.debug.message("Response(Element): wrong input.");
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("wrongInput"));
-	}
+    // Make sure this is a Response
+    if (root == null) {
+        SAMLUtils.debug.message("Response(Element): null input.");
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("nullInput"));
+    }
+    String tag = null;
+    if (((tag = root.getLocalName()) == null) ||
+        (!tag.equals("Response"))) {
+        SAMLUtils.debug.message("Response(Element): wrong input.");
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("wrongInput"));
+    }
 
-	List signs = XMLUtils.getElementsByTagNameNS1(root,
-					SAMLConstants.XMLSIG_NAMESPACE_URI,
-					SAMLConstants.XMLSIG_ELEMENT_NAME);
-	int signsSize = signs.size();
-	if (signsSize == 1) {
-	    xmlString = XMLUtils.print(root);
-	    signed = true;
-	} else if (signsSize != 0) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response(Element): included more than"
-		    + " one Signature element.");
-	    }
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("moreElement"));
-	}
+    List signs = XMLUtils.getElementsByTagNameNS1(root,
+                    SAMLConstants.XMLSIG_NAMESPACE_URI,
+                    SAMLConstants.XMLSIG_ELEMENT_NAME);
+    int signsSize = signs.size();
+    if (signsSize == 1) {
+        xmlString = XMLUtils.print(root);
+        signed = true;
+    } else if (signsSize != 0) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response(Element): included more than"
+            + " one Signature element.");
+        }
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("moreElement"));
+    }
 
-	// Attribute ResponseID
-	responseID = root.getAttribute("ResponseID");
-	if ((responseID == null) || (responseID.length() == 0)) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response.parseXML: "
-				+ "Reponse doesn't have ResponseID.");
-	    }
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("missingAttribute"));
-	}
+    // Attribute ResponseID
+    responseID = root.getAttribute("ResponseID");
+    if ((responseID == null) || (responseID.length() == 0)) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response.parseXML: "
+                + "Reponse doesn't have ResponseID.");
+        }
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("missingAttribute"));
+    }
 
-	// Attribute InResponseTo
-	if (root.hasAttribute("InResponseTo")) {
-	    inResponseTo = root.getAttribute("InResponseTo");
-	}
+    // Attribute InResponseTo
+    if (root.hasAttribute("InResponseTo")) {
+        inResponseTo = root.getAttribute("InResponseTo");
+    }
 
-	// Attribute MajorVersion
-	parseMajorVersion(root.getAttribute("MajorVersion"));
+    // Attribute MajorVersion
+    parseMajorVersion(root.getAttribute("MajorVersion"));
 
-	parseMinorVersion(root.getAttribute("MinorVersion"));
+    parseMinorVersion(root.getAttribute("MinorVersion"));
 
-	if (root.hasAttribute("Recipient")) {
-	    recipient = root.getAttribute("Recipient");
-	}
+    if (root.hasAttribute("Recipient")) {
+        recipient = root.getAttribute("Recipient");
+    }
 
-	// Attribute IssueInstant
-	String instantString = root.getAttribute("IssueInstant");
-	if ((instantString == null) || (instantString.length() == 0)) {
-	    SAMLUtils.debug.message("Response(Element): missing IssueInstant");
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("missingAttribute"));
-	} else {
-	    try {
-		issueInstant = DateUtils.stringToDate(instantString);
-	    } catch (ParseException e) {
-		SAMLUtils.debug.message(
-		    "Resposne(Element): could not parse IssueInstant", e);
-		throw new SAMLRequesterException(SAMLUtils.bundle.getString(
-			"wrongInput"));
-	    }
-	}
+    // Attribute IssueInstant
+    String instantString = root.getAttribute("IssueInstant");
+    if ((instantString == null) || (instantString.length() == 0)) {
+        SAMLUtils.debug.message("Response(Element): missing IssueInstant");
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("missingAttribute"));
+    } else {
+        try {
+        issueInstant = DateUtils.stringToDate(instantString);
+        } catch (ParseException e) {
+        SAMLUtils.debug.message(
+            "Resposne(Element): could not parse IssueInstant", e);
+        throw new SAMLRequesterException(SAMLUtils.bundle.getString(
+            "wrongInput"));
+        }
+    }
 
-	NodeList nl = root.getChildNodes();
-	Node child;
-	String childName;
-	int length = nl.getLength();
-	for (int i = 0; i < length; i++) {
-	    child = nl.item(i);
-	    if ((childName = child.getLocalName()) != null) {
-		if (childName.equals("Signature")) {
-		    signature = (Element) child;
-		} else if (childName.equals("Status")) {
-		    if (status != null) {
-			if (SAMLUtils.debug.messageEnabled()) {
-			    SAMLUtils.debug.message("Response: included more"
-				+ " than one <Status>");
-			}
-			throw new SAMLRequesterException(
-			    SAMLUtils.bundle.getString("moreElement"));
-		    }
-		    status = new Status((Element) child);
-		} else if (childName.equals("Assertion")) {
+    NodeList nl = root.getChildNodes();
+    Node child;
+    String childName;
+    int length = nl.getLength();
+    for (int i = 0; i < length; i++) {
+        child = nl.item(i);
+        if ((childName = child.getLocalName()) != null) {
+        if (childName.equals("Signature")) {
+            signature = (Element) child;
+        } else if (childName.equals("Status")) {
+            if (status != null) {
+            if (SAMLUtils.debug.messageEnabled()) {
+                SAMLUtils.debug.message("Response: included more"
+                + " than one <Status>");
+            }
+            throw new SAMLRequesterException(
+                SAMLUtils.bundle.getString("moreElement"));
+            }
+            status = new Status((Element) child);
+        } else if (childName.equals("Assertion")) {
                     if (assertions == Collections.EMPTY_LIST) {
-		        assertions = new ArrayList();
-		    }
+                assertions = new ArrayList();
+            }
                     Element canoEle = SAMLUtils.getCanonicalElement(child);
                     if (canoEle == null) {
                         throw new SAMLRequesterException(
@@ -432,24 +433,24 @@ public class Response extends AbstractResponse {
                     }
 
                     Assertion oneAssertion= new Assertion(canoEle);
-		    issuer = oneAssertion.getIssuer(); 
-		    assertions.add(oneAssertion);
-		} else {
-		    if (SAMLUtils.debug.messageEnabled()) {
-			SAMLUtils.debug.message("Response: included wrong "
-			    + "element:" + childName);
-		    }
-		    throw new SAMLRequesterException(
-			SAMLUtils.bundle.getString("wrongInput"));
-		}
-	    } // end if childName != null
-	} // end for loop
+            issuer = oneAssertion.getIssuer();
+            assertions.add(oneAssertion);
+        } else {
+            if (SAMLUtils.debug.messageEnabled()) {
+            SAMLUtils.debug.message("Response: included wrong "
+                + "element:" + childName);
+            }
+            throw new SAMLRequesterException(
+            SAMLUtils.bundle.getString("wrongInput"));
+        }
+        } // end if childName != null
+    } // end for loop
 
-	if (status == null) {
-	    SAMLUtils.debug.message("Response: missing element <Status>.");
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("oneElement"));
-	}
+    if (status == null) {
+        SAMLUtils.debug.message("Response: missing element <Status>.");
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("oneElement"));
+    }
     }
 
     /**
@@ -458,34 +459,34 @@ public class Response extends AbstractResponse {
      * @exception SAMLException when the version mismatchs.
      */
     private void parseMajorVersion(String majorVer) throws SAMLException {
-	try {
-	    majorVersion = Integer.parseInt(majorVer);
-	} catch (NumberFormatException e) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response(Element): invalid "
-		    + "MajorVersion", e);
-	    }
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("wrongInput"));
-	}
+    try {
+        majorVersion = Integer.parseInt(majorVer);
+    } catch (NumberFormatException e) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response(Element): invalid "
+            + "MajorVersion", e);
+        }
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("wrongInput"));
+    }
 
-	if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
-	    if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
-		if (SAMLUtils.debug.messageEnabled()) {
-		    SAMLUtils.debug.message("Response(Element):MajorVersion of"
-			+ " the Response is too high.");
-		}
-		throw new SAMLVersionMismatchException(
-		    SAMLUtils.bundle.getString("responseVersionTooHigh"));
-	    } else {
-		if (SAMLUtils.debug.messageEnabled()) {
-		    SAMLUtils.debug.message("Response(Element):MajorVersion of"
-			+ " the Response is too low.");
-		}
-		throw new SAMLVersionMismatchException(
-		    SAMLUtils.bundle.getString("responseVersionTooLow"));
-	    }
-	}
+    if (majorVersion != SAMLConstants.PROTOCOL_MAJOR_VERSION) {
+        if (majorVersion > SAMLConstants.PROTOCOL_MAJOR_VERSION) {
+        if (SAMLUtils.debug.messageEnabled()) {
+            SAMLUtils.debug.message("Response(Element):MajorVersion of"
+            + " the Response is too high.");
+        }
+        throw new SAMLVersionMismatchException(
+            SAMLUtils.bundle.getString("responseVersionTooHigh"));
+        } else {
+        if (SAMLUtils.debug.messageEnabled()) {
+            SAMLUtils.debug.message("Response(Element):MajorVersion of"
+            + " the Response is too low.");
+        }
+        throw new SAMLVersionMismatchException(
+            SAMLUtils.bundle.getString("responseVersionTooLow"));
+        }
+    }
     }
 
     /**
@@ -494,35 +495,35 @@ public class Response extends AbstractResponse {
      * @exception SAMLException when the version mismatchs.
      */
     private void parseMinorVersion(String minorVer) throws SAMLException {
-	try {
-	    minorVersion = Integer.parseInt(minorVer);
-	} catch (NumberFormatException e) {
-	    if (SAMLUtils.debug.messageEnabled()) {
-		SAMLUtils.debug.message("Response(Element): invalid "
-		    + "MinorVersion", e);
-	    }
-	    throw new SAMLRequesterException(
-		SAMLUtils.bundle.getString("wrongInput"));
-	}
+    try {
+        minorVersion = Integer.parseInt(minorVer);
+    } catch (NumberFormatException e) {
+        if (SAMLUtils.debug.messageEnabled()) {
+        SAMLUtils.debug.message("Response(Element): invalid "
+            + "MinorVersion", e);
+        }
+        throw new SAMLRequesterException(
+        SAMLUtils.bundle.getString("wrongInput"));
+    }
 
-	if (minorVersion > SAMLConstants.PROTOCOL_MINOR_VERSION_ONE) {
+    if (minorVersion > SAMLConstants.PROTOCOL_MINOR_VERSION_ONE) {
             if (SAMLUtils.debug.messageEnabled()) {
-	        SAMLUtils.debug.message("Response(Element): MinorVersion"
-				+ " of the Response is too high.");
+            SAMLUtils.debug.message("Response(Element): MinorVersion"
+                + " of the Response is too high.");
             }
             throw new SAMLRequestVersionTooHighException(
-			 SAMLUtils.bundle.getString("responseVersionTooHigh"));    
-        } else if (minorVersion < SAMLConstants.PROTOCOL_MINOR_VERSION_ZERO) { 
+             SAMLUtils.bundle.getString("responseVersionTooHigh"));
+        } else if (minorVersion < SAMLConstants.PROTOCOL_MINOR_VERSION_ZERO) {
             if (SAMLUtils.debug.messageEnabled()) {
-	        SAMLUtils.debug.message("Response(Element): MinorVersion"
-				+ " of the Response is too low.");
+            SAMLUtils.debug.message("Response(Element): MinorVersion"
+                + " of the Response is too low.");
             }
-            throw new SAMLRequestVersionTooLowException( 
-			 SAMLUtils.bundle.getString("responseVersionTooLow"));
+            throw new SAMLRequestVersionTooLowException(
+             SAMLUtils.bundle.getString("responseVersionTooLow"));
         }
     }
 
-    /** 
+    /**
      * This method returns the set of Assertions that is the content of
      * the response.
      * @return The set of Assertions that is the content of the response.
@@ -530,7 +531,7 @@ public class Response extends AbstractResponse {
      *		in the response.
      */
     public List getAssertion() {
-	return assertions;
+    return assertions;
     }
 
     /**
@@ -540,17 +541,17 @@ public class Response extends AbstractResponse {
      *		false otherwise.
      */
     public boolean addAssertion(Assertion assertion) {
-	if (signed) {
-	    return false;
-	}
-	if (assertion == null) {
-	    return false;
-	}
-	if ((assertions == null) || (assertions == Collections.EMPTY_LIST)) {
-	    assertions = new ArrayList();
-	}
-	assertions.add(assertion);
-	return true;
+    if (signed) {
+        return false;
+    }
+    if (assertion == null) {
+        return false;
+    }
+    if ((assertions == null) || (assertions == Collections.EMPTY_LIST)) {
+        assertions = new ArrayList();
+    }
+    assertions.add(assertion);
+    return true;
     }
 
     /**
@@ -558,7 +559,7 @@ public class Response extends AbstractResponse {
      * @return The Status of the response.
      */
     public Status getStatus() {
-	return status;
+    return status;
     }
 
     /**
@@ -568,14 +569,14 @@ public class Response extends AbstractResponse {
      * @return true if the operation is successful.
      */
     public boolean setStatus(Status status) {
-	if (signed) {
-	    return false;
-	}
-	if (status == null) {
-	    return false;
-	}
-	this.status = status;
-	return true;
+    if (signed) {
+        return false;
+    }
+    if (status == null) {
+        return false;
+    }
+    this.status = status;
+    return true;
     }
 
     /**
@@ -584,10 +585,10 @@ public class Response extends AbstractResponse {
      * @return A boolean value: true if the operation succeeds; false otherwise.
      */
     public boolean setSignature(Element elem) {
-        signatureString = XMLUtils.print(elem); 
-        return super.setSignature(elem); 
+        signatureString = XMLUtils.print(elem);
+        return super.setSignature(elem);
     }
-    
+
     /**
      * This method translates the response to an XML document String based on
      * the Response schema described above.
@@ -596,7 +597,7 @@ public class Response extends AbstractResponse {
      *		<code>MajorVersion</code>, etc.
      */
     public String toString() {
-	return this.toString(true, true);
+    return this.toString(true, true);
     }
 
     /**
@@ -608,9 +609,9 @@ public class Response extends AbstractResponse {
      * @param declareNS Determines whether or not the namespace is declared
      *        within the Element.
      * @return A string containing the valid XML for this element
-     */   
+     */
     public String toString(boolean includeNS, boolean declareNS) {
-	return toString(includeNS, declareNS, false);
+    return toString(includeNS, declareNS, false);
     }
 
     /**
@@ -624,62 +625,62 @@ public class Response extends AbstractResponse {
      * @param includeHeader Determines whether the output include the XML
      *	      declaration header.
      * @return A string containing the valid XML for this element
-     */   
+     */
     public String toString(boolean includeNS,
-			boolean declareNS,
-			boolean includeHeader) {
-	if (signed && (xmlString != null)) {
-	    return xmlString;
-	}
+            boolean declareNS,
+            boolean includeHeader) {
+    if (signed && (xmlString != null)) {
+        return xmlString;
+    }
 
-	StringBuffer xml = new StringBuffer(300);
-	if (includeHeader) {
-	    xml.append("<?xml version=\"1.0\" encoding=\"").
-		append(SAMLConstants.DEFAULT_ENCODING).append("\" ?>\n");
-	}
-	String prefix = "";
-	String uri = "";
-	if (includeNS) {
-	    prefix = SAMLConstants.PROTOCOL_PREFIX;
-	}
+    StringBuffer xml = new StringBuffer(300);
+    if (includeHeader) {
+        xml.append("<?xml version=\"1.0\" encoding=\"").
+        append(SAMLConstants.DEFAULT_ENCODING).append("\" ?>\n");
+    }
+    String prefix = "";
+    String uri = "";
+    if (includeNS) {
+        prefix = SAMLConstants.PROTOCOL_PREFIX;
+    }
 
-	if (declareNS) {
-	    uri = SAMLConstants.PROTOCOL_NAMESPACE_STRING;
-	}
+    if (declareNS) {
+        uri = SAMLConstants.PROTOCOL_NAMESPACE_STRING;
+    }
 
-	String instantString = DateUtils.toUTCDateFormat(issueInstant);
+    String instantString = DateUtils.toUTCDateFormat(issueInstant);
 
-	xml.append("<").append(prefix).append("Response").append(uri).
-	    append(" ResponseID=\"").append(responseID).append("\"");
-	if (inResponseTo != null) {
-	    xml.append(" InResponseTo=\"").append(inResponseTo).append("\"");
-	}
-	xml.append(" MajorVersion=\"").append(majorVersion).append("\"").
-	    append(" MinorVersion=\"").append(minorVersion).append("\"").
-	    append(" IssueInstant=\"").append(instantString).append("\"");
-	if (recipient != null) {
-	    xml.append(" Recipient=\"").append(XMLUtils.escapeSpecialCharacters(recipient)).append("\"");
-	}
-	xml.append(">\n");
+    xml.append("<").append(prefix).append("Response").append(uri).
+        append(" ResponseID=\"").append(responseID).append("\"");
+    if (inResponseTo != null) {
+        xml.append(" InResponseTo=\"").append(XMLUtils.escapeSpecialCharacters(inResponseTo)).append("\"");
+    }
+    xml.append(" MajorVersion=\"").append(majorVersion).append("\"").
+        append(" MinorVersion=\"").append(minorVersion).append("\"").
+        append(" IssueInstant=\"").append(instantString).append("\"");
+    if (recipient != null) {
+        xml.append(" Recipient=\"").append(XMLUtils.escapeSpecialCharacters(recipient)).append("\"");
+    }
+    xml.append(">\n");
 
-	if (signed) {
-	    if (signatureString != null) {
-		xml.append(signatureString);
-	    } else if (signature != null) {
-		signatureString = XMLUtils.print(signature);
-		xml.append(signatureString);
-	    }
-	}
+    if (signed) {
+        if (signatureString != null) {
+        xml.append(signatureString);
+        } else if (signature != null) {
+        signatureString = XMLUtils.print(signature);
+        xml.append(signatureString);
+        }
+    }
 
-	xml.append(status.toString(includeNS, false));
-	if ((assertions != null) && (assertions != Collections.EMPTY_LIST)) {
-	    Iterator j = assertions.iterator();
-	    while (j.hasNext()) {
-		xml.append(((Assertion) j.next()).toString(true, true));
-	    }
-	}
+    xml.append(status.toString(includeNS, false));
+    if ((assertions != null) && (assertions != Collections.EMPTY_LIST)) {
+        Iterator j = assertions.iterator();
+        while (j.hasNext()) {
+        xml.append(((Assertion) j.next()).toString(true, true));
+        }
+    }
 
-	xml.append("</").append(prefix).append("Response>\n");
-	return xml.toString();
+    xml.append("</").append(prefix).append("Response>\n");
+    return xml.toString();
     }
 }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/impl/SubjectConfirmationDataImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/assertion/impl/SubjectConfirmationDataImpl.java
@@ -24,9 +24,8 @@
  *
  * $Id: SubjectConfirmationDataImpl.java,v 1.5 2008/11/10 22:57:01 veiming Exp $
  *
+ * Portions Copyrighted 2023 Wren Security
  */
-
-
 package com.sun.identity.saml2.assertion.impl;
 
 import java.util.ArrayList;
@@ -56,7 +55,7 @@ import com.sun.identity.saml2.common.SAML2SDKUtils;
  *  that allows the subject to be confirmed or constrains the circumstances
  *  under which the act of subject confirmation can take place. Subejct
  *  confirmation takes place when a relying party seeks to verify the
- *  relationship between an entity presenting the assertion and the 
+ *  relationship between an entity presenting the assertion and the
  *  subject of the assertion's claims.
  */
 public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
@@ -98,7 +97,7 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
             throw new SAML2Exception(
                       SAML2SDKUtils.bundle.getString("nullInput"));
         }
-        
+
         // Make sure this is an SubjectConfirmationData.
         String tag = element.getLocalName();
         if ((tag == null) || (!tag.equals(elementName))) {
@@ -115,13 +114,13 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
         parseAttributes(attrs);
         parseContent(element);
     }
-    
+
     /**
-     *  Parse and sets content values 
+     *  Parse and sets content values
      *
-     *  @param element Element for this class object 
+     *  @param element Element for this class object
      */
-    protected void parseContent(Element element) 
+    protected void parseContent(Element element)
     throws SAML2Exception
     {
         if (element == null) {
@@ -145,11 +144,11 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
     }
 
     /**
-     *  Sets all the attribute values 
+     *  Sets all the attribute values
      *
-     *  @param attrs Map table has attribute name and value pairs 
+     *  @param attrs Map table has attribute name and value pairs
      */
-    protected void parseAttributes(NamedNodeMap attrs) 
+    protected void parseAttributes(NamedNodeMap attrs)
     throws SAML2Exception
     {
         if (attrs == null) {
@@ -173,7 +172,7 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
                 } else if (attrName.equals("Recipient")) {
                     recipient = attrValue;
                 } else if (attrName.equals("xsi:type")) {
-                    contentType = attrValue;    
+                    contentType = attrValue;
                 } else {
                     continue;
                 }
@@ -187,7 +186,7 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
                       SAML2SDKUtils.bundle.getString("wrongInput"));
         }
     }
-    
+
     /**
      * Returns the time instant at which the subject can no longer be
      * confirmed
@@ -217,7 +216,7 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
         }
         notOnOrAfter = value;
     }
-    
+
 
     /**
      *  Returns the ID of a SAML protocol message in response to which
@@ -251,10 +250,10 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
     }
 
     /**
-     * Returns a list of arbitrary XML elements to be added to this 
+     * Returns a list of arbitrary XML elements to be added to this
      * <code>SubejctConfirmationData</code> object.
      *
-     * @return a list of arbitrary XML elements to be added to this 
+     * @return a list of arbitrary XML elements to be added to this
      * <code>SubejctConfirmationData</code> object.
      * @see #setContent(List)
      */
@@ -267,10 +266,10 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
     }
 
     /**
-     * Sets a list of arbitrary XML elements to be added to this 
+     * Sets a list of arbitrary XML elements to be added to this
      * <code>SubejctConfirmationData</code> object.
      *
-     * @param value a list of arbitrary XML elements to be added to this 
+     * @param value a list of arbitrary XML elements to be added to this
      * <code>SubejctConfirmationData</code> object.
      * @exception SAML2Exception if the object is immutable
      * @see #getContent()
@@ -287,10 +286,10 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
 
     /**
      *  Returns the URI specifying the entity or location to which an
-     *  attesting entity can present the assertion 
+     *  attesting entity can present the assertion
      *
      *  @return the URI specifying the entity or location to which an
-     *  attesting entity can present the assertion 
+     *  attesting entity can present the assertion
      *  @see #setRecipient(String)
      */
     public String getRecipient()
@@ -300,10 +299,10 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
 
     /**
      *  Sets the URI specifying the entity or location to which an
-     *  attesting entity can present the assertion 
+     *  attesting entity can present the assertion
      *
      *  @param value the URI specifying the entity or location to which an
-     *  attesting entity can present the assertion 
+     *  attesting entity can present the assertion
      *  @exception SAML2Exception if the object is immutable
      *  @see #getRecipient
      */
@@ -346,11 +345,11 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
     }
 
     /**
-     *  Returns the network address/location from which an attesting 
-     *  entity can present the assertion 
+     *  Returns the network address/location from which an attesting
+     *  entity can present the assertion
      *
-     *  @return the network address/location from which an attesting 
-     *  entity can present the assertion 
+     *  @return the network address/location from which an attesting
+     *  entity can present the assertion
      *  @see #setAddress(String)
      */
     public String getAddress()
@@ -359,11 +358,11 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
     }
 
     /**
-     *  Sets the network address/location from which an attesting 
-     *  entity can present the assertion 
+     *  Sets the network address/location from which an attesting
+     *  entity can present the assertion
      *
-     *  @param value the network address/location from which an attesting 
-     *  entity can present the assertion 
+     *  @param value the network address/location from which an attesting
+     *  entity can present the assertion
      *  @exception SAML2Exception if the object is immutable
      *  @see #getAddress
      */
@@ -376,22 +375,22 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
 
         address = value;
     }
-    
+
     /**
-     *  Returns the content type attribute     
+     *  Returns the content type attribute
      *
-     *  @return the content type attribute     
+     *  @return the content type attribute
      *  @see #setContentType(String)
      */
     public String getContentType()
     {
         return contentType;
     }
-    
+
     /**
      *  Sets the content type attribute.
      *
-     *  @param attribute attribute type value for the content that will be 
+     *  @param attribute attribute type value for the content that will be
      *         added
      *  @throws SAML2Exception if the object is immutable
      */
@@ -430,7 +429,7 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
 
         String NS="";
         String appendNS="";
-            
+
         if (declareNS) {
             NS = SAML2Constants.ASSERTION_DECLARE_STR;
         }
@@ -443,9 +442,9 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
         xml.append(getElementValue(includeNSPrefix, declareNS));
         xml.append("</").append(appendNS).append(elementName).append(">");
 
-        return xml.toString();    
+        return xml.toString();
      }
-    
+
     /**
      * Returns a String representation of the element value
      * @param includeNSPrefix Determines whether the namespace qualifier is
@@ -462,56 +461,56 @@ public class SubjectConfirmationDataImpl implements SubjectConfirmationData {
 
         if (notOnOrAfter != null) {
             xml.append("NotOnOrAfter=\"");
-            xml.append(DateUtils.toUTCDateFormat(notOnOrAfter));        
-            xml.append("\" ");        
+            xml.append(DateUtils.toUTCDateFormat(notOnOrAfter));
+            xml.append("\" ");
         }
-        
+
         if (inResponseTo != null) {
             xml.append("InResponseTo=\"");
-            xml.append(inResponseTo);        
-            xml.append("\" ");        
+            xml.append(XMLUtils.escapeSpecialCharacters(inResponseTo));
+            xml.append("\" ");
         }
-        
+
         if (recipient != null) {
             xml.append("Recipient=\"");
-            xml.append(recipient);        
-            xml.append("\" ");        
+            xml.append(recipient);
+            xml.append("\" ");
         }
-        
+
         if (notBefore != null) {
             xml.append("NotBefore=\"");
-            xml.append(DateUtils.toUTCDateFormat(notBefore));        
-            xml.append("\" ");        
+            xml.append(DateUtils.toUTCDateFormat(notBefore));
+            xml.append("\" ");
         }
-        
+
         if (address != null) {
             xml.append("Address=\"");
-            xml.append(address);        
-            xml.append("\" ");        
+            xml.append(address);
+            xml.append("\" ");
         }
-        
+
         if(contentType != null) {
             xml.append(SAML2Constants.XSI_DECLARE_STR).append(" ")
                .append("xsi:type=\"")
                .append(contentType)
                .append("\" ");
         }
-        
+
         xml.append(">");
-        
+
         if (!getContent().isEmpty()) {
             Iterator it = getContent().iterator();
             while (it.hasNext()){
                 Object obj = it.next();
                 if(obj instanceof Element) {
-                   xml.append(XMLUtils.print((Element)obj)).append(" ");                   
+                   xml.append(XMLUtils.print((Element)obj)).append(" ");
                 } else if(obj instanceof String) {
                     xml.append((String)obj);
                 }
             }
         }
-                
-        return xml.toString();    
+
+        return xml.toString();
      }
 
    /**

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/ArtifactResponseImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/ArtifactResponseImpl.java
@@ -24,10 +24,8 @@
  *
  * $Id: ArtifactResponseImpl.java,v 1.2 2008/06/25 05:47:59 qcheng Exp $
  *
+ * Portions Copyrighted 2023 Wren Security
  */
-
-
-
 package com.sun.identity.saml2.protocol.impl;
 
 import java.security.PublicKey;
@@ -71,9 +69,9 @@ import com.sun.identity.saml2.protocol.ArtifactResponse;
  * </pre>
  */
 public class ArtifactResponseImpl extends StatusResponseImpl
-	implements ArtifactResponse {
+    implements ArtifactResponse {
     private String anyString = null;
-    
+
     private void parseElement(Element element)
         throws SAML2Exception {
         // make sure that the input xml block is not null
@@ -137,8 +135,8 @@ public class ArtifactResponseImpl extends StatusResponseImpl
                     if (issuer != null) {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement: included more than one "
-				+ "Issuer.");
+                + "parseElement: included more than one "
+                + "Issuer.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("moreElement"));
@@ -146,11 +144,11 @@ public class ArtifactResponseImpl extends StatusResponseImpl
                     if (signatureString != null ||
                         extensions != null ||
                         status != null ||
-			anyString != null)
+            anyString != null)
                     {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement:wrong sequence.");
+                + "parseElement:wrong sequence.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("schemaViolation"));
@@ -161,18 +159,18 @@ public class ArtifactResponseImpl extends StatusResponseImpl
                     if (signatureString != null) {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement:included more than one "
-				+ "Signature.");
+                + "parseElement:included more than one "
+                + "Signature.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
                     if (extensions != null || status != null ||
-			anyString != null)
-		    {
+            anyString != null)
+            {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement:wrong sequence.");
+                + "parseElement:wrong sequence.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("schemaViolation"));
@@ -183,17 +181,17 @@ public class ArtifactResponseImpl extends StatusResponseImpl
                     if (extensions != null) {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement:included more than one "
-				+ "Extensions.");
+                + "parseElement:included more than one "
+                + "Extensions.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
                     if (status != null || anyString != null)
-		    {
+            {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement:wrong sequence.");
+                + "parseElement:wrong sequence.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("schemaViolation"));
@@ -204,40 +202,40 @@ public class ArtifactResponseImpl extends StatusResponseImpl
                     if (status != null) {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement: included more than one "
-				+ "Status.");
+                + "parseElement: included more than one "
+                + "Status.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
-		    if (anyString != null) {
-			 if (SAML2SDKUtils.debug.messageEnabled()) {
+            if (anyString != null) {
+             if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ResponseImpl.parse"
                                 + "Element:wrong sequence.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("schemaViolation"));
-		    }
+            }
                     status = ProtocolFactory.getInstance().createStatus(
                         (Element) child);
                 } else {
-		    if (anyString != null) {
+            if (anyString != null) {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ArtifactResponseImpl."
-				+ "parseElement: included more than one "
-				+ "any element.");
+                + "parseElement: included more than one "
+                + "any element.");
                         }
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("moreElement"));
-	
-		    }
-		    anyString = XMLUtils.print((Element) child);
+
+            }
+            anyString = XMLUtils.print((Element) child);
                 }
             }
         }
 
         super.validateData();
-	isMutable = false;
+    isMutable = false;
     }
 
     /**
@@ -264,7 +262,7 @@ public class ArtifactResponseImpl extends StatusResponseImpl
     }
 
     /**
-     * Constructor with <code>ArtifactResponse</code> in xml string 
+     * Constructor with <code>ArtifactResponse</code> in xml string
      * format.
      */
     public ArtifactResponseImpl(String xmlString)
@@ -287,7 +285,7 @@ public class ArtifactResponseImpl extends StatusResponseImpl
      * @see #setAny(String)
      */
     public String getAny() {
-	return anyString;
+    return anyString;
     }
 
     /**
@@ -299,12 +297,12 @@ public class ArtifactResponseImpl extends StatusResponseImpl
      */
     public void setAny(String value)
         throws SAML2Exception {
-	if (isMutable) {
-	    anyString = value;
-	} else {
-	    throw new SAML2Exception(
-		SAML2SDKUtils.bundle.getString("objectImmutable"));
-	}
+    if (isMutable) {
+        anyString = value;
+    } else {
+        throw new SAML2Exception(
+        SAML2SDKUtils.bundle.getString("objectImmutable"));
+    }
     }
 
     /**
@@ -314,7 +312,7 @@ public class ArtifactResponseImpl extends StatusResponseImpl
      * @throws SAML2Exception if it could not create String object
      */
     public String toXMLString() throws SAML2Exception {
-	return this.toXMLString(true, false);
+    return this.toXMLString(true, false);
     }
 
     /**
@@ -327,12 +325,11 @@ public class ArtifactResponseImpl extends StatusResponseImpl
      * @throws SAML2Exception if it could not create String object.
      * @return a String representation of this Object.
      **/
-    public String toXMLString(boolean includeNSPrefix, boolean declareNS)
-	throws SAML2Exception {
-	if (isSigned && signedXMLString != null) {
-	    return signedXMLString;
-	}
-	this.validateData();
+    public String toXMLString(boolean includeNSPrefix, boolean declareNS) throws SAML2Exception {
+        if (isSigned && signedXMLString != null) {
+            return signedXMLString;
+        }
+        this.validateData();
         StringBuffer result = new StringBuffer(1000);
         String prefix = "";
         String uri = "";
@@ -345,10 +342,12 @@ public class ArtifactResponseImpl extends StatusResponseImpl
 
         result.append("<").append(prefix).append("ArtifactResponse").
                 append(uri).append(" ID=\"").append(responseId).append("\"");
-	if (inResponseTo != null && inResponseTo.trim().length() != 0) {
-	    result.append(" InResponseTo=\"").append(inResponseTo).append("\"");
-	}
-	
+        if (inResponseTo != null && inResponseTo.trim().length() != 0) {
+            result.append(" InResponseTo=\"")
+                    .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
+                    .append("\"");
+        }
+
         result.append(" Version=\"").append(version).append("\"").
                 append(" IssueInstant=\"").
                 append(DateUtils.toUTCDateFormat(issueInstant)).append("\"");
@@ -369,10 +368,10 @@ public class ArtifactResponseImpl extends StatusResponseImpl
         if (extensions != null) {
             result.append(extensions.toXMLString(includeNSPrefix, declareNS));
         }
-	result.append(status.toXMLString(includeNSPrefix, declareNS));
-	if (anyString != null && anyString.trim().length() != 0) {
-	    result.append(anyString);
-	}
+        result.append(status.toXMLString(includeNSPrefix, declareNS));
+        if (anyString != null && anyString.trim().length() != 0) {
+            result.append(anyString);
+        }
         result.append("</").append(prefix).append("ArtifactResponse>");
         return result.toString();
     }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/NameIDMappingResponseImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/NameIDMappingResponseImpl.java
@@ -24,8 +24,8 @@
  *
  * $Id: NameIDMappingResponseImpl.java,v 1.2 2008/06/25 05:48:00 qcheng Exp $
  *
+ * Portions Copyrighted 2023 Wren Security
  */
-
 package com.sun.identity.saml2.protocol.impl;
 
 import org.w3c.dom.Document;
@@ -54,14 +54,14 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
     EncryptedID encryptedID = null;
 
     /**
-     * Constructor to create <code>ManageNameIDResponse</code> Object. 
+     * Constructor to create <code>ManageNameIDResponse</code> Object.
      */
     public NameIDMappingResponseImpl() {
         isMutable = true;
     }
 
     /**
-     * Constructor to create <code>ManageNameIDResponse</code> Object. 
+     * Constructor to create <code>ManageNameIDResponse</code> Object.
      *
      * @param element Document Element of <code>ManageNameIDRequest<code>
      *     object.
@@ -77,7 +77,7 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
     }
 
     /**
-     * Constructor to create <code>ManageNameIDResponse</code> Object. 
+     * Constructor to create <code>ManageNameIDResponse</code> Object.
      *
      * @param xmlString XML representation of the
      *     <code>ManageNameIDRequest<code> object.
@@ -99,7 +99,7 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
     private void parseElement(Element element) throws SAML2Exception {
         AssertionFactory af = AssertionFactory.getInstance();
         ProtocolFactory pf = ProtocolFactory.getInstance();
-        
+
         // make sure that the input xml block is not null
         if (element == null) {
             if (SAML2SDKUtils.debug.messageEnabled()) {
@@ -124,13 +124,13 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
 
         responseId = element.getAttribute("ID");
         validateID(responseId);
-            
+
         version = element.getAttribute("Version");
         validateVersion(version);
 
         String issueInstantStr = element.getAttribute("IssueInstant");
         validateIssueInstant(issueInstantStr);
-            
+
         destination = element.getAttribute("Destination");
         consent = element.getAttribute("Consent");
         inResponseTo = element.getAttribute("InResponseTo");
@@ -147,7 +147,7 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
                     } else if (cName.equals("Signature")) {
                         signatureString =
                             XMLUtils.getElementString((Element)childNode);
-                        isSigned = true; 
+                        isSigned = true;
                     } else if (cName.equals("Extensions")) {
                         extensions = pf.createExtensions((Element)childNode);
                     } else if (cName.equals("NameID")) {
@@ -156,7 +156,7 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
                         encryptedID = af.createEncryptedID((Element)childNode);
                     } else if (cName.equals("Status")) {
                         status = pf.createStatus((Element)childNode);
-                    } 
+                    }
                 }
             }
         }
@@ -173,7 +173,7 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
     public String toXMLString() throws SAML2Exception {
         return toXMLString(true, false);
     }
-    
+
     /**
      * Returns the <code>ManageNameIDResponse</code> in an XML document String
      * format based on the <code>ManageNameIDResponse</code> schema described
@@ -199,20 +199,22 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
         String NS="";
         String NSP="";
         String uri="";
-            
+
         if (declareNS) {
             NS = SAML2Constants.PROTOCOL_DECLARE_STR;
             uri=NS;
         }
-            
+
         if (includeNSPrefix) {
             NSP = SAML2Constants.PROTOCOL_PREFIX;
         }
-        
+
         result.append("<").append(NSP).append("NameIDMappingResponse")
               .append(uri).append(" ID=\"").append(responseId).append("\"");
         if (inResponseTo != null && inResponseTo.trim().length() != 0) {
-            result.append(" InResponseTo=\"").append(inResponseTo).append("\"");
+            result.append(" InResponseTo=\"")
+                    .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
+                    .append("\"");
         }
 
         result.append(" Version=\"").append(version).append("\"")
@@ -241,12 +243,12 @@ public class NameIDMappingResponseImpl extends StatusResponseImpl
         if (encryptedID != null) {
             result.append(encryptedID.toXMLString(includeNSPrefix,declareNS));
         }
-        
+
         result.append(status.toXMLString(includeNSPrefix, declareNS));
 
         result.append("</").append(NSP).append(elementName).append(">");
-        
-        return result.toString();    
+
+        return result.toString();
     }
 
     /**

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/ResponseImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/ResponseImpl.java
@@ -24,10 +24,8 @@
  *
  * $Id: ResponseImpl.java,v 1.4 2009/12/16 05:26:39 ericow Exp $
  *
+ * Portions Copyrighted 2023 Wren Security
  */
-
-
-
 package com.sun.identity.saml2.protocol.impl;
 
 import java.security.PublicKey;
@@ -85,7 +83,7 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
 
     private List assertions = null;
     private List encAssertions = null;
-    
+
     private void parseElement(Element element)
         throws SAML2Exception {
         // make sure that the input xml block is not null
@@ -157,8 +155,8 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                     if (signatureString != null ||
                         extensions != null ||
                         status != null ||
-			assertions != null ||
-			encAssertions != null)
+            assertions != null ||
+            encAssertions != null)
                     {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ResponseImpl.parse"
@@ -179,8 +177,8 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
                     if (extensions != null || status != null ||
-			assertions != null || encAssertions != null)
-		    {
+            assertions != null || encAssertions != null)
+            {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ResponseImpl.parse"
                                 + "Element:wrong sequence.");
@@ -188,8 +186,8 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                         throw new SAML2Exception(
                             SAML2SDKUtils.bundle.getString("schemaViolation"));
                     }
-                    signatureString = XMLUtils.print((Element) child, 
-                        "UTF-8");  
+                    signatureString = XMLUtils.print((Element) child,
+                        "UTF-8");
                     isSigned = true;
                 } else if (childName.equals("Extensions")) {
                     if (extensions != null) {
@@ -201,8 +199,8 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
                     if (status != null || assertions != null ||
-			encAssertions != null)
-		    {
+            encAssertions != null)
+            {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ResponseImpl.parse"
                                 + "Element:wrong sequence.");
@@ -222,7 +220,7 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                             SAML2SDKUtils.bundle.getString("moreElement"));
                     }
                     if (assertions != null || encAssertions != null)
-		    {
+            {
                         if (SAML2SDKUtils.debug.messageEnabled()) {
                             SAML2SDKUtils.debug.message("ResponseImpl.parse"
                                 + "Element:wrong sequence.");
@@ -233,9 +231,9 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                     status = ProtocolFactory.getInstance().createStatus(
                         (Element) child);
                 } else if (childName.equals("Assertion")) {
-		    if (assertions == null) {
-			assertions = new ArrayList();
-		    }
+            if (assertions == null) {
+            assertions = new ArrayList();
+            }
                     Element canoEle = SAMLUtils.getCanonicalElement(child);
                     if (canoEle == null) {
                         throw new SAML2Exception(
@@ -245,11 +243,11 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
                     assertions.add(AssertionFactory.getInstance().
                         createAssertion(canoEle));
                 } else if (childName.equals("EncryptedAssertion")) {
-		    if (encAssertions == null) {
-			encAssertions = new ArrayList();
-		    }
-		    encAssertions.add(AssertionFactory.getInstance().
-			createEncryptedAssertion((Element) child));
+            if (encAssertions == null) {
+            encAssertions = new ArrayList();
+            }
+            encAssertions.add(AssertionFactory.getInstance().
+            createEncryptedAssertion((Element) child));
                 } else {
                     if (SAML2SDKUtils.debug.messageEnabled()) {
                         SAML2SDKUtils.debug.message("ResponseImpl.parse"
@@ -262,17 +260,17 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
         }
 
         super.validateData();
-	if (assertions != null) {
-	    Iterator iter = assertions.iterator();
-	    while (iter.hasNext()) {
-		((Assertion) iter.next()).makeImmutable();
-	    }
-	    assertions = Collections.unmodifiableList(assertions);
-	}
-	if (encAssertions != null) {
-	    encAssertions = Collections.unmodifiableList(encAssertions);
-	}
-	isMutable = false;
+    if (assertions != null) {
+        Iterator iter = assertions.iterator();
+        while (iter.hasNext()) {
+        ((Assertion) iter.next()).makeImmutable();
+        }
+        assertions = Collections.unmodifiableList(assertions);
+    }
+    if (encAssertions != null) {
+        encAssertions = Collections.unmodifiableList(encAssertions);
+    }
+    isMutable = false;
     }
     /**
      * Class constructor. Caller may need to call setters to populate the
@@ -319,13 +317,13 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
     }
 
     /**
-     * Returns <code>Assertion</code>(s) of the response. 
+     * Returns <code>Assertion</code>(s) of the response.
      *
      * @return List of <code>Assertion</code>(s) in the response.
      * @see #setAssertion(List)
      */
     public List getAssertion() {
-	return assertions;
+    return assertions;
     }
 
     /**
@@ -336,9 +334,9 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
      * @see #getAssertion()
      */
     public void setAssertion(List value)
-	throws SAML2Exception
+    throws SAML2Exception
     {
-	 if (isMutable) {
+     if (isMutable) {
             this.assertions = value;
         } else {
             throw new SAML2Exception(
@@ -347,13 +345,13 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
     }
 
     /**
-     * Returns <code>EncryptedAssertion</code>(s) of the response. 
+     * Returns <code>EncryptedAssertion</code>(s) of the response.
      *
      * @return List of <code>EncryptedAssertion</code>(s) in the response.
      * @see #setEncryptedAssertion(List)
      */
     public List getEncryptedAssertion() {
-	return encAssertions;
+    return encAssertions;
     }
 
     /**
@@ -364,9 +362,9 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
      * @see #getEncryptedAssertion()
      */
     public void setEncryptedAssertion(List value)
-	throws SAML2Exception
+    throws SAML2Exception
     {
- 	if (isMutable) {
+     if (isMutable) {
             this.encAssertions = value;
         } else {
             throw new SAML2Exception(
@@ -379,17 +377,17 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
      */
     public void makeImmutable() {
         if (isMutable) {
-	    if (assertions != null) {
-		Iterator iter = assertions.iterator();
-		while (iter.hasNext()) {
-		    ((Assertion) iter.next()).makeImmutable();
-		}
-		assertions = Collections.unmodifiableList(assertions);
-	    }
-	    if (encAssertions != null) {
-		encAssertions = Collections.unmodifiableList(encAssertions);
-	    }
-	    super.makeImmutable();
+        if (assertions != null) {
+        Iterator iter = assertions.iterator();
+        while (iter.hasNext()) {
+            ((Assertion) iter.next()).makeImmutable();
+        }
+        assertions = Collections.unmodifiableList(assertions);
+        }
+        if (encAssertions != null) {
+        encAssertions = Collections.unmodifiableList(encAssertions);
+        }
+        super.makeImmutable();
         }
     }
 
@@ -400,7 +398,7 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
      * @throws SAML2Exception if it could not create String object
      */
     public String toXMLString() throws SAML2Exception {
-	return this.toXMLString(true, false);
+    return this.toXMLString(true, false);
     }
 
     /**
@@ -414,11 +412,11 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
      * @return a String representation of this Object.
      **/
     public String toXMLString(boolean includeNSPrefix, boolean declareNS)
-	throws SAML2Exception {
-	if (isSigned && signedXMLString != null) {
-	    return signedXMLString;
-	}
-	this.validateData();
+    throws SAML2Exception {
+    if (isSigned && signedXMLString != null) {
+        return signedXMLString;
+    }
+    this.validateData();
         StringBuffer result = new StringBuffer(1000);
         String prefix = "";
         String uri = "";
@@ -431,10 +429,12 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
 
         result.append("<").append(prefix).append("Response").
                 append(uri).append(" ID=\"").append(responseId).append("\"");
-	if (inResponseTo != null && inResponseTo.trim().length() != 0) {
-	    result.append(" InResponseTo=\"").append(inResponseTo).append("\"");
-	}
-	
+        if (inResponseTo != null && inResponseTo.trim().length() != 0) {
+            result.append(" InResponseTo=\"")
+                    .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
+                    .append("\"");
+        }
+
         result.append(" Version=\"").append(version).append("\"").
                 append(" IssueInstant=\"").
                 append(DateUtils.toUTCDateFormat(issueInstant)).append("\"");
@@ -455,21 +455,21 @@ public class ResponseImpl extends StatusResponseImpl implements Response {
         if (extensions != null) {
             result.append(extensions.toXMLString(includeNSPrefix, declareNS));
         }
-	result.append(status.toXMLString(includeNSPrefix, declareNS));
-	if (assertions != null) {
-	    Iterator iter = assertions.iterator();
-	    while (iter.hasNext()) {
-		result.append(((Assertion) iter.next()).toXMLString(
-			includeNSPrefix, declareNS));
-	    }
-	}
-	if (encAssertions != null) {
-	    Iterator iter1 = encAssertions.iterator();
-	    while (iter1.hasNext()) {
-		result.append(((EncryptedAssertion) iter1.next()).toXMLString(
-			includeNSPrefix, declareNS));
-	    }
-	}
+    result.append(status.toXMLString(includeNSPrefix, declareNS));
+    if (assertions != null) {
+        Iterator iter = assertions.iterator();
+        while (iter.hasNext()) {
+        result.append(((Assertion) iter.next()).toXMLString(
+            includeNSPrefix, declareNS));
+        }
+    }
+    if (encAssertions != null) {
+        Iterator iter1 = encAssertions.iterator();
+        while (iter1.hasNext()) {
+        result.append(((EncryptedAssertion) iter1.next()).toXMLString(
+            includeNSPrefix, declareNS));
+        }
+    }
         result.append("</").append(prefix).append("Response>");
         return result.toString();
     }

--- a/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/StatusResponseImpl.java
+++ b/openam-federation/openam-federation-library/src/main/java/com/sun/identity/saml2/protocol/impl/StatusResponseImpl.java
@@ -25,6 +25,7 @@
  * $Id: StatusResponseImpl.java,v 1.4 2008/06/25 05:48:01 qcheng Exp $
  *
  * Portions Copyrighted 2015-2016 ForgeRock AS.
+ * Portions Copyrighted 2023 Wren Security
  */
 package com.sun.identity.saml2.protocol.impl;
 
@@ -56,7 +57,7 @@ import org.w3c.dom.Element;
  */
 
 public abstract class StatusResponseImpl implements StatusResponse {
-    
+
     protected String version = null;
     protected Date issueInstant = null;
     protected String destination = null;
@@ -82,7 +83,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.lang.String getVersion() {
         return version;
     }
-    
+
     /**
      * Sets the value of the version property.
      *
@@ -98,7 +99,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the issueInstant property.
      *
@@ -108,7 +109,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.util.Date getIssueInstant() {
         return issueInstant;
     }
-    
+
     /**
      * Sets the value of the issueInstant property.
      *
@@ -124,7 +125,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the destination property.
      *
@@ -134,7 +135,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.lang.String getDestination() {
         return destination;
     }
-    
+
     /**
      * Sets the value of the destination property.
      *
@@ -150,7 +151,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the signature element, the <code>StatusResponse</code> contains
      * as <code>String</code>.
@@ -162,7 +163,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public String getSignature() {
         return signatureString;
     }
-    
+
     /** Signs the StatusResponse
      *
      * @param privateKey Signing key
@@ -196,7 +197,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public Extensions getExtensions() {
         return extensions;
     }
-    
+
     /**
      * Sets the value of the extensions property.
      *
@@ -212,7 +213,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the consent property.
      *
@@ -222,7 +223,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.lang.String getConsent() {
         return consent;
     }
-    
+
     /**
      * Sets the value of the consent property.
      *
@@ -238,7 +239,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the inResponseTo property.
      *
@@ -248,7 +249,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.lang.String getInResponseTo() {
         return inResponseTo;
     }
-    
+
     /**
      * Sets the value of the inResponseTo property.
      *
@@ -264,7 +265,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the status property.
      *
@@ -274,7 +275,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public com.sun.identity.saml2.protocol.Status getStatus() {
         return status;
     }
-    
+
     /**
      * Sets the value of the status property.
      *
@@ -291,7 +292,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the id property.
      *
@@ -301,7 +302,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public java.lang.String getID() {
         return responseId;
     }
-    
+
     /**
      * Sets the value of the id property.
      *
@@ -317,7 +318,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns the value of the issuer property.
      *
@@ -327,7 +328,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public Issuer getIssuer() {
         return issuer;
     }
-    
+
     /**
      * Sets the value of the issuer property.
      *
@@ -344,7 +345,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("objectImmutable"));
         }
     }
-    
+
     /**
      * Returns whether the <code>StatusResponse</code> is signed or not.
      *
@@ -356,13 +357,13 @@ public abstract class StatusResponseImpl implements StatusResponse {
 
     @Override
     public boolean isSignatureValid(Set<X509Certificate> verificationCerts)
-        throws SAML2Exception { 	
+        throws SAML2Exception {
         if (isSignatureValid == null) {
              isSignatureValid = SigManager.getSigInstance().verify(signedXMLString, getID(), verificationCerts);
          }
          return isSignatureValid.booleanValue();
-    }   
-    
+    }
+
     /**
      * Returns the <code>StatusResponse</code> in an XML document String format
      * based on the <code>StatusResponse</code> schema described above.
@@ -374,7 +375,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public String toXMLString() throws SAML2Exception {
         return toXMLString(true,false);
     }
-    
+
     /**
      * Returns the <code>StatusResponse</code> in an XML document String format
      * based on the <code>StatusResponse</code> schema described above.
@@ -389,15 +390,15 @@ public abstract class StatusResponseImpl implements StatusResponse {
      */
     public String toXMLString(boolean includeNSPrefix,
     boolean declareNS) throws SAML2Exception {
-        
+
         StringBuffer xmlString = new StringBuffer(1000);
-        
+
         if (declareNS) {
             xmlString.append(SAML2Constants.PROTOCOL_DECLARE_STR)
             .append(SAML2Constants.NEWLINE);
-            
+
         }
-        
+
         xmlString.append(SAML2Constants.ID).append(SAML2Constants.EQUAL)
         .append(SAML2Constants.QUOTE)
         .append(responseId).append(SAML2Constants.QUOTE)
@@ -411,7 +412,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
         .append(SAML2Constants.QUOTE)
         .append(DateUtils.toUTCDateFormat(issueInstant))
         .append(SAML2Constants.QUOTE);
-        
+
         if ((destination != null) && (destination.length() > 0)) {
             xmlString.append(SAML2Constants.SPACE)
             .append(SAML2Constants.DESTINATION)
@@ -420,7 +421,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             .append(destination)
             .append(SAML2Constants.QUOTE);
         }
-        
+
         if ((consent != null) && (consent.length() > 0)) {
             xmlString.append(SAML2Constants.SPACE)
             .append(SAML2Constants.CONSENT)
@@ -429,18 +430,18 @@ public abstract class StatusResponseImpl implements StatusResponse {
             .append(consent)
             .append(SAML2Constants.QUOTE);
         }
-        
+
         if ((inResponseTo != null) && (inResponseTo.length() > 0)) {
             xmlString.append(SAML2Constants.SPACE)
             .append(SAML2Constants.INRESPONSETO)
             .append(SAML2Constants.EQUAL)
             .append(SAML2Constants.QUOTE)
-            .append(inResponseTo)
+            .append(XMLUtils.escapeSpecialCharacters(inResponseTo))
             .append(SAML2Constants.QUOTE);
         }
-        
+
         xmlString.append(SAML2Constants.END_TAG);
-        
+
         if (issuer != null) {
             String issuerString = issuer.toXMLString(includeNSPrefix,declareNS);
             xmlString.append(SAML2Constants.NEWLINE).append(issuerString);
@@ -456,10 +457,10 @@ public abstract class StatusResponseImpl implements StatusResponse {
             xmlString.append(SAML2Constants.NEWLINE)
             .append(status.toXMLString(includeNSPrefix,declareNS));
         }
-        
+
         return xmlString.toString();
     }
-    
+
     /**
      * Makes this object immutable.
      */
@@ -477,7 +478,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             isMutable = false;
         }
     }
-    
+
     /**
      * Returns true if object is mutable.
      *
@@ -486,7 +487,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
     public boolean isMutable() {
         return isMutable;
     }
-    
+
    /* Validates the responseId in the SAML Response. */
     protected void validateID(String responseId) throws SAML2Exception {
         if ((responseId == null) || (responseId.length() == 0 )) {
@@ -495,8 +496,8 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("missingIDAttr"));
         }
     }
-    
-    
+
+
    /* Validates the version in the SAML Response. */
     protected void validateVersion(String version) throws SAML2Exception {
         if ((version == null) || (version.length() == 0) ) {
@@ -507,7 +508,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             "incorrectVersion"));
         }
     }
-    
+
    /* Validates the IssueInstant attribute in the SAML Response. */
     protected void validateIssueInstant(String issueInstantStr)
     throws SAML2Exception {
@@ -524,7 +525,7 @@ public abstract class StatusResponseImpl implements StatusResponse {
             }
         }
     }
-    
+
     /* Validates the Status element in the SAML Response. */
     protected void validateStatus()
     throws SAML2Exception {
@@ -532,8 +533,8 @@ public abstract class StatusResponseImpl implements StatusResponse {
             throw new SAML2Exception(
             SAML2SDKUtils.bundle.getString("missingStatus"));
         }
-    }    
-    
+    }
+
    /* Validates the required elements in the SAML Response. */
     protected void validateData() throws SAML2Exception {
         validateID(responseId);
@@ -543,6 +544,6 @@ public abstract class StatusResponseImpl implements StatusResponse {
             SAML2SDKUtils.bundle.getString("incorrectIssueInstant"));
         }
         validateIssueInstant(DateUtils.dateToString(issueInstant));
-        validateStatus();        
+        validateStatus();
     }
 }


### PR DESCRIPTION
This PR introduces XML escaping of the SAML response attribute `inResponseTo` to resolve the security vulnerability published as a [CVE-2021-37154](https://nvd.nist.gov/vuln/detail/CVE-2021-37154).

I was able to reproduce the exploit using the current version built with JDK 17. 