### PR TITLE
Handle token validity maximum value.

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/cts/api/tokens/Token.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/api/tokens/Token.java
@@ -13,7 +13,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Portions copyright 2022 Wren Security
+ * Portions copyright 2022-2023 Wren Security
  */
 package org.forgerock.openam.cts.api.tokens;
 
@@ -58,6 +58,9 @@ import com.sun.identity.shared.encode.Base64;
 @Title(CORE_TOKEN_RESOURCE + "resource.schema." + TITLE)
 @Description(CORE_TOKEN_RESOURCE + "resource.schema." + DESCRIPTION)
 public class Token {
+
+    // Maximum allowed value of token validity
+    private static final String MAX_ALLOWED_DATETIME = "99991231235959.000Z";
 
     /**
      * Note: This map stores all data for the Token. It is intentionally using a String to Object mapping
@@ -315,7 +318,11 @@ public class Token {
             } else if (CoreTokenField.TOKEN_TYPE.equals(field)) {
                 s = ((TokenType) value).name();
             } else if (CoreTokenFieldTypes.isCalendar(field)) {
-                s = GeneralizedTime.valueOf((Calendar) value).toString();
+                if (((Calendar) value).get(Calendar.YEAR) > 9999) {
+                    s = MAX_ALLOWED_DATETIME;
+                } else {
+                    s = GeneralizedTime.valueOf((Calendar) value).toString();
+                }
             } else if (CoreTokenFieldTypes.isByteArray(field)) {
                 s = Base64.encode((byte[]) value);
             } else if (CoreTokenFieldTypes.isInteger(field)) {


### PR DESCRIPTION
This PR introduces the maximum allowed validity for tokens stored in CTS. Agent tokens currently use the `Long.MAX_VALUE` [value](https://github.com/WrenSecurity/wrenam/blob/main/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java#L1387), but the Wren:DS `GeneralizedTime` component fails to parse it (see stacktrace bellow).

```
java.util.concurrent.ExecutionException: org.forgerock.i18n.LocalizedIllegalArgumentException: The provided value "2922690551202174704.192+0100" is not a valid generalized time value because "69" is not a valid month specification
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
	at org.forgerock.openam.shared.concurrency.ThreadMonitor$WatchDog.run(ThreadMonitor.java:294)
	at org.forgerock.openam.audit.context.AuditRequestContextPropagatingRunnable.run(AuditRequestContextPropagatingRunnable.java:42)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.forgerock.i18n.LocalizedIllegalArgumentException: The provided value "2922690551202174704.192+0100" is not a valid generalized time value because "69" is not a valid month specification
	at org.forgerock.opendj.ldap.GeneralizedTime.valueOf(GeneralizedTime.java:221)
	at org.forgerock.openam.cts.api.tokens.Token.get(Token.java:349)
	at org.forgerock.openam.cts.api.tokens.Token.getAttribute(Token.java:198)
	at org.forgerock.openam.cts.utils.LdapTokenAttributeConversion.getEntry(LdapTokenAttributeConversion.java:96)
	at org.forgerock.openam.cts.impl.LdapAdapter.create(LdapAdapter.java:117)
	at org.forgerock.openam.sm.datalayer.impl.tasks.UpdateTask.performTask(UpdateTask.java:60)
	at org.forgerock.openam.sm.datalayer.api.AbstractTask.execute(AbstractTask.java:49)
	at org.forgerock.openam.sm.datalayer.impl.SeriesTaskExecutor$AuditRequestContextPropagatingTask.execute(SeriesTaskExecutor.java:217)
	at org.forgerock.openam.sm.datalayer.impl.SimpleTaskExecutor.execute(SimpleTaskExecutor.java:67)
	at org.forgerock.openam.sm.datalayer.impl.SeriesTaskExecutorThread.run(SeriesTaskExecutorThread.java:93)
	... 6 more
```

I will create issue in Wren:DS to introduce `GeneralizedTime` maximum year validation.