### PR TITLE
Fix non-expiring sessions management.

### DIFF
--- a/openam-core/src/test/java/org/forgerock/openam/session/service/NonExpiringSessionManagerTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/service/NonExpiringSessionManagerTest.java
@@ -76,7 +76,7 @@ public class NonExpiringSessionManagerTest extends AbstractMockBasedTest {
     public void shouldSetUpSessionCorrectly() {
         nonExpiringSessionManager.addNonExpiringSession(mockInternalSession);
         verify(mockInternalSession).setMaxSessionTime(InternalSession.NON_EXPIRING_SESSION_LENGTH_MINUTES);
-        verify(mockInternalSession).setMaxIdleTime(10);
+        verify(mockInternalSession).setMaxIdleTime(25);
         verify(mockInternalSession).setLatestAccessTime();
     }
 


### PR DESCRIPTION
This PR mainly fixes the `ConcurrentModificationException` (see stacktrace bellow) when extending the validity of non-expiring sessions. I also extended the maximum idle time of the non-expiring session to cover the situation where a single iteration of the job fails.

```
ERROR: ThreadMonitor: Thread WatchDog detected error, restarting
java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.forgerock.openam.shared.concurrency.ThreadMonitor$WatchDog.run(ThreadMonitor.java:294)
	at org.forgerock.openam.audit.context.AuditRequestContextPropagatingRunnable.run(AuditRequestContextPropagatingRunnable.java:42)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1620)
	at org.forgerock.openam.session.service.NonExpiringSessionManager$NonExpiringSessionUpdater.run(NonExpiringSessionManager.java:84)
	at org.forgerock.openam.audit.context.AuditRequestContextPropagatingRunnable.run(AuditRequestContextPropagatingRunnable.java:42)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	... 3 more
```