### PR TITLE
Cap max session time to a safe value.

### DIFF
--- a/openam-core/src/main/java/com/iplanet/dpro/session/service/InternalSession.java
+++ b/openam-core/src/main/java/com/iplanet/dpro/session/service/InternalSession.java
@@ -338,6 +338,10 @@ public class InternalSession implements Serializable, AMSession, SessionPersiste
      *            Maximum Session Time
      */
     public void setMaxSessionTime(long maxSessionTimeInMinutes) {
+        if (maxSessionTimeInMinutes > NON_EXPIRING_SESSION_LENGTH_MINUTES) {
+            debug.warning("Setting maxSessionTimeInMinutes to a very large value that can lead to overflow: "
+                    + maxSessionTimeInMinutes);
+        }
         if (this.maxSessionTimeInMinutes != maxSessionTimeInMinutes) {
             this.maxSessionTimeInMinutes = maxSessionTimeInMinutes;
             notifyPersistenceManager();
@@ -358,6 +362,10 @@ public class InternalSession implements Serializable, AMSession, SessionPersiste
      * @param maxIdleTimeInMinutes
      */
     public void setMaxIdleTime(long maxIdleTimeInMinutes) {
+        if (maxIdleTimeInMinutes > NON_EXPIRING_SESSION_LENGTH_MINUTES) {
+            debug.warning("Setting maxIdleTimeInMinutes to a very large value that can lead to overflow: "
+                    + maxIdleTimeInMinutes);
+        }
         this.maxIdleTimeInMinutes = maxIdleTimeInMinutes;
         notifyPersistenceManager();
     }
@@ -374,11 +382,15 @@ public class InternalSession implements Serializable, AMSession, SessionPersiste
     /**
      * Sets the maximum caching time(in minutes) for the Internal Session.
      *
-     * @param t
+     * @param maxCachingTimeInMinutes
      *        Maximum Caching Time
      */
-    public void setMaxCachingTime(long t) {
-        maxCachingTimeInMinutes = t;
+    public void setMaxCachingTime(long maxCachingTimeInMinutes) {
+        if (maxCachingTimeInMinutes > NON_EXPIRING_SESSION_LENGTH_MINUTES) {
+            debug.warning("Setting maxCachingTimeInMinutes to a very large value that can lead to overflow: "
+                    + maxCachingTimeInMinutes);
+        }
+        this.maxCachingTimeInMinutes = maxCachingTimeInMinutes;
         notifyPersistenceManager();
     }
 

--- a/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
+++ b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java
@@ -1384,7 +1384,7 @@ public class LoginState {
                                 userDN + " with idletimeout to " +
                                 AGENT_SESSION_IDLE_TIME);
                     }
-                    session.setMaxSessionTime(Long.MAX_VALUE / 60);
+                    session.setMaxSessionTime(InternalSession.NON_EXPIRING_SESSION_LENGTH_MINUTES);
                     session.setMaxIdleTime(AGENT_SESSION_IDLE_TIME);
                     session.setMaxCachingTime(AGENT_SESSION_IDLE_TIME);
                 } else {


### PR DESCRIPTION
This change fixes issues with immediate expiration of agent sessions created with `com.iplanet.am.session.agentSessionIdleTime` system property set to a non-zero value.

The original issue was that when the `agentSessionIdleTime` was set, then [max session time was set to `Long.MAX_VALUE`](https://github.com/WrenSecurity/wrenam/blob/e68df578ef92d4557806d945ecda5baeecfe134b/openam-core/src/main/java/com/sun/identity/authentication/service/LoginState.java#L1387), which [caused value overflow in `getMaxSessionExpirationTime`](https://github.com/WrenSecurity/wrenam/blob/e68df578ef92d4557806d945ecda5baeecfe134b/openam-core/src/main/java/com/iplanet/dpro/session/service/InternalSession.java#L1103) and the session was immediately marked as expired.

The issue led to a quite strange behavior of [not including `tokenId` field](https://github.com/WrenSecurity/wrenam/blob/e68df578ef92d4557806d945ecda5baeecfe134b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/authn/RestAuthenticationHandler.java#L281) in REST `/authentication` response:

```json
{
    "message": "Authentication Successful",
    "successUrl": "/auth/console",
    "realm": "/"
}
```