### PR TITLE
Remove useless error message when consent saving is disabled.

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
@@ -320,8 +320,6 @@ public class RealmOAuth2ProviderSettings implements OAuth2ProviderSettings {
                         }
                     }
                 }
-            } else {
-                logger.error("Can't save consent as it is not configured properly for the realm:" + realm);
             }
         } catch (Exception e) {
             logger.error("There was a problem getting the saved consent from the attribute: "


### PR DESCRIPTION
This PR removes a useless error message that is logged when checking stored consent and consent saving is disabled.