### PR TITLE
Upgrade Commons FileUpload dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.5</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.6</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
 
         <!-- Source code has to be Java 8 compliant (code base is not JPMS ready) -->
@@ -157,7 +157,7 @@
         <commons-codec.version>1.6</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-digester.version>2.1</commons-digester.version>
-        <commons-fileupload.version>1.3.1</commons-fileupload.version>
+        <commons-fileupload.version>1.5</commons-fileupload.version>
         <commons-io.version>2.3</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <commons-logging.version>1.1.3</commons-logging.version>


### PR DESCRIPTION
This PR upgrades Apache Commons FileUpload dependency to resolve the security vulnerability published as a [CVE-2016-1000031](https://nvd.nist.gov/vuln/detail/CVE-2016-1000031).