### PR TITLE
Fix non expiring session management (#141)

### DIFF
--- a/openam-core/src/main/java/com/iplanet/sso/providers/dpro/SSOProviderImpl.java
+++ b/openam-core/src/main/java/com/iplanet/sso/providers/dpro/SSOProviderImpl.java
@@ -28,6 +28,7 @@
 
 /**
  * Portions copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 package com.iplanet.sso.providers.dpro;
 
@@ -340,7 +341,7 @@ public final class SSOProviderImpl implements SSOProvider {
             SSOTokenID tokenid = token.getTokenID();
             String id = tokenid.toString();
             SessionID sessid = new SessionID(id);
-            Session session = sessionCache.getSession(sessid);
+            Session session = sessionCache.getSession(sessid, true);
             session.destroySession(session);
         } catch (Exception e) {
             if (debug.messageEnabled()) {

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
@@ -5254,7 +5254,7 @@ public class LoginState {
         if ((stateless && !restriction.isRestricted(getUserDN()) || isNoSession())) {
             return;
         }
-        authenticationSessionStore.promoteSession(sessionReference);
+        authenticationSessionStore.promoteSession(sessionReference, AdminTokenAction.isActiveLogin());
     }
 
     /**

--- a/openam-core/src/main/java/com/sun/identity/security/AdminTokenAction.java
+++ b/openam-core/src/main/java/com/sun/identity/security/AdminTokenAction.java
@@ -178,13 +178,12 @@ public class AdminTokenAction implements PrivilegedAction<SSOToken> {
     }
 
     private void resetInstance() {
-        if (appSSOToken != null) {
-            // XXX Temporarily disabled to workaround unavailable CTS token store issue (see https://github.com/WrenSecurity/wrenam/issues/63)
-            // try {
-            //     getInstance().tokenManager.destroyToken(appSSOToken);
-            // } catch (SSOException ssoe) {
-            //     debug.error("AdminTokenAction.reset: cannot destroy appSSOToken.", ssoe);
-            // }
+        if (appSSOToken != null && !SystemProperties.isServerMode()) {
+             try {
+                 getInstance().tokenManager.destroyToken(appSSOToken);
+             } catch (SSOException ssoe) {
+                 debug.error("AdminTokenAction.reset: cannot destroy appSSOToken.", ssoe);
+             }
             appSSOToken = null;
         }
         internalAppSSOToken = null;

--- a/openam-core/src/main/java/org/forgerock/openam/authentication/service/AuthSessionFactory.java
+++ b/openam-core/src/main/java/org/forgerock/openam/authentication/service/AuthSessionFactory.java
@@ -102,7 +102,7 @@ public class AuthSessionFactory {
         String id = "id=" + rdnValueFromDn(clientID) + ",ou=user," + ServiceManager.getBaseDN();
         session.putProperty(UNIVERSAL_IDENTIFIER, id);
 
-        authenticationSessionStore.promoteSession(session.getSessionID());
+        authenticationSessionStore.promoteSession(session.getSessionID(), true);
 
         return session;
     }

--- a/openam-core/src/main/java/org/forgerock/openam/session/service/SessionAccessManager.java
+++ b/openam-core/src/main/java/org/forgerock/openam/session/service/SessionAccessManager.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 package org.forgerock.openam.session.service;
 
@@ -127,16 +128,19 @@ public class SessionAccessManager {
      * @param session The session to persist.
      */
     public void persistInternalSession(InternalSession session) {
-
         try {
             internalSessionStore.store(session);
         } catch (SessionPersistenceException e) {
             throw new RuntimeException(e);
         }
+    }
 
-        if (!session.willExpire()) {
-            nonExpiringSessionManager.addNonExpiringSession(session);
-        }
+    /**
+     * Track and keep alive non-expiring local session.
+     * @param session The session to keep alive.
+     */
+    public void trackNonExpiringSession(InternalSession session) {
+        nonExpiringSessionManager.addNonExpiringSession(session);
     }
 
     /**

--- a/openam-core/src/test/java/org/forgerock/openam/session/service/NonExpiringSessionManagerTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/session/service/NonExpiringSessionManagerTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2021 Wren Security.
+ * Portions Copyright 2021-2023 Wren Security.
  */
 
 package org.forgerock.openam.session.service;
@@ -27,10 +27,8 @@ import static org.mockito.Mockito.verify;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.forgerock.openam.session.service.NonExpiringSessionManager;
 import org.forgerock.openam.shared.concurrency.ThreadMonitor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeMethod;
@@ -75,8 +73,6 @@ public class NonExpiringSessionManagerTest extends AbstractMockBasedTest {
     @Test
     public void shouldSetUpSessionCorrectly() {
         nonExpiringSessionManager.addNonExpiringSession(mockInternalSession);
-        verify(mockInternalSession).setMaxSessionTime(InternalSession.NON_EXPIRING_SESSION_LENGTH_MINUTES);
-        verify(mockInternalSession).setMaxIdleTime(25);
         verify(mockInternalSession).setLatestAccessTime();
     }
 


### PR DESCRIPTION
Current AM behavior was error prone to memory leaks and has a confusing logic regarding keeping non-expiring sessions active. This PR introduces a potentially breaking change in the sense that the responsibility of keeping the session active is now on the session holder and not the AM server. AM server only keeps its own sessions active.

Introduced changes:

* `NonExpiringSessionManager` is no longer responsible for updating session expiration attributes.
   * Setting correct expiration attributes is being done by `InternalSession#setNonExpiring` (this is a breaking change for clients / agents that might expect different behavior).
* `AdminTokenAction` was extended with thread-local property so that `AuthenticationSessionStore` can decide whether the newly registered session should be registered in `NonExpiringSessionManager`.
   *  This might feel like *spaghetti code*, but I was not able to come up with a better approach that would not require huge code changes.
 