### PR TITLE
[AM SA #201801-01] Remove JWT bearer token grant type.

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
+++ b/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2012-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.openam.oauth2;
@@ -53,7 +54,7 @@ public class OAuth2Constants {
 
     /*
      * public static final Set<String> params;
-     * 
+     *
      * static { Set<String> paramSet = new HashSet<String>();
      * paramSet.add(Params.ACCESS_TOKEN); paramSet.add(Params.CLIENT_ID);
      * paramSet.add(Params.CLIENT_SECRET); paramSet.add(Params.CODE);
@@ -151,7 +152,7 @@ public class OAuth2Constants {
          * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest">3.1.2.1 Authentication Request</a>
          */
         public static final String ACR_VALUES = "acr_values";
-        
+
         /** Parameter usage location: OpenId Connect request. */
         public static final String LOGIN_HINT = "login_hint";
 
@@ -270,8 +271,6 @@ public class OAuth2Constants {
          */
         public static final String SAML2_BEARER = "urn:ietf:params:oauth:grant-type:saml2-bearer";
 
-        public static final String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
-
         public static final String DEVICE_CODE = "http://oauth.net/grant_type/device/1.0";
     }
 
@@ -383,7 +382,7 @@ public class OAuth2Constants {
 
         /*
          * 8.1.1. Registration Template
-         * 
+         *
          * Algorithm name: The name requested (e.g., "example"). Body hash
          * algorithm: The corresponding algorithm used to calculate the payload
          * body hash. Change controller: For standards-track RFCs, state "IETF".
@@ -393,63 +392,63 @@ public class OAuth2Constants {
          * specifies the algorithm, preferably including a URI that can be used
          * to retrieve a copy of the document. An indication of the relevant
          * sections may also be included, but is not required.
-         * 
+         *
          * 8.1.2. Initial Registry Contents
-         * 
+         *
          * The HTTP MAC authentication scheme algorithm registry's initial
          * contents are:
-         * 
-         * 
-         * 
+         *
+         *
+         *
          * Hammer-Lahav, et al. Expires November 12, 2011 [Page 22]
-         * 
+         *
          * Internet-Draft MAC Authentication May 2011
-         * 
-         * 
+         *
+         *
          * o Algorithm name: hmac-sha-1 o Body hash algorithm: sha-1 o Change
          * controller: IETF o Specification document(s): [[ this document ]]
-         * 
+         *
          * o Algorithm name: hmac-sha-256 o Body hash algorithm: sha-256 o
          * Change controller: IETF o Specification document(s): [[ this document
          * ]]
-         * 
+         *
          * 8.2. OAuth Access Token Type Registration
-         * 
+         *
          * This specification registers the following access token type in the
          * OAuth Access Token Type Registry.
-         * 
+         *
          * 8.2.1. The "mac" OAuth Access Token Type
-         * 
+         *
          * Type name: mac Additional Token Endpoint Response Parameters: secret,
          * algorithm HTTP Authentication Scheme(s): MAC Change controller: IETF
          * Specification document(s): [[ this document ]]
-         * 
+         *
          * 8.3. OAuth Parameters Registration
-         * 
+         *
          * This specification registers the following parameters in the OAuth
          * Parameters Registry established by [I-D.ietf-oauth-v2].
-         * 
+         *
          * 8.3.1. The "mac_key" OAuth Parameter
-         * 
+         *
          * Parameter name: mac_key Parameter usage location: authorization
          * response, token response Change controller: IETF Specification
          * document(s): [[ this document ]] Related information: None
-         * 
+         *
          * 8.3.2. The "mac_algorithm" OAuth Parameter
-         * 
+         *
          * Parameter name: mac_algorithm
-         * 
-         * 
-         * 
-         * 
-         * 
-         * 
-         * 
+         *
+         *
+         *
+         *
+         *
+         *
+         *
          * Hammer-Lahav, et al. Expires November 12, 2011 [Page 23]
-         * 
+         *
          * Internet-Draft MAC Authentication May 2011
-         * 
-         * 
+         *
+         *
          * Parameter usage location: authorization response, token response
          * Change controller: IETF Specification document(s): [[ this document
          * ]] Related information: None

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/JwtBearerGrantTypeHandler.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/JwtBearerGrantTypeHandler.java
@@ -39,6 +39,7 @@ import org.forgerock.openam.oauth2.OAuth2UrisFactory;
 /**
  * Implementation of the JwtBearerGrantTypeHandler for the JWT Bearer grant.
  *
+ * @deprecated Implementation contains critical security issue (AM SA #201801-01) and should be rewritten.
  * @since 12.0.0
  */
 public class JwtBearerGrantTypeHandler extends GrantTypeHandler {
@@ -56,7 +57,7 @@ public class JwtBearerGrantTypeHandler extends GrantTypeHandler {
     public AccessToken handle(OAuth2Request request, ClientRegistration clientRegistration,
             OAuth2ProviderSettings providerSettings) throws RedirectUriMismatchException,
             InvalidRequestException, InvalidGrantException, InvalidCodeException,
-            ServerException, UnauthorizedClientException, InvalidScopeException, 
+            ServerException, UnauthorizedClientException, InvalidScopeException,
             InvalidClientException, NotFoundException {
 
         final String jwtParameter = request.getParameter(OAuth2Constants.SAML20.ASSERTION);

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/AccessTokenFlowFinder.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/restlet/AccessTokenFlowFinder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.oauth2.restlet;
@@ -41,7 +42,6 @@ public class AccessTokenFlowFinder extends OAuth2FlowFinder {
         endpointClasses.put(CLIENT_CREDENTIALS, wrap(TokenEndpointResource.class));
         endpointClasses.put(PASSWORD, wrap(TokenEndpointResource.class));
         endpointClasses.put(DEVICE_CODE, wrap(TokenEndpointResource.class));
-        endpointClasses.put(JWT_BEARER, wrap(TokenEndpointResource.class));
         endpointClasses.put(SAML2_BEARER, wrap(TokenEndpointResource.class));
         return endpointClasses;
     }

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/guice/OAuth2GuiceModule.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/guice/OAuth2GuiceModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 package org.forgerock.openam.oauth2.guice;
 
@@ -26,7 +27,6 @@ import static org.forgerock.oauth2.core.TokenStore.REALM_AGNOSTIC_TOKEN_STORE;
 import static org.forgerock.openam.oauth2.OAuth2Constants.TokenEndpoint.AUTHORIZATION_CODE;
 import static org.forgerock.openam.oauth2.OAuth2Constants.TokenEndpoint.CLIENT_CREDENTIALS;
 import static org.forgerock.openam.oauth2.OAuth2Constants.TokenEndpoint.DEVICE_CODE;
-import static org.forgerock.openam.oauth2.OAuth2Constants.TokenEndpoint.JWT_BEARER;
 import static org.forgerock.openam.oauth2.OAuth2Constants.TokenEndpoint.PASSWORD;
 import static org.forgerock.openam.rest.service.RestletUtils.wrap;
 
@@ -63,7 +63,6 @@ import org.forgerock.oauth2.core.ClientRegistrationStore;
 import org.forgerock.oauth2.core.DeviceCodeGrantTypeHandler;
 import org.forgerock.oauth2.core.DuplicateRequestParameterValidator;
 import org.forgerock.oauth2.core.GrantTypeHandler;
-import org.forgerock.oauth2.core.JwtBearerGrantTypeHandler;
 import org.forgerock.oauth2.core.OAuth2ProviderSettings;
 import org.forgerock.oauth2.core.OAuth2ProviderSettingsFactory;
 import org.forgerock.oauth2.core.OAuth2Request;
@@ -218,7 +217,6 @@ public class OAuth2GuiceModule extends AbstractModule {
         grantTypeHandlers.addBinding(PASSWORD).to(PasswordCredentialsGrantTypeHandler.class);
         grantTypeHandlers.addBinding(AUTHORIZATION_CODE).to(AuthorizationCodeGrantTypeHandler.class);
         grantTypeHandlers.addBinding(DEVICE_CODE).to(DeviceCodeGrantTypeHandler.class);
-        grantTypeHandlers.addBinding(JWT_BEARER).to(JwtBearerGrantTypeHandler.class);
 
         final Multibinder<AuthorizeRequestHook> authorizeRequestHooks = Multibinder.newSetBinder(
                 binder(), AuthorizeRequestHook.class);


### PR DESCRIPTION
This PR removes JWT bearer token grant type to workaround the security vulnerability published as a AM SA #201801-01.