### PR TITLE
Upgrade wrensec-commons. Remove PowerMock dependency.

### DIFF
--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/cts/CoreTokenResourceAuthzModuleTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/cts/CoreTokenResourceAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.core.rest.cts;
@@ -26,6 +27,8 @@ import org.forgerock.openam.cts.CoreTokenConfig;
 import org.forgerock.openam.rest.resource.SSOTokenContext;
 import org.forgerock.openam.utils.Config;
 import org.forgerock.util.promise.Promise;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -40,10 +43,22 @@ public class CoreTokenResourceAuthzModuleTest {
     SessionService mockService = mock(SessionService.class);
     CoreTokenConfig mockCoreTokenConfig = mock(CoreTokenConfig.class);
     Debug mockDebug = mock(Debug.class);
+    private SSOTokenContext mockSSOTokenContext;
 
     @BeforeTest
     public void beforeTest() {
         given(mockConfig.get()).willReturn(mockService);
+    }
+
+    @BeforeMethod
+    public void setup() {
+        mockSSOTokenContext = mock(SSOTokenContext.class);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        mockSSOTokenContext = null;
     }
 
     @Test
@@ -53,7 +68,6 @@ public class CoreTokenResourceAuthzModuleTest {
         given(mockCoreTokenConfig.isCoreTokenResourceEnabled()).willReturn(false);
         CoreTokenResourceAuthzModule testModule = new CoreTokenResourceAuthzModule(mockConfig, mockDebug,
                 mockCoreTokenConfig);
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
 
         //when
         Promise<AuthorizationResult, ResourceException> result = testModule.authorize(mockSSOTokenContext);
@@ -71,7 +85,6 @@ public class CoreTokenResourceAuthzModuleTest {
 
         CoreTokenResourceAuthzModule testModule = new CoreTokenResourceAuthzModule(mockConfig, mockDebug,
                 mockCoreTokenConfig);
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
 
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
@@ -93,7 +106,6 @@ public class CoreTokenResourceAuthzModuleTest {
         given(mockCoreTokenConfig.isCoreTokenResourceEnabled()).willReturn(true);
         CoreTokenResourceAuthzModule testModule = new CoreTokenResourceAuthzModule(mockConfig, mockDebug,
                 mockCoreTokenConfig);
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
 
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/session/SessionResourceV2Test.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/session/SessionResourceV2Test.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.core.rest.session;
@@ -104,6 +105,7 @@ public class SessionResourceV2Test {
         };
         sessionResource = new SessionResourceV2(ssoTokenManager, authUtilsWrapper,
                 sessionResourceUtil, sessionPropertyWhitelist, sessionService, partialSessionFactory);
+        given(mockContext.asContext(SSOTokenContext.class)).willReturn(mockContext);
         given(mockContext.getCallerSSOToken()).willReturn(ssoToken);
     }
 

--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -417,31 +417,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.hdrhistogram</groupId>
             <artifactId>HdrHistogram</artifactId>
         </dependency>

--- a/openam-core/src/test/java/com/iplanet/dpro/session/service/SessionServerConfigTest.java
+++ b/openam-core/src/test/java/com/iplanet/dpro/session/service/SessionServerConfigTest.java
@@ -1,37 +1,49 @@
 package com.iplanet.dpro.session.service;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
 import com.iplanet.am.util.SystemProperties;
 import com.iplanet.services.naming.WebtopNaming;
 import com.sun.identity.shared.Constants;
 import com.sun.identity.shared.debug.Debug;
 import org.forgerock.openam.session.SessionServiceURLService;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
+public class SessionServerConfigTest {
 
-@PrepareForTest({ SystemProperties.class, WebtopNaming.class })
-public class SessionServerConfigTest extends PowerMockTestCase {
+    private MockedStatic<SystemProperties> systemProperties;
+    private MockedStatic<WebtopNaming> webtopNaming;
+
+    @BeforeMethod
+    public void setup() {
+        this.systemProperties = mockStatic(SystemProperties.class);
+        this.webtopNaming = mockStatic(WebtopNaming.class);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        this.systemProperties.close();
+        this.webtopNaming.close();
+    }
 
     @Test
     public void localServerIsPrimaryServerIfNoSiteSetup() throws Exception {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get(Constants.AM_SERVER_PROTOCOL)).willReturn("http");
-        given(SystemProperties.get(Constants.AM_SERVER_HOST)).willReturn("openam.example.com");
-        given(SystemProperties.get(Constants.AM_SERVER_PORT)).willReturn("8080");
-        given(SystemProperties.get(Constants.AM_SERVICES_DEPLOYMENT_DESCRIPTOR)).willReturn("/openam");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_PROTOCOL)).thenReturn("http");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_HOST)).thenReturn("openam.example.com");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_PORT)).thenReturn("8080");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVICES_DEPLOYMENT_DESCRIPTOR)).thenReturn("/openam");
 
         String primary = "01";
-        PowerMockito.mockStatic(WebtopNaming.class);
-        given(WebtopNaming.getServerID("http", "openam.example.com", "8080", "/openam")).willReturn(primary);
-        given(WebtopNaming.getAMServerID()).willReturn("01");
-        given(WebtopNaming.getLocalServer()).willReturn("http://openam.example.com:8080/openam");
+        webtopNaming.when(() -> WebtopNaming.getServerID("http", "openam.example.com", "8080", "/openam")).thenReturn(primary);
+        webtopNaming.when(WebtopNaming::getAMServerID).thenReturn("01");
+        webtopNaming.when(WebtopNaming::getLocalServer).thenReturn("http://openam.example.com:8080/openam");
 
         // When
         SessionServerConfig config = new SessionServerConfig(mock(Debug.class), mock(SessionServiceURLService.class));
@@ -43,19 +55,17 @@ public class SessionServerConfigTest extends PowerMockTestCase {
     @Test
     public void localServerAndPrimaryServerDifferIfSiteSetup() throws Exception {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get(Constants.AM_SERVER_PROTOCOL)).willReturn("http");
-        given(SystemProperties.get(Constants.AM_SERVER_HOST)).willReturn("openam.example.com");
-        given(SystemProperties.get(Constants.AM_SERVER_PORT)).willReturn("8080");
-        given(SystemProperties.get(Constants.AM_SERVICES_DEPLOYMENT_DESCRIPTOR)).willReturn("/openam");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_PROTOCOL)).thenReturn("http");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_HOST)).thenReturn("openam.example.com");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVER_PORT)).thenReturn("8080");
+        systemProperties.when(() -> SystemProperties.get(Constants.AM_SERVICES_DEPLOYMENT_DESCRIPTOR)).thenReturn("/openam");
 
         String primary = "01";
-        PowerMockito.mockStatic(WebtopNaming.class);
-        given(WebtopNaming.getServerID("http", "openam.example.com", "8080", "/openam")).willReturn(primary);
-        given(WebtopNaming.isSiteEnabled(anyString())).willReturn(true); // enable site
-        given(WebtopNaming.getSiteID(anyString())).willReturn("02");
-        given(WebtopNaming.getAMServerID()).willReturn("01");
-        given(WebtopNaming.getLocalServer()).willReturn("http://openam.example.com:8080/openam");
+        webtopNaming.when(() -> WebtopNaming.getServerID("http", "openam.example.com", "8080", "/openam")).thenReturn(primary);
+        webtopNaming.when(() -> WebtopNaming.isSiteEnabled(anyString())).thenReturn(true); // enable site
+        webtopNaming.when(() -> WebtopNaming.getSiteID(anyString())).thenReturn("02");
+        webtopNaming.when(WebtopNaming::getAMServerID).thenReturn("01");
+        webtopNaming.when(WebtopNaming::getLocalServer).thenReturn("http://openam.example.com:8080/openam");
 
         // When
         SessionServerConfig config = new SessionServerConfig(mock(Debug.class), mock(SessionServiceURLService.class));

--- a/openam-core/src/test/java/org/forgerock/openam/cts/impl/LDAPConfigTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/impl/LDAPConfigTest.java
@@ -12,37 +12,44 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2017 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.cts.impl;
 
 import com.iplanet.am.util.SystemProperties;
 import org.forgerock.opendj.ldap.DN;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
 /**
  * @author robert.wapshott@forgerock.com
  */
-@PrepareForTest(SystemProperties.class)
-public class LDAPConfigTest extends PowerMockTestCase {
+public class LDAPConfigTest {
 
-    private LDAPConfig config;
+    private MockedStatic<SystemProperties> systemProperties;
+
+    @BeforeMethod
+    public void setup() {
+        this.systemProperties = mockStatic(SystemProperties.class);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        this.systemProperties.close();
+    }
 
     @Test
     public void shouldIndicateHasChanged() {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get("test-root-suffix")).willReturn("badger");
+        systemProperties.when(() -> SystemProperties.get("test-root-suffix")).thenReturn("badger");
 
         LDAPConfig config = new TestLDAPConfig();
 
@@ -53,8 +60,7 @@ public class LDAPConfigTest extends PowerMockTestCase {
     @Test
     public void shouldIndicateHasNotChanged() {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get("test-root-suffix")).willReturn(null);
+        systemProperties.when(() -> SystemProperties.get("test-root-suffix")).thenReturn(null);
 
         LDAPConfig config = new TestLDAPConfig();
 
@@ -65,8 +71,7 @@ public class LDAPConfigTest extends PowerMockTestCase {
     @Test
     public void shouldReturnDefaultRootSuffix() {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get("test-root-suffix")).willReturn(null);
+        systemProperties.when(() -> SystemProperties.get("test-root-suffix")).thenReturn(null);
 
         LDAPConfig config = new TestLDAPConfig();
 
@@ -80,8 +85,7 @@ public class LDAPConfigTest extends PowerMockTestCase {
     @Test
     public void shouldReturnExternalRootSuffix() {
         // Given
-        PowerMockito.mockStatic(SystemProperties.class);
-        given(SystemProperties.get("test-root-suffix")).willReturn("dc=google,dc=com");
+        systemProperties.when(() -> SystemProperties.get("test-root-suffix")).thenReturn("dc=google,dc=com");
 
         LDAPConfig config = new TestLDAPConfig();
 

--- a/openam-core/src/test/java/org/forgerock/openam/cts/worker/process/CTSWorkerBaseProcessTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/worker/process/CTSWorkerBaseProcessTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 package org.forgerock.openam.cts.worker.process;
 
@@ -19,6 +20,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.verify;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 
 import java.util.Arrays;
@@ -44,7 +46,7 @@ public class CTSWorkerBaseProcessTest {
     public void setUp() throws Exception {
         mockQuery = mock(CTSWorkerQuery.class);
         mockFilter = mock(CTSWorkerFilter.class);
-        mockProcess = mock(CTSWorkerBaseProcess.class);
+        mockProcess = spy(CTSWorkerBaseProcess.class);
     }
 
     @AfterMethod

--- a/openam-core/src/test/java/org/forgerock/openam/services/email/MailServerImplTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/services/email/MailServerImplTest.java
@@ -20,6 +20,7 @@
  * "Portions copyright [year] [name of copyright owner]"
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.openam.services.email;
@@ -29,10 +30,7 @@ import com.sun.identity.shared.debug.Debug;
 import com.sun.identity.sm.ServiceConfig;
 import com.sun.identity.sm.ServiceConfigManager;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.mail.MessagingException;
@@ -45,10 +43,11 @@ import java.util.Set;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class MailServerImplTest extends PowerMockTestCase {
+public class MailServerImplTest {
 
     private MailServerImpl mailServerMock;
     private AMSendMail sendMailMock;
@@ -90,10 +89,10 @@ public class MailServerImplTest extends PowerMockTestCase {
 
     @BeforeMethod
     public void setup(){
-        ServiceConfigManager serviceConfigManagerMock = PowerMockito.mock(ServiceConfigManager.class);
-        ServiceConfig serviceConfigMock = PowerMockito.mock(ServiceConfig.class);
-        Debug debugMock = PowerMockito.mock(Debug.class);
-        sendMailMock = PowerMockito.mock(AMSendMail.class);
+        ServiceConfigManager serviceConfigManagerMock = mock(ServiceConfigManager.class);
+        ServiceConfig serviceConfigMock = mock(ServiceConfig.class);
+        Debug debugMock = mock(Debug.class);
+        sendMailMock = mock(AMSendMail.class);
         Map<String, Set<String>> options = createOptionsMap();
         try{
             Mockito.doNothing().when(sendMailMock).postMail(eq(recipients), anyString(), anyString(), anyString());

--- a/openam-datastore/pom.xml
+++ b/openam-datastore/pom.xml
@@ -17,7 +17,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.wrensecurity.wrenam</groupId>
         <artifactId>wrenam-project</artifactId>
@@ -43,16 +43,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/GenericRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/GenericRepoTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 package org.forgerock.openam.idrepo.ldap;
 
@@ -34,7 +35,6 @@ import org.forgerock.openam.utils.MapHelper;
 import org.forgerock.opendj.ldap.Filter;
 import org.forgerock.opendj.ldap.ResultCode;
 import org.mockito.ArgumentCaptor;
-import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -679,7 +679,7 @@ public class GenericRepoTest extends IdRepoTestBase {
 
     @ Test (expectedExceptions = IllegalStateException.class)
     public void shouldThrowExceptionIfListenerAlreadyExists() {
-        IdRepoListener newIdRepoListener = PowerMockito.mock(IdRepoListener.class);
+        IdRepoListener newIdRepoListener = mock(IdRepoListener.class);
         idrepo.addListener(null, newIdRepoListener);
     }
 

--- a/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/PSearchRepoTest.java
+++ b/openam-datastore/src/test/java/org/forgerock/openam/idrepo/ldap/PSearchRepoTest.java
@@ -12,17 +12,17 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 package org.forgerock.openam.idrepo.ldap;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
 import com.sun.identity.idm.IdRepoListener;
 import org.forgerock.openam.utils.MapHelper;
-import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.testng.Assert.fail;
 
 
 public class PSearchRepoTest  extends IdRepoTestBase {
@@ -48,7 +48,7 @@ public class PSearchRepoTest  extends IdRepoTestBase {
 
     @Test(dependsOnMethods = "addListenerNoPSearch", expectedExceptions = IllegalStateException.class)
     public void exceptionListenerAlreadyExists() {
-        IdRepoListener newIdRepoListener = PowerMockito.mock(IdRepoListener.class);
+        IdRepoListener newIdRepoListener = mock(IdRepoListener.class);
         idrepo.addListener(null, newIdRepoListener);
     }
 

--- a/openam-entitlements/pom.xml
+++ b/openam-entitlements/pom.xml
@@ -109,21 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
             <type>test-jar</type>

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ApplicationV1FilterTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/ApplicationV1FilterTest.java
@@ -13,16 +13,19 @@
 *
 * Copyright 2015 ForgeRock AS.
 * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+* Portions Copyright 2023 Wren Security
 */
 package org.forgerock.openam.entitlement.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.forgerock.json.JsonValue.array;
+import static org.forgerock.json.JsonValue.field;
+import static org.forgerock.json.JsonValue.json;
+import static org.forgerock.json.JsonValue.object;
 import static org.forgerock.json.test.assertj.AssertJJsonValueAssert.assertThat;
-import static org.forgerock.json.JsonValue.*;
-import static org.mockito.BDDMockito.any;
-import static org.mockito.BDDMockito.anyCollectionOf;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -34,7 +37,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.security.auth.Subject;
-import org.forgerock.services.context.Context;
 import org.forgerock.json.JsonValue;
 import org.forgerock.json.resource.BadRequestException;
 import org.forgerock.json.resource.CreateRequest;
@@ -51,18 +53,16 @@ import org.forgerock.json.resource.UpdateRequest;
 import org.forgerock.openam.entitlement.ResourceType;
 import org.forgerock.openam.entitlement.configuration.SmsAttribute;
 import org.forgerock.openam.entitlement.guice.EntitlementRestGuiceModule;
-import org.forgerock.openam.entitlement.rest.ApplicationV1Filter;
-import org.forgerock.openam.entitlement.rest.ApplicationV1FilterTransformer;
-import org.forgerock.openam.entitlement.rest.EntitlementsExceptionMappingHandler;
 import org.forgerock.openam.entitlement.service.ApplicationService;
 import org.forgerock.openam.entitlement.service.ApplicationServiceFactory;
 import org.forgerock.openam.entitlement.service.ResourceTypeService;
-import org.forgerock.openam.forgerockrest.guice.ForgerockRestGuiceModule;
 import org.forgerock.openam.rest.resource.ContextHelper;
 import org.forgerock.openam.utils.CollectionUtils;
+import org.forgerock.services.context.Context;
 import org.forgerock.util.promise.Promise;
 import org.forgerock.util.query.QueryFilter;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -468,7 +468,7 @@ public class ApplicationV1FilterTest {
         // Then
         verify(requestHandler).handleQuery(eq(context), eq(queryRequest), queryResultHandlerCaptor.capture());
         verify(applicationTransformer).transform(eq(mockQueryResponse), eq(context), eq(queryRequest), eq(queryResultHandler),
-                anyCollectionOf(ResourceResponse.class));
+                ArgumentMatchers.<ResourceResponse>anyCollection());
     }
 
     /**

--- a/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyResourceEvaluationTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/entitlement/rest/PolicyResourceEvaluationTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions Copyright 2023 Wren Security
 */
 
 package org.forgerock.openam.entitlement.rest;
@@ -42,8 +43,6 @@ import org.forgerock.openam.entitlement.rest.model.json.PolicyRequest;
 import org.forgerock.openam.rest.RealmContext;
 import org.forgerock.openam.rest.resource.SubjectContext;
 import org.forgerock.util.promise.Promise;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -227,31 +226,4 @@ public class PolicyResourceEvaluationTest {
         return ClientContext.newInternalClientContext(new RealmContext(subjectContext, realm));
     }
 
-    /**
-     * Given a resource exception verifies that the code matches the expected code.
-     */
-    private final static class ResourceExceptionMatcher extends BaseMatcher<ResourceException> {
-
-        private final int expectedCode;
-
-        public ResourceExceptionMatcher(final int expectedCode) {
-            this.expectedCode = expectedCode;
-        }
-
-        @Override
-        public boolean matches(final Object o) {
-            if (!(o instanceof ResourceException)) {
-                return false;
-            }
-
-            ResourceException exception = (ResourceException)o;
-            return exception.getCode() == expectedCode;
-        }
-
-        @Override
-        public void describeTo(final Description description) {
-            description.appendText("Expected resource exception code was " + expectedCode);
-        }
-
-    }
 }

--- a/openam-entitlements/src/test/java/org/forgerock/openam/xacml/v3/rest/XacmlServiceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/xacml/v3/rest/XacmlServiceTest.java
@@ -38,15 +38,9 @@ import org.forgerock.openam.rest.representations.JacksonRepresentationFactory;
 import org.forgerock.openam.utils.JsonValueBuilder;
 import org.forgerock.openam.xacml.v3.DiffStatus;
 import org.forgerock.openam.xacml.v3.ImportStep;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import org.restlet.Request;
 import org.restlet.Response;
 import org.restlet.data.Disposition;
@@ -55,7 +49,8 @@ import org.restlet.data.Status;
 import org.restlet.ext.jackson.JacksonRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.resource.ResourceException;
-
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iplanet.sso.SSOException;
 import com.iplanet.sso.SSOToken;
@@ -69,8 +64,6 @@ import com.sun.identity.security.AdminTokenAction;
 import com.sun.identity.shared.Constants;
 import com.sun.identity.shared.debug.Debug;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({RestLog.class})
 public class XacmlServiceTest  {
 
     private static final ConcurrentMap<String, Object> REQUEST_ATTRIBUTES = new ConcurrentHashMap<String, Object>() {{
@@ -96,7 +89,7 @@ public class XacmlServiceTest  {
     private JacksonRepresentationFactory jacksonRepresentationFactory =
             new JacksonRepresentationFactory(new ObjectMapper());
 
-    @Before
+    @BeforeMethod
     public void setup() throws Exception {
         this.importExport = mock(XACMLExportImport.class);
         this.debug = mock(Debug.class);
@@ -353,7 +346,7 @@ public class XacmlServiceTest  {
 
     @Test
     public void testPermissionsCheckSuccess() {
-        RestLog restLog = PowerMockito.mock(RestLog.class);
+        RestLog restLog = mock(RestLog.class);
 
         DelegationEvaluator evaluator = mock(DelegationEvaluator.class);
         XacmlService xacmlService = new XacmlService(importExport, adminTokenAction, this.debug, restLog, evaluator,
@@ -385,7 +378,7 @@ public class XacmlServiceTest  {
 
     @Test
     public void testPermissionsCheckFail() {
-        RestLog restLog = PowerMockito.mock(RestLog.class);
+        RestLog restLog = mock(RestLog.class);
 
         DelegationEvaluator evaluator = mock(DelegationEvaluator.class);
         XacmlService xacmlService = new XacmlService(importExport, adminTokenAction, this.debug, restLog, evaluator,

--- a/openam-ldap-utils/src/main/java/org/forgerock/openam/ldap/LDAPRequests.java
+++ b/openam-ldap-utils/src/main/java/org/forgerock/openam/ldap/LDAPRequests.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.ldap;
@@ -239,7 +240,7 @@ public final class LDAPRequests {
      *
      * @see Requests#newModifyDNRequest(String, String)
      * @param name the DN of the entry to modify.
-     * @param newName the new DN of the entry.
+     * @param newName the new RDN of the entry.
      * @return the modify DN request.
      */
     public static ModifyDNRequest newModifyDNRequest(final String name, final String newName) {

--- a/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPRequestsTest.java
+++ b/openam-ldap-utils/src/test/java/org/forgerock/openam/ldap/LDAPRequestsTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.ldap;
@@ -74,7 +75,7 @@ public class LDAPRequestsTest {
                 { LDAPRequests.newAddRequest(Entries.makeEntry("dn: " + dn)) },
                 { LDAPRequests.newDeleteRequest(dn) },
                 { LDAPRequests.newDeleteRequest(DN.valueOf(dn)) },
-                { LDAPRequests.newModifyDNRequest(dn, "uid=test2,dc=example,dc=com") }
+                { LDAPRequests.newModifyDNRequest(dn, "uid=test2") }
         };
     }
 

--- a/openam-oauth2/pom.xml
+++ b/openam-oauth2/pom.xml
@@ -200,31 +200,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-reflect</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>

--- a/openam-oauth2/src/test/java/org/forgerock/oauth2/core/AuthorizationCodeGrantTypeHandlerTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/oauth2/core/AuthorizationCodeGrantTypeHandlerTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2021 Wren Security.
+ * Portions Copyright 2021-2023 Wren Security.
  */
 
 package org.forgerock.oauth2.core;
@@ -70,6 +70,8 @@ public class AuthorizationCodeGrantTypeHandlerTest {
 
         uris = mock(OAuth2Uris.class);
         given(urisFactory.get(any(OAuth2Request.class))).willReturn(uris);
+        given(tokenStore.createAccessToken(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
+                anySet(), any(), anyString(), anyString(), any())).willReturn(spy(AccessToken.class));
     }
 
     @Test (expectedExceptions = InvalidRequestException.class)
@@ -173,7 +175,7 @@ public class AuthorizationCodeGrantTypeHandlerTest {
         OAuth2Request request = mock(OAuth2Request.class);
         given(request.getParameter("code")).willReturn("abc123");
         ClientRegistration clientRegistration = mock(ClientRegistration.class);
-        AuthorizationCode authorizationCode = mock(AuthorizationCode.class);
+        AuthorizationCode authorizationCode = spy(new AuthorizationCode(null));
 
         given(uris.getTokenEndpoint()).willReturn("Token Endpoint");
         given(clientAuthenticator.authenticate(request, "Token Endpoint")).willReturn(clientRegistration);

--- a/openam-rest/pom.xml
+++ b/openam-rest/pom.xml
@@ -155,33 +155,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>httpunit</groupId>
             <artifactId>httpunit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng-common</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/RestLogTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/forgerockrest/utils/RestLogTest.java
@@ -12,9 +12,17 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.forgerockrest.utils;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 import com.sun.identity.log.Logger;
 import com.sun.identity.log.messageid.LogMessageProvider;
@@ -24,14 +32,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import javax.security.auth.Subject;
 import org.forgerock.json.resource.ResourceException;
-import org.forgerock.services.context.Context;
 import org.forgerock.openam.rest.resource.SSOTokenContext;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import org.forgerock.openam.rest.resource.SubjectContext;
+import org.forgerock.services.context.Context;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -132,6 +135,8 @@ public class RestLogTest {
         Subject subject = new Subject(false, princes, Collections.EMPTY_SET, Collections.EMPTY_SET);
 
         when(tokenContext.getCallerSubject()).thenReturn(subject);
+        when(tokenContext.containsContext(SubjectContext.class)).thenReturn(true);
+        when(tokenContext.asContext(SubjectContext.class)).thenReturn(tokenContext);
 
         return tokenContext;
     }

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/AdminOnlyAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/AdminOnlyAuthzModuleTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2015 ForgeRock AS.
+* Portions Copyright 2023 Wren Security
 */
 package org.forgerock.openam.rest.authz;
 
@@ -29,6 +30,8 @@ import org.forgerock.json.resource.ResourceException;
 import org.forgerock.openam.rest.resource.SSOTokenContext;
 import org.forgerock.openam.utils.Config;
 import org.forgerock.util.promise.Promise;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -36,6 +39,7 @@ public class AdminOnlyAuthzModuleTest {
 
     Config<SessionService> mockConfig = mock(Config.class);
     SessionService mockService = mock(SessionService.class);
+    private SSOTokenContext mockSSOTokenContext;
 
     public AdminOnlyAuthzModule testModule = new AdminOnlyAuthzModule(mockConfig, mock(Debug.class));
 
@@ -44,11 +48,21 @@ public class AdminOnlyAuthzModuleTest {
         given(mockConfig.get()).willReturn(mockService);
     }
 
+    @BeforeMethod
+    public void setup() {
+        mockSSOTokenContext = mock(SSOTokenContext.class);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        mockSSOTokenContext = null;
+    }
+
     @Test
     public void shouldAuthorizeValidContext() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
 
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
@@ -67,7 +81,6 @@ public class AdminOnlyAuthzModuleTest {
     public void shouldFailNonSuperUser() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
 
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
@@ -86,7 +99,6 @@ public class AdminOnlyAuthzModuleTest {
     public void shouldErrorInvalidContext() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
 
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/AgentOnlyAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/AgentOnlyAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 package org.forgerock.openam.rest.authz;
 
@@ -72,6 +73,7 @@ public class AgentOnlyAuthzModuleTest {
         MockitoAnnotations.initMocks(this);
         authzModule = new AgentOnlyAuthzModule(mockAgentIdentity, mockDebug);
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
         given(mockSSOToken.getPrincipal()).willReturn(mockPrincipal);
         given(mockPrincipal.getName()).willReturn("irrelevant");
     }

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/STSPublishServiceAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/STSPublishServiceAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.rest.authz;
@@ -83,6 +84,7 @@ public class STSPublishServiceAuthzModuleTest {
         given(mockConfig.get()).willReturn(mockService);
         testModule = new STSPublishServiceAuthzModule(mockConfig, mockAgentIdentity, mock(Debug.class));
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
         given(mockSSOToken.getProperty(Constants.UNIVERSAL_IDENTIFIER)).willReturn("test");
         given(mockSSOToken.getPrincipal()).willReturn(mockPrincipal);
         given(mockPrincipal.getName()).willReturn("irrelevant");

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/STSTokenGenerationServiceAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/STSTokenGenerationServiceAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.rest.authz;
@@ -87,6 +88,7 @@ public class STSTokenGenerationServiceAuthzModuleTest {
         MockitoAnnotations.initMocks(this);
         authzModule = new STSTokenGenerationServiceAuthzModule(mockConfig, mockAgentIdentity, mockSpecialUserIdentity, mockDebug);
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
         given(mockSSOToken.getPrincipal()).willReturn(mockPrincipal);
         given(mockPrincipal.getName()).willReturn("irrelevant");
         given(mockConfig.get()).willReturn(mockSessionService);

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/SpecialAndAdminUserOnlyAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/SpecialAndAdminUserOnlyAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.rest.authz;
@@ -60,6 +61,7 @@ public class SpecialAndAdminUserOnlyAuthzModuleTest {
     public void setup() throws SSOException {
         MockitoAnnotations.initMocks(this);
         given(mockSSOTokenContext.getCallerSSOToken()).willReturn(mockSSOToken);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
         given(mockSSOToken.getPrincipal()).willReturn(mockPrincipal);
         given(mockPrincipal.getName()).willReturn("irrelevant");
         authzModule = new SpecialAndAdminUserOnlyAuthzModule(mockConfig, mockSpecialUserIdentity, mock(Debug.class));

--- a/openam-rest/src/test/java/org/forgerock/openam/rest/authz/SpecialOrAdminOrAgentAuthzModuleTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/rest/authz/SpecialOrAdminOrAgentAuthzModuleTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 package org.forgerock.openam.rest.authz;
 
@@ -28,6 +29,8 @@ import org.forgerock.openam.forgerockrest.utils.SpecialUserIdentity;
 import org.forgerock.openam.rest.resource.SSOTokenContext;
 import org.forgerock.openam.utils.Config;
 import org.forgerock.util.promise.Promise;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -44,6 +47,7 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
     public SpecialOrAdminOrAgentAuthzModule testModule;
     private AgentIdentity mockAgentIdentity;
     private SpecialUserIdentity mockSpecialUserIdentity;
+    private SSOTokenContext mockSSOTokenContext;
 
     @BeforeTest
     public void beforeTest() {
@@ -55,11 +59,21 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
                 mock(Debug.class));
     }
 
+    @BeforeMethod
+    public void setup() {
+        mockSSOTokenContext = mock(SSOTokenContext.class);
+        given(mockSSOTokenContext.asContext(SSOTokenContext.class)).willReturn(mockSSOTokenContext);
+    }
+
+    @AfterMethod
+    public void cleanup() {
+        mockSSOTokenContext = null;
+    }
+
     @Test
     public void shouldAuthorizeAdmin() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
         Principal principal = mock(Principal.class);
         given(mockSSOToken.getPrincipal()).willReturn(principal);
@@ -82,7 +96,6 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
     public void shouldAuthorizeAgent() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
         Principal principal = mock(Principal.class);
         given(mockSSOToken.getPrincipal()).willReturn(principal);
@@ -105,7 +118,6 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
     public void shouldAuthorizeSpecialUser() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
         Principal principal = mock(Principal.class);
         given(mockSSOToken.getPrincipal()).willReturn(principal);
@@ -128,7 +140,6 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
     public void shouldFailNonAgentNonSuperUser() throws Exception {
 
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
         Principal principal = mock(Principal.class);
         given(mockSSOToken.getPrincipal()).willReturn(principal);
@@ -150,7 +161,6 @@ public class SpecialOrAdminOrAgentAuthzModuleTest {
     @Test
     public void shouldErrorInvalidContext() throws Exception {
         //given
-        SSOTokenContext mockSSOTokenContext = mock(SSOTokenContext.class);
         SSOToken mockSSOToken = mock(SSOToken.class);
         Principal principal = mock(Principal.class);
         given(mockSSOToken.getPrincipal()).willReturn(principal);

--- a/openam-restlet/pom.xml
+++ b/openam-restlet/pom.xml
@@ -102,6 +102,11 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
         </dependency>
@@ -112,33 +117,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>httpunit</groupId>
             <artifactId>httpunit</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng-common</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-uma/src/test/java/org/forgerock/openam/uma/rest/PendingRequestResourceTest.java
+++ b/openam-uma/src/test/java/org/forgerock/openam/uma/rest/PendingRequestResourceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.uma.rest;
@@ -194,6 +195,7 @@ public class PendingRequestResourceTest {
         Realm realm = realmTestHelper.mockRealm(realmName);
         RealmContext realmContext = mock(RealmContext.class);
         given(realmContext.getRealm()).willReturn(realm);
+        given(realmContext.asContext(RealmContext.class)).willReturn(realmContext);
         return realmContext;
     }
 

--- a/openam-uma/src/test/java/org/forgerock/openam/uma/rest/ResourceSetServiceTest.java
+++ b/openam-uma/src/test/java/org/forgerock/openam/uma/rest/ResourceSetServiceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.uma.rest;
@@ -155,6 +156,7 @@ public class ResourceSetServiceTest {
     private Context mockContext(String realmName) {
         Realm realm = realmTestHelper.mockRealm(realmName.substring(1));
         RealmContext realmContext = mock(RealmContext.class);
+        given(realmContext.asContext(RealmContext.class)).willReturn(realmContext);
         given(realmContext.getRealm()).willReturn(realm);
         return realmContext;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.6</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.7</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
 
         <!-- Source code has to be Java 8 compliant (code base is not JPMS ready) -->
@@ -141,15 +141,14 @@
 
         <!-- Wren Security Dependencies -->
         <wrends.version>5.0.0</wrends.version>
-        <wrensec-commons.version>22.5.0</wrensec-commons.version>
+        <wrensec-commons.version>22.6.0-SNAPSHOT</wrensec-commons.version>
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
         <wrensec-ui.version>22.1.2</wrensec-ui.version>
 
-        <mockito.version>3.12.4</mockito.version>
+        <mockito.version>5.5.0</mockito.version>
         <ant.contrib.version>1.0b3</ant.contrib.version>
         <guice.version>3.0</guice.version>
         <restlet.version>2.3.4</restlet.version>
-        <powermock.version>2.0.9</powermock.version>
         <slf4j.version>1.7.21</slf4j.version>
         <santuario.xmlsec.version>3.0.2</santuario.xmlsec.version>
         <click.version>2.3.0</click.version>
@@ -205,6 +204,7 @@
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version>
         <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
     </properties>
 
     <modules>
@@ -267,7 +267,6 @@
                 <type>pom</type>
             </dependency>
 
-            <!-- We need to downgrade Mockito version because PowerMock is not compatible with 4+ -->
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
@@ -1042,25 +1041,6 @@
                 <version>3.2</version>
                 <scope>test</scope>
             </dependency>
-            <!-- Powermock -->
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-support</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-easymock</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>httpunit</groupId>
                 <artifactId>httpunit</artifactId>
@@ -1078,36 +1058,6 @@
                         <artifactId>servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-core</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-reflect</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng-common</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>javassist</groupId>
@@ -1148,6 +1098,12 @@
                 <groupId>org.wrensecurity.wrenam</groupId>
                 <artifactId>openam-time-travel</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <!-- Needed to override version from org.restlet.ext.jackson -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
I have upgraded the version of `wrensec-commons` to the latest SNAPSHOT with upgraded `TestNG` and `Jackson` dependencies. The `PowerMock` library is not compatible with TestNG 7.5.0+ and does not appear to be maintained anymore. So I have removed the PowerMock library from the repository.

I have successfully run our tests from the `wrenam-test` repository using the newly built version.