### PR TITLE
Add OAuth2 revocation_endpoint to .well-known

### DIFF
--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2Uris.java
@@ -13,6 +13,7 @@
  *
  * Copyright 2014-2015 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+ * Portions Copyrighted 2023 Wren Security
  */
 
 package org.forgerock.oauth2.core;
@@ -106,5 +107,12 @@ public interface OAuth2Uris {
      * @return The URL.
      */
     String getResourceSetRegistrationEndpoint();
+
+    /**
+     * Gets the URI for the OAuth2 token revocation endpoint.
+     *
+     * @return The URL.
+     */
+    String getRevocationEndpoint();
 
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OAuth2UrisFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.oauth2;
@@ -167,6 +168,11 @@ public class OAuth2UrisFactory {
         @Override
         public String getResourceSetRegistrationEndpoint() {
             return baseUrl + "/resource_set";
+        }
+
+        @Override
+        public String getRevocationEndpoint() {
+            return baseUrl + "/token/revoke";
         }
 
         @Override

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProviderConfiguration.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2017 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 package org.forgerock.openidconnect;
@@ -101,6 +102,7 @@ public class OpenIDConnectProviderConfiguration {
         configuration.put("claims_parameter_supported", providerSettings.getClaimsParameterSupported());
         configuration.put("token_endpoint_auth_methods_supported", providerSettings.getEndpointAuthMethodsSupported());
         configuration.put("introspection_endpoint", uris.getIntrospectionEndpoint());
+        configuration.put("revocation_endpoint", uris.getRevocationEndpoint());
 
         return new JsonValue(configuration);
     }


### PR DESCRIPTION
This PR adds optional field `revocation_endpoint` to the OAuth2  .well-known resource.

https://datatracker.ietf.org/doc/html/rfc8414#section-2