### PR TITLE
Fix NPE caused by missing secret key alias

### DIFF
--- a/openam-shared/src/main/java/org/forgerock/openam/utils/AMKeyProvider.java
+++ b/openam-shared/src/main/java/org/forgerock/openam/utils/AMKeyProvider.java
@@ -319,7 +319,9 @@ public class AMKeyProvider implements KeyProvider {
                 return (SecretKey) key;
             }
 
-            logger.error("Expected a key of type javax.crypto.SecretKey but got " + key.getClass().getName());
+            if (key != null) {
+                logger.error("Expected a key of type javax.crypto.SecretKey but got " + key.getClass().getName());
+            }
         } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
             logger.error("Unable to get the secret key for certificate alias " + certAlias, e);
         }


### PR DESCRIPTION
This change prevents from NPE and logs better exception when a secret key for self-service signing is deleted from the AM keystore.

```
java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "key" is null
```

vs

```
org.forgerock.selfservice.core.config.StageConfigException: Unable to retrieve key for certificate alias selfservicesigntest
```