### PR TITLE
Cleanup and upgrade dependencies to fix various CVEs

### DIFF
--- a/openam-audit/openam-audit-configuration/pom.xml
+++ b/openam-audit/openam-audit-configuration/pom.xml
@@ -79,6 +79,7 @@
         </dependency>
 
         <!-- Test Dependencies -->
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/openam-audit/openam-audit-context/pom.xml
+++ b/openam-audit/openam-audit-context/pom.xml
@@ -43,10 +43,15 @@
             <artifactId>forgerock-audit-core</artifactId>
         </dependency>
 
+        <!-- XXX This can be removed when Commons switches to Jakarta as well -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-audit/openam-audit-core/pom.xml
+++ b/openam-audit/openam-audit-core/pom.xml
@@ -54,9 +54,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-adaptive/pom.xml
+++ b/openam-authentication/openam-auth-adaptive/pom.xml
@@ -36,9 +36,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-application/pom.xml
+++ b/openam-authentication/openam-auth-application/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-cert/pom.xml
+++ b/openam-authentication/openam-auth-cert/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-common/pom.xml
+++ b/openam-authentication/openam-auth-common/pom.xml
@@ -36,14 +36,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.security.auth.message</artifactId>
+            <groupId>jakarta.security.auth.message</groupId>
+            <artifactId>jakarta.security.auth.message-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-fr-oath/pom.xml
+++ b/openam-authentication/openam-auth-fr-oath/pom.xml
@@ -42,9 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-hotp/pom.xml
+++ b/openam-authentication/openam-auth-hotp/pom.xml
@@ -31,14 +31,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-httpbasic/pom.xml
+++ b/openam-authentication/openam-auth-httpbasic/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-msisdn/pom.xml
+++ b/openam-authentication/openam-auth-msisdn/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-oath/pom.xml
+++ b/openam-authentication/openam-auth-oath/pom.xml
@@ -37,9 +37,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-oauth2/pom.xml
+++ b/openam-authentication/openam-auth-oauth2/pom.xml
@@ -42,9 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-oidc/pom.xml
+++ b/openam-authentication/openam-auth-oidc/pom.xml
@@ -46,9 +46,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-persistentcookie/pom.xml
+++ b/openam-authentication/openam-auth-persistentcookie/pom.xml
@@ -41,11 +41,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/openam-authentication/openam-auth-push/pom.xml
+++ b/openam-authentication/openam-auth-push/pom.xml
@@ -40,9 +40,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-saml2/pom.xml
+++ b/openam-authentication/openam-auth-saml2/pom.xml
@@ -46,9 +46,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-authentication/openam-auth-scripted/pom.xml
+++ b/openam-authentication/openam-auth-scripted/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -55,11 +54,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-authentication/openam-auth-windowsdesktopsso/pom.xml
+++ b/openam-authentication/openam-auth-windowsdesktopsso/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-cli/openam-cli-impl/pom.xml
+++ b/openam-cli/openam-cli-impl/pom.xml
@@ -53,9 +53,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-common-auth-ui/pom.xml
+++ b/openam-common-auth-ui/pom.xml
@@ -31,14 +31,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-console/pom.xml
+++ b/openam-console/pom.xml
@@ -37,13 +37,6 @@
                 <artifactId>maven-war-plugin</artifactId>
 
                 <configuration>
-                    <packagingExcludes>
-                        WEB-INF/lib/jersey-core-1.1.5.2.jar,
-                        WEB-INF/lib/jaxb-api-1.0.6.jar,
-                        WEB-INF/lib/jaxb-libs-1.0.6.jar,
-                        WEB-INF/lib/jaxb-xjc-1.0.6.jar,
-                    </packagingExcludes>
-
                     <archive>
                         <manifestEntries>
                             <Specification-Title>Wren:AM Admin Console</Specification-Title>
@@ -168,14 +161,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-core-rest/pom.xml
+++ b/openam-core-rest/pom.xml
@@ -65,9 +65,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-core/pom.xml
+++ b/openam-core/pom.xml
@@ -324,8 +324,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
 
         <dependency>
@@ -359,24 +359,23 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
 
         <dependency>
@@ -407,13 +406,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
         </dependency>
 
         <dependency>
-             <groupId>org.easytesting</groupId>
-             <artifactId>fest-assert</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-dashboard/pom.xml
+++ b/openam-dashboard/pom.xml
@@ -52,9 +52,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-distribution/openam-distribution-ssoadmintools/pom.xml
+++ b/openam-distribution/openam-distribution-ssoadmintools/pom.xml
@@ -35,11 +35,11 @@
             opendj-server,forgerock-util,json,xmlsec,openam-core,
             openam-entitlements,openam-shared,openam-dtd-schema,openam-license-manager-cli,openam-license-core,
             openam-audit-context,wrensec-guice-core,wrensec-guava-base,wrensec-guava-collect,
-            guice,guice-assistedinject,commons-lang,commons-collections,org.apache.servicemix.bundles.javax-inject,
+            guice,guice-assistedinject,commons-lang,commons-collections,jakarta.inject-api,
             slf4j-api,slf4j-nop,opendj-core,opendj-grizzly,i18n-core,openam-ldap-utils,grizzly-framework,
             forgerock-audit-core,openam-audit-configuration,i18n-slf4j,
             opendj-server-legacy,opendj-config,opendj-cli,chf-http-core,joda-time,
-            jackson-core,jackson-databind,jackson-annotations,jaxb-api
+            jackson-core,jackson-databind,jackson-annotations,jakarta.xml.bind-api
         </setupArtifactIDs>
     </properties>
 
@@ -247,9 +247,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>
@@ -291,8 +295,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-distribution/openam-distribution-ssoadmintools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
+++ b/openam-distribution/openam-distribution-ssoadmintools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
@@ -22,7 +22,7 @@
 * your own identifying information:
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
-* Portions Copyrighted 2022 Wren Security
+* Portions Copyrighted 2022-2023 Wren Security
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -62,12 +62,12 @@
                 <include>org.wrensecurity.wrenam:openam-ldap-utils</include>
                 <include>org.wrensecurity.wrenam:openam-audit-context</include>
                 <include>org.forgerock.commons:json-resource</include>
-                <include>javax.inject:javax.inject</include>
+                <include>jakarta.inject:jakarta.inject-api</include>
                 <include>com.google.inject:guice:jar:no_aop</include>
                 <include>com.google.inject.extensions:guice-assistedinject</include>
                 <include>commons-lang:commons-lang</include>
                 <include>commons-collections:commons-collections</include>
-                <include>javax.xml:jaxrpc-api</include>
+                <include>jakarta.xml.rpc:jakarta.xml.rpc-api</include>
                 <include>external:jaxrpc-impl</include>
                 <include>com.sun.xml.rpc:jaxrpc-spi</include>
                 <include>org.json:json</include>
@@ -75,7 +75,7 @@
                 <include>org.codehaus.jackson:jackson-mapper-asl</include>
                 <include>org.codehaus.jackson:jackson-databind</include>
                 <include>external:jsr173_api</include>
-                <include>javax.mail:mail</include>
+                <include>jakarta.mail:jakarta.mail-api</include>
                 <include>relaxngDatatype:relaxngDatatype</include>
                 <include>external:webservices-api</include>
                 <include>external:webservices-rt</include>
@@ -99,7 +99,7 @@
             <outputDirectory>lib</outputDirectory>
             <scope>provided</scope>
             <includes>
-                <include>javax.servlet:servlet-api</include>
+                <include>jakarta.servlet:jakarta.servlet-api</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
+++ b/openam-distribution/openam-distribution-ssoconfiguratortools/src/main/assembly/openAMToolsAssembly_Descriptor.xml
@@ -23,6 +23,7 @@
 * your own identifying information:
 * "Portions Copyrighted [year] [name of copyright owner]"
 *
+* Portions Copyrighted 2023 Wren Security
 -->
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
     <id>openam-ssoConfiguratorTools</id>
@@ -42,7 +43,8 @@
                 <include>com.google.inject:guice:jar:no_aop</include>
                 <include>org.wrensecurity.commons:wrensec-guice-core</include>
                 <include>org.wrensecurity.wrenam:openam-license-manager-cli</include>
-                <include>org.apache.servicemix.bundles:org.apache.servicemix.bundles.javax-inject</include>
+                <include>jakarta.inject:jakarta.inject-api</include>
+                <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.slf4j:slf4j-nop</include>
                 <include>commons-lang:commons-lang</include>

--- a/openam-entitlements/pom.xml
+++ b/openam-entitlements/pom.xml
@@ -72,9 +72,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -88,13 +87,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-entitlements/src/test/java/org/forgerock/openam/xacml/v3/rest/XacmlServiceTest.java
+++ b/openam-entitlements/src/test/java/org/forgerock/openam/xacml/v3/rest/XacmlServiceTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security
  */
 
 package org.forgerock.openam.xacml.v3.rest;
@@ -230,7 +231,7 @@ public class XacmlServiceTest  {
             fail("Expect exception");
         } catch (ResourceException e) {
             assertThat(e.getStatus().getCode()).isEqualTo(BAD_REQUEST);
-            assertThat(e.getMessage()).isEqualTo("No policies found in XACML document");
+            assertThat(e.getMessage()).startsWith("No policies found in XACML document");
         }
     }
 
@@ -251,7 +252,7 @@ public class XacmlServiceTest  {
             fail("Expect exception");
         } catch (ResourceException e) {
             assertThat(e.getStatus().getCode()).isEqualTo(BAD_REQUEST);
-            assertThat(e.getMessage()).isEqualTo("JSON Exception.");
+            assertThat(e.getMessage()).startsWith("JSON Exception.");
         }
     }
 
@@ -340,7 +341,7 @@ public class XacmlServiceTest  {
             fail("Expect exception");
         } catch (ResourceException e) {
             assertThat(e.getStatus().getCode()).isEqualTo(INTERNAL_ERROR);
-            assertThat(e.getMessage()).isEqualTo("JSON Exception.");
+            assertThat(e.getMessage()).startsWith("JSON Exception.");
         }
     }
 

--- a/openam-examples/openam-example-clientsdk-cli/pom.xml
+++ b/openam-examples/openam-example-clientsdk-cli/pom.xml
@@ -65,9 +65,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-examples/openam-example-clientsdk-war/pom.xml
+++ b/openam-examples/openam-example-clientsdk-war/pom.xml
@@ -99,9 +99,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-federation/OpenFM/pom.xml
+++ b/openam-federation/OpenFM/pom.xml
@@ -145,9 +145,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-federation/openam-federation-library/pom.xml
+++ b/openam-federation/openam-federation-library/pom.xml
@@ -191,6 +191,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.santuario</groupId>
        	    <artifactId>xmlsec</artifactId>
         </dependency>
@@ -201,21 +206,20 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
+            <groupId>jakarta.xml.rpc</groupId>
+            <artifactId>jakarta.xml.rpc-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-bundle</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>external</groupId>
             <artifactId>esapiport</artifactId>
@@ -225,18 +229,13 @@
             <groupId>com.sun.xml.rpc</groupId>
             <artifactId>jaxrpc-impl</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wrensecurity.wrenam</groupId>
             <artifactId>openam-idpdiscovery</artifactId>
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-        </dependency>
-        
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>

--- a/openam-federation/openam-fedlet-unconfigured-war/pom.xml
+++ b/openam-federation/openam-fedlet-unconfigured-war/pom.xml
@@ -228,8 +228,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-federation/openam-idpdiscovery-war/pom.xml
+++ b/openam-federation/openam-idpdiscovery-war/pom.xml
@@ -89,9 +89,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-federation/openam-idpdiscovery/pom.xml
+++ b/openam-federation/openam-idpdiscovery/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-notifications-integration/pom.xml
+++ b/openam-notifications-integration/pom.xml
@@ -52,8 +52,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-notifications-websocket/pom.xml
+++ b/openam-notifications-websocket/pom.xml
@@ -50,8 +50,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-notifications/pom.xml
+++ b/openam-notifications/pom.xml
@@ -39,8 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-oauth2-saml2/pom.xml
+++ b/openam-oauth2-saml2/pom.xml
@@ -47,9 +47,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-oauth2/pom.xml
+++ b/openam-oauth2/pom.xml
@@ -56,9 +56,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -77,8 +76,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>
@@ -135,6 +134,7 @@
         <dependency>
             <groupId>org.restlet.jee</groupId>
             <artifactId>org.restlet.ext.freemarker</artifactId>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.freemarker</groupId>
@@ -152,11 +152,6 @@
             <groupId>org.wrensecurity.wrenam</groupId>
             <artifactId>openam-restlet</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
         </dependency>
 
         <dependency>
@@ -200,8 +195,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javassist</groupId>
+            <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-plugins/openam-auth-postauthentication/pom.xml
+++ b/openam-plugins/openam-auth-postauthentication/pom.xml
@@ -36,9 +36,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-push-notification/pom.xml
+++ b/openam-push-notification/pom.xml
@@ -64,8 +64,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/openam-radius/openam-radius-server/pom.xml
+++ b/openam-radius/openam-radius-server/pom.xml
@@ -46,15 +46,14 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons.guava</groupId>
             <artifactId>wrensec-guava-eventbus</artifactId>
-        </dependency>      
+        </dependency>
     </dependencies>
 
     <build>
@@ -105,7 +104,7 @@
                          </configuration>
                      </execution>
                  </executions>
-             </plugin>         
+             </plugin>
         </plugins>
     </build>
 </project>

--- a/openam-rest/pom.xml
+++ b/openam-rest/pom.xml
@@ -31,9 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -149,20 +148,20 @@
             <artifactId>fest-assert</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.easymock</groupId>-->
+<!--            <artifactId>easymock</artifactId>-->
+<!--        </dependency>-->
 
-        <dependency>
-            <groupId>httpunit</groupId>
-            <artifactId>httpunit</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>httpunit</groupId>-->
+<!--            <artifactId>httpunit</artifactId>-->
+<!--        </dependency>-->
 
-        <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty-servlet-tester</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.mortbay.jetty</groupId>-->
+<!--            <artifactId>jetty-servlet-tester</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.wrensecurity.wrenam</groupId>
@@ -171,8 +170,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-restlet/pom.xml
+++ b/openam-restlet/pom.xml
@@ -32,9 +32,8 @@
     <dependencies>
         <!-- Java EE -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -111,20 +110,20 @@
             <artifactId>fest-assert</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.easymock</groupId>-->
+<!--            <artifactId>easymock</artifactId>-->
+<!--        </dependency>-->
 
-        <dependency>
-            <groupId>httpunit</groupId>
-            <artifactId>httpunit</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>httpunit</groupId>-->
+<!--            <artifactId>httpunit</artifactId>-->
+<!--        </dependency>-->
 
-        <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty-servlet-tester</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.mortbay.jetty</groupId>-->
+<!--            <artifactId>jetty-servlet-tester</artifactId>-->
+<!--        </dependency>-->
 
         <dependency>
             <groupId>org.wrensecurity.wrenam</groupId>
@@ -133,8 +132,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-samples/custom-authentication-module/pom.xml
+++ b/openam-samples/custom-authentication-module/pom.xml
@@ -35,16 +35,16 @@
             <artifactId>openam-core</artifactId>
             <version>${openam.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.wrensecurity.wrenam</groupId>
             <artifactId>openam-shared</artifactId>
             <version>${openam.version}</version>
         </dependency>
+
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/openam-schema/openam-idsvcs-schema/pom.xml
+++ b/openam-schema/openam-idsvcs-schema/pom.xml
@@ -104,26 +104,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb1-impl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.xml.soap</groupId>
-            <artifactId>jakarta.xml.soap-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.sun.xml.rpc</groupId>
             <artifactId>jaxrpc-spi</artifactId>
         </dependency>
@@ -135,7 +115,7 @@
 
         <dependency>
             <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
+            <artifactId>jakarta.mail</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-jaxrpc-schema/pom.xml
+++ b/openam-schema/openam-jaxrpc-schema/pom.xml
@@ -108,9 +108,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-federation-library</artifactId>
-            <version>${project.version}</version>
+            <groupId>com.sun.xml.rpc</groupId>
+            <artifactId>jaxrpc-impl</artifactId>
         </dependency>
 
         <dependency>
@@ -119,23 +118,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb1-impl</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml</groupId>
-            <artifactId>jaxrpc-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sun.xml.rpc</groupId>
-            <artifactId>jaxrpc-impl</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-federation-library</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-liberty-schema/pom.xml
+++ b/openam-schema/openam-liberty-schema/pom.xml
@@ -29,55 +29,73 @@
     <name>Wren:AM - Liberty Schema</name>
     <description>Wren:AM Liberty Schema Components</description>
 
-    <build>
-        <plugins>
-<!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jaxb2-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>xjc-liberty</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                    </execution>
-               </executions>
-               <configuration>
-                    <extension>true</extension>
-                    <nv>true</nv>
-                    <schemaFiles>
-						lib-id-sis-pp.xsd,
-						lib-arch-metadata.xsd,
-						idff-entity-config-schema.xsd,
-						lib-arch-disco-svc.xsd,
-						lib-arch-interact-svc.xsd,
-						lib-arch-paos.xsd,
-						lib-arch-soap-binding.xsd,
-						lib-arch-security-fmwk.xsd,
-						secext.xsd,
-						discoentry.xsd,
-						ppextension.xsd,
-						lib-idwsf-authn-svc.xsd,
-						liberty-idwsf-disco-svc-v1.1.xsd,
-						liberty-idwsf-soap-binding-v1.1.xsd
-                    </schemaFiles>
-               </configuration>
-           </plugin>
--->
-        </plugins>
-    </build>
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.codehaus.mojo</groupId>-->
+<!--                <artifactId>jaxb2-maven-plugin</artifactId>-->
 
-    
+<!--                <dependencies>-->
+<!--                     https://github.com/eclipse-ee4j/jaxb-ri/issues/1287 -->
+<!--                    <dependency>-->
+<!--                        <groupId>com.sun.xml.bind</groupId>-->
+<!--                        <artifactId>jaxb-impl</artifactId>-->
+<!--                        <version>${jaxb-impl.version}</version>-->
+<!--                    </dependency>-->
+
+<!--                    <dependency>-->
+<!--                        <groupId>org.glassfish.jaxb</groupId>-->
+<!--                        <artifactId>jaxb-jxc</artifactId>-->
+<!--                        <version>2.3.8</version>-->
+<!--                    </dependency>-->
+
+<!--                    <dependency>-->
+<!--                        <groupId>org.glassfish.jaxb</groupId>-->
+<!--                        <artifactId>jaxb-xjc</artifactId>-->
+<!--                        <version>2.3.8</version>-->
+<!--                    </dependency>-->
+<!--                </dependencies>-->
+
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>xjc-saml2</id>-->
+
+<!--                        <goals>-->
+<!--                            <goal>xjc</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+
+<!--                <configuration>-->
+<!--                    <extension>true</extension>-->
+<!--                    <laxSchemaValidation>true</laxSchemaValidation>-->
+
+<!--                    <sources>-->
+<!--                        <source>src/main/xsd/lib-id-sis-pp.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-metadata.xsd</source>-->
+<!--                        <source>src/main/xsd/idff-entity-config-schema.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-disco-svc.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-interact-svc.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-paos.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-soap-binding.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-arch-security-fmwk.xsd</source>-->
+<!--                        <source>src/main/xsd/secext.xsd</source>-->
+<!--                        <source>src/main/xsd/discoentry.xsd</source>-->
+<!--                        <source>src/main/xsd/ppextension.xsd</source>-->
+<!--                        <source>src/main/xsd/lib-idwsf-authn-svc.xsd</source>-->
+<!--                        <source>src/main/xsd/liberty-idwsf-disco-svc-v1.1.xsd</source>-->
+<!--                        <source>src/main/xsd/liberty-idwsf-soap-binding-v1.1.xsd</source>-->
+<!--                        <source>src/main/xsd/liberty-idwsf-soap-binding-v1.1.xsd</source>-->
+<!--                    </sources>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
+
     <dependencies>
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-shared</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
 
         <dependency>
@@ -86,13 +104,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>com.sun.msv.datatype.xsd</groupId>
+            <artifactId>xsdlib</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.sun.msv.datatype.xsd</groupId>
-            <artifactId>xsdlib</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-shared</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-liberty-schema/src/main/java/com/sun/xml/bind/Messages.java
+++ b/openam-schema/openam-liberty-schema/src/main/java/com/sun/xml/bind/Messages.java
@@ -1,0 +1,124 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package com.sun.xml.bind;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+/**
+ * Formats error messages.
+ *
+ * @since 1.0
+ */
+// Wren:AM This is a monkey patch for generated classes that use this jaxb1-impl class
+// whilst there is private enum with the same coordinates in jaxb-impl.
+public class Messages
+{
+    public static String format( String property ) {
+        return format( property, null );
+    }
+    
+    public static String format( String property, Object arg1 ) {
+        return format( property, new Object[]{arg1} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2 ) {
+        return format( property, new Object[]{arg1,arg2} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2, Object arg3 ) {
+        return format( property, new Object[]{arg1,arg2,arg3} );
+    }
+    
+    // add more if necessary.
+    
+    /** Loads a string resource and formats it with specified arguments. */
+    public static String format( String property, Object[] args ) {
+        String text = ResourceBundle.getBundle(Messages.class.getName()).getString(property);
+        return MessageFormat.format(text,args);
+    }
+    
+//
+//
+// Message resources
+//
+//
+    public static final String CI_NOT_NULL= // 0 args
+        "DefaultJAXBContextImpl.CINotNull";
+       
+    public static final String CI_CI_NOT_NULL = // 0 args
+        "DefaultJAXBContextImpl.CICINotNull";
+        
+    public static final String NO_BGM = // 1 arg
+        "GrammarInfo.NoBGM";
+        
+    public static final String UNABLE_TO_READ_BGM = // 0 args
+        "GrammarInfo.UnableToReadBGM";
+
+    public static final String COLLISION_DETECTED = // 2 args
+        "GrammarInfoFacade.CollisionDetected";
+
+    public static final String INCOMPATIBLE_VERSION = // 3 args
+        "GrammarInfoFacade.IncompatibleVersion";
+
+    public static final String MISSING_INTERFACE = // 1 arg
+        "ImplementationRegistry.MissingInterface";
+
+    public static final String BUILD_ID = // 0 args
+        "DefaultJAXBContextImpl.buildID";
+    
+    public static final String INCORRECT_VERSION =
+        "ContextFactory.IncorrectVersion";
+
+    public static final String ERR_TYPE_MISMATCH = // arg:3 since JAXB 1.0.3
+        "Util.TypeMismatch";
+    
+/*        
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+  */      
+}

--- a/openam-schema/openam-mib-schema/pom.xml
+++ b/openam-schema/openam-mib-schema/pom.xml
@@ -132,13 +132,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-shared</artifactId>
+            <groupId>external</groupId>
+            <artifactId>jdmkrt</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>external</groupId>
-            <artifactId>jdmkrt</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-shared</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-saml2-schema/pom.xml
+++ b/openam-schema/openam-saml2-schema/pom.xml
@@ -29,48 +29,45 @@
     <name>Wren:AM - SAML2 Schema</name>
     <description>Wren:AM SAML2 Schema Components</description>
 
-    <build>
-        <plugins>
-<!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jaxb2-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>xjc-saml2</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                    </execution>
-               </executions>
-               <configuration>
-                    <extension>true</extension>
-                    <schemaFiles>
-						entity-config-schema.xsd,
-						saml-schema-assertion-2.0.xsd,
-						saml-schema-metadata-2.0.xsd,
-						schema.xsd,
-						sstc-saml-metadata-ext-query.xsd,
-						sstc-saml-metadata-x509-query.xsd,
-						sstc-metadata-attr.xsd,
-						sstc-saml-attribute-ext.xsd,
-						sstc-saml-idp-discovery.xsd
-                    </schemaFiles>
-               </configuration>
-           </plugin>
--->
-        </plugins>
-    </build>
-    
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.codehaus.mojo</groupId>-->
+<!--                <artifactId>jaxb2-maven-plugin</artifactId>-->
+
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>xjc-saml2</id>-->
+
+<!--                        <goals>-->
+<!--                            <goal>xjc</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+
+<!--                <configuration>-->
+<!--                    <extension>true</extension>-->
+
+<!--                    <sources>-->
+<!--                        <source>src/main/xsd/entity-config-schema.xsd</source>-->
+<!--                        <source>src/main/xsd/saml-schema-assertion-2.0.xsd</source>-->
+<!--                        <source>src/main/xsd/saml-schema-metadata-2.0.xsd</source>-->
+<!--                        <source>src/main/xsd/schema.xsd</source>-->
+<!--                        <source>src/main/xsd/sstc-saml-metadata-ext-query.xsd</source>-->
+<!--                        <source>src/main/xsd/sstc-saml-metadata-x509-query.xsd</source>-->
+<!--                        <source>src/main/xsd/sstc-metadata-attr.xsd</source>-->
+<!--                        <source>src/main/xsd/sstc-saml-attribute-ext.xsd</source>-->
+<!--                        <source>src/main/xsd/sstc-saml-idp-discovery.xsd</source>-->
+<!--                    </sources>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
+
     <dependencies>
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-shared</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
 
         <dependency>
@@ -79,8 +76,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-shared</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-saml2-schema/src/main/java/com/sun/xml/bind/Messages.java
+++ b/openam-schema/openam-saml2-schema/src/main/java/com/sun/xml/bind/Messages.java
@@ -1,0 +1,124 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package com.sun.xml.bind;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+/**
+ * Formats error messages.
+ *
+ * @since 1.0
+ */
+// Wren:AM This is a monkey patch for generated classes that use this jaxb1-impl class
+// whilst there is private enum with the same coordinates in jaxb-impl.
+public class Messages
+{
+    public static String format( String property ) {
+        return format( property, null );
+    }
+    
+    public static String format( String property, Object arg1 ) {
+        return format( property, new Object[]{arg1} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2 ) {
+        return format( property, new Object[]{arg1,arg2} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2, Object arg3 ) {
+        return format( property, new Object[]{arg1,arg2,arg3} );
+    }
+    
+    // add more if necessary.
+    
+    /** Loads a string resource and formats it with specified arguments. */
+    public static String format( String property, Object[] args ) {
+        String text = ResourceBundle.getBundle(Messages.class.getName()).getString(property);
+        return MessageFormat.format(text,args);
+    }
+    
+//
+//
+// Message resources
+//
+//
+    public static final String CI_NOT_NULL= // 0 args
+        "DefaultJAXBContextImpl.CINotNull";
+       
+    public static final String CI_CI_NOT_NULL = // 0 args
+        "DefaultJAXBContextImpl.CICINotNull";
+        
+    public static final String NO_BGM = // 1 arg
+        "GrammarInfo.NoBGM";
+        
+    public static final String UNABLE_TO_READ_BGM = // 0 args
+        "GrammarInfo.UnableToReadBGM";
+
+    public static final String COLLISION_DETECTED = // 2 args
+        "GrammarInfoFacade.CollisionDetected";
+
+    public static final String INCOMPATIBLE_VERSION = // 3 args
+        "GrammarInfoFacade.IncompatibleVersion";
+
+    public static final String MISSING_INTERFACE = // 1 arg
+        "ImplementationRegistry.MissingInterface";
+
+    public static final String BUILD_ID = // 0 args
+        "DefaultJAXBContextImpl.buildID";
+    
+    public static final String INCORRECT_VERSION =
+        "ContextFactory.IncorrectVersion";
+
+    public static final String ERR_TYPE_MISMATCH = // arg:3 since JAXB 1.0.3
+        "Util.TypeMismatch";
+    
+/*        
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+  */      
+}

--- a/openam-schema/openam-wsfederation-schema/pom.xml
+++ b/openam-schema/openam-wsfederation-schema/pom.xml
@@ -29,38 +29,32 @@
     <name>Wren:AM - WS Federation Schema</name>
     <description>Wren:AM Schemata Components</description>
 
-    <build>
-        <plugins>
-<!--
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jaxb2-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>xjc-wsfederation</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                    </execution>
-               </executions>
-               <configuration>
-                    <extension>true</extension>
-               </configuration>
-           </plugin>
--->
-        </plugins>
-    </build>
+<!--    <build>-->
+<!--        <plugins>-->
+<!--            <plugin>-->
+<!--                <groupId>org.codehaus.mojo</groupId>-->
+<!--                <artifactId>jaxb2-maven-plugin</artifactId>-->
 
-    
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>xjc-wsfederation</id>-->
+<!--                        <goals>-->
+<!--                            <goal>xjc</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+
+<!--                <configuration>-->
+<!--                    <extension>true</extension>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
+<!--        </plugins>-->
+<!--    </build>-->
+
     <dependencies>
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-shared</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
 
         <dependency>
@@ -69,8 +63,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-shared</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-schema/openam-wsfederation-schema/src/main/java/com/sun/xml/bind/Messages.java
+++ b/openam-schema/openam-wsfederation-schema/src/main/java/com/sun/xml/bind/Messages.java
@@ -1,0 +1,124 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 1997-2011 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+
+package com.sun.xml.bind;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+/**
+ * Formats error messages.
+ *
+ * @since 1.0
+ */
+// Wren:AM This is a monkey patch for generated classes that use this jaxb1-impl class
+// whilst there is private enum with the same coordinates in jaxb-impl.
+public class Messages
+{
+    public static String format( String property ) {
+        return format( property, null );
+    }
+    
+    public static String format( String property, Object arg1 ) {
+        return format( property, new Object[]{arg1} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2 ) {
+        return format( property, new Object[]{arg1,arg2} );
+    }
+    
+    public static String format( String property, Object arg1, Object arg2, Object arg3 ) {
+        return format( property, new Object[]{arg1,arg2,arg3} );
+    }
+    
+    // add more if necessary.
+    
+    /** Loads a string resource and formats it with specified arguments. */
+    public static String format( String property, Object[] args ) {
+        String text = ResourceBundle.getBundle(Messages.class.getName()).getString(property);
+        return MessageFormat.format(text,args);
+    }
+    
+//
+//
+// Message resources
+//
+//
+    public static final String CI_NOT_NULL= // 0 args
+        "DefaultJAXBContextImpl.CINotNull";
+       
+    public static final String CI_CI_NOT_NULL = // 0 args
+        "DefaultJAXBContextImpl.CICINotNull";
+        
+    public static final String NO_BGM = // 1 arg
+        "GrammarInfo.NoBGM";
+        
+    public static final String UNABLE_TO_READ_BGM = // 0 args
+        "GrammarInfo.UnableToReadBGM";
+
+    public static final String COLLISION_DETECTED = // 2 args
+        "GrammarInfoFacade.CollisionDetected";
+
+    public static final String INCOMPATIBLE_VERSION = // 3 args
+        "GrammarInfoFacade.IncompatibleVersion";
+
+    public static final String MISSING_INTERFACE = // 1 arg
+        "ImplementationRegistry.MissingInterface";
+
+    public static final String BUILD_ID = // 0 args
+        "DefaultJAXBContextImpl.buildID";
+    
+    public static final String INCORRECT_VERSION =
+        "ContextFactory.IncorrectVersion";
+
+    public static final String ERR_TYPE_MISMATCH = // arg:3 since JAXB 1.0.3
+        "Util.TypeMismatch";
+    
+/*        
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+    static final String = // arg
+        "";
+  */      
+}

--- a/openam-schema/openam-wsfederation-schema/src/main/xml/catalog.xml
+++ b/openam-schema/openam-wsfederation-schema/src/main/xml/catalog.xml
@@ -1,0 +1,52 @@
+<!--
+   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+  
+   Copyright (c) 2007 Sun Microsystems Inc. All Rights Reserved
+  
+   The contents of this file are subject to the terms
+   of the Common Development and Distribution License
+   (the License). You may not use this file except in
+   compliance with the License.
+
+   You can obtain a copy of the License at
+   https://opensso.dev.java.net/public/CDDLv1.0.html or
+   opensso/legal/CDDLv1.0.txt
+   See the License for the specific language governing
+   permission and limitations under the License.
+
+   When distributing Covered Code, include this CDDL
+   Header Notice in each file and include the License file
+   at opensso/legal/CDDLv1.0.txt.
+   If applicable, add the following below the CDDL Header,
+   with the fields enclosed by brackets [] replaced by
+   your own identifying information:
+   "Portions Copyrighted [year] [name of copyright owner]"
+
+   $Id: catalog.xml,v 1.2 2008/06/25 05:48:43 qcheng Exp $
+
+   Portions Copyrighted 2023 Wren Security
+-->
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <system
+      systemId="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd"
+      uri="../xsd/oasis-200401-wss-wssecurity-secext-1.0.xsd" />
+  <system
+      systemId="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+      uri="../xsd/oasis-200401-wss-wssecurity-utility-1.0.xsd" />
+  <system
+      systemId="http://www.w3.org/2006/03/addressing/ws-addr.xsd"
+      uri="../xsd/ws-addr.xsd" />
+  <system
+      systemId="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200512/ws-securitypolicy-1.2.xsd"
+      uri="../xsd/ws-securitypolicy-1.2.xsd" />
+  <system
+      systemId="http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd"
+      uri="../xsd/xmldsig-core-schema.xsd" />
+  <system
+      systemId="http://www.w3.org/2001/xml.xsd"
+      uri="../xsd/xml.xsd" />
+  <system
+      systemId="http://schemas.xmlsoap.org/ws/2004/09/policy/ws-policy.xsd"
+      uri="../xsd/ws-policy.xsd" />
+</catalog>

--- a/openam-schema/openam-xacml3-schema/pom.xml
+++ b/openam-schema/openam-xacml3-schema/pom.xml
@@ -31,8 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/openam-scripting/pom.xml
+++ b/openam-scripting/pom.xml
@@ -103,20 +103,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/openam-selfservice/pom.xml
+++ b/openam-selfservice/pom.xml
@@ -80,9 +80,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-server-auth-ui/pom.xml
+++ b/openam-server-auth-ui/pom.xml
@@ -42,14 +42,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-server-only/pom.xml
+++ b/openam-server-only/pom.xml
@@ -176,14 +176,6 @@
                 <artifactId>maven-war-plugin</artifactId>
 
                 <configuration>
-                    <packagingExcludes>
-                        WEB-INF/lib/jersey-core-1.1.5.2.jar,
-                        WEB-INF/lib/jaxb-api-1.0.6.jar,
-                        WEB-INF/lib/jaxb-libs-1.0.6.jar,
-                        WEB-INF/lib/jaxb-xjc-1.0.6.jar,
-                        WEB-INF/lib/jaxp-api-1.4.2.jar,
-                    </packagingExcludes>
-
                     <archive>
                         <manifestEntries>
                             <Specification-Title>Wren:AM Server</Specification-Title>
@@ -1015,14 +1007,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-shared/pom.xml
+++ b/openam-shared/pom.xml
@@ -56,14 +56,18 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
 
         <dependency>
@@ -74,13 +78,6 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
-            <exclusions>
-                <!-- FIXME This is to prevent duplicate JAXB dependency. -->
-                <exclusion>
-                    <groupId>com.sun.xml.bind</groupId>
-                    <artifactId>jaxb-osgi</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/openam-sts/openam-common-sts/pom.xml
+++ b/openam-sts/openam-common-sts/pom.xml
@@ -63,14 +63,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-sts/openam-publish-sts/pom.xml
+++ b/openam-sts/openam-publish-sts/pom.xml
@@ -80,14 +80,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-sts/openam-rest-sts/pom.xml
+++ b/openam-sts/openam-rest-sts/pom.xml
@@ -80,14 +80,13 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
+++ b/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
@@ -80,6 +80,7 @@
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxws</artifactId>
             <version>${cxf.version}</version>
+
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.geronimo.genesis</groupId>

--- a/openam-sts/openam-token-service-sts/pom.xml
+++ b/openam-sts/openam-token-service-sts/pom.xml
@@ -85,9 +85,8 @@
             Necessary because SSOTokenManager is referenced?
         -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/openam-test/pom.xml
+++ b/openam-test/pom.xml
@@ -75,9 +75,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-tokens/pom.xml
+++ b/openam-tokens/pom.xml
@@ -50,8 +50,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-tools/build-helper-plugin/pom.xml
+++ b/openam-tools/build-helper-plugin/pom.xml
@@ -68,14 +68,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>org.wrensecurity.wrenam</groupId>
-            <artifactId>openam-cli-definitions</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
 
         <dependency>
@@ -84,13 +83,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-cli-definitions</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/openam-tools/build-helper-plugin/src/main/java/org/forgerock/maven/plugins/CLIDefinitionGenerator.java
+++ b/openam-tools/build-helper-plugin/src/main/java/org/forgerock/maven/plugins/CLIDefinitionGenerator.java
@@ -68,7 +68,7 @@ public class CLIDefinitionGenerator extends AbstractMojo {
     @Parameter(required = true)
     private String outputDir;
 
-    @Parameter(defaultValue = "${project}",required = true, readonly = true)
+    @Parameter(defaultValue = "${project}", required = true, readonly = true)
     protected MavenProject project = new MavenProject();
 
     @Override

--- a/openam-tools/openam-configurator-tool/pom.xml
+++ b/openam-tools/openam-configurator-tool/pom.xml
@@ -99,8 +99,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-tools/openam-license-servlet/pom.xml
+++ b/openam-tools/openam-license-servlet/pom.xml
@@ -41,9 +41,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>

--- a/openam-tools/openam-upgrade-tool/pom.xml
+++ b/openam-tools/openam-upgrade-tool/pom.xml
@@ -99,8 +99,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.servicemix.bundles</groupId>
-            <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/openam-uma/pom.xml
+++ b/openam-uma/pom.xml
@@ -72,9 +72,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -99,6 +98,7 @@
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/openam-upgrade/pom.xml
+++ b/openam-upgrade/pom.xml
@@ -79,24 +79,18 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
 
         <dependency>
@@ -105,6 +99,11 @@
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
         </dependency>
     </dependencies>
 
@@ -140,6 +139,7 @@
                         <groupId>org.wrensecurity.wrenam</groupId>
                         <artifactId>openam-build-tools</artifactId>
                         <version>${project.version}</version>
+
                         <exclusions>
                             <!-- This is temporary fix to prevent Maven fetching incorrect dependency -->
                             <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.7</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.8</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
 
         <!-- Source code has to be Java 8 compliant (code base is not JPMS ready) -->
@@ -145,65 +145,90 @@
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
         <wrensec-ui.version>22.1.2</wrensec-ui.version>
 
+        <!-- Test Dependencies -->
         <mockito.version>5.5.0</mockito.version>
+
+        <!-- Build Dependencies -->
         <ant.contrib.version>1.0b3</ant.contrib.version>
-        <guice.version>3.0</guice.version>
-        <restlet.version>2.3.4</restlet.version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <santuario.xmlsec.version>3.0.2</santuario.xmlsec.version>
-        <click.version>2.3.0</click.version>
-        <commons-beanutils.version>1.8.3</commons-beanutils.version>
-        <commons-codec.version>1.6</commons-codec.version>
+
+        <!-- Common Runtime Dependencies -->
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <commons-codec.version>1.16.0</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-digester.version>2.1</commons-digester.version>
         <commons-fileupload.version>1.5</commons-fileupload.version>
-        <commons-io.version>2.3</commons-io.version>
+        <commons-io.version>2.13.0</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <commons-logging.version>1.1.3</commons-logging.version>
+        <commons-logging.version>1.2</commons-logging.version>
         <commons-logging-api.version>1.1</commons-logging-api.version>
-        <esapiport.version>2013-12-04</esapiport.version>
-        <geoip.version>2.0.0</geoip.version>
-        <groovy.version>2.4.6</groovy.version>
-        <groovy-sandbox.version>1.6</groovy-sandbox.version>
-        <jaxb-api.version>2.3.1</jaxb-api.version>
-        <jaxb.version>2.3.7</jaxb.version>
-        <jaxb1.version>2.2.5-1</jaxb1.version>
-        <jaxrpc-api.version>1.1</jaxrpc-api.version>
-        <jaxrpc-impl.version>1.1.4_01-wren1</jaxrpc-impl.version>
-        <jaxrpc-spi.version>1.1.4_01-wren1</jaxrpc-spi.version>
-        <jersey-bundle.version>1.1.1-ea</jersey-bundle.version>
-        <jato.version>2005-05-04</jato.version>
-        <cc-ui.version>2008-08-08</cc-ui.version>
-        <jsr311-api.version>1.1.1</jsr311-api.version>
-        <jstl.version>1.1.2</jstl.version>
-        <mail.version>1.5.1</mail.version>
-        <jersey-oauth.version>1.1.5.2</jersey-oauth.version>
-        <relaxngDatatype.version>20020414</relaxngDatatype.version>
-        <rhino.version>1.7R4</rhino.version>
-        <saaj-api.version>1.3.4</saaj-api.version>
-        <saaj-impl.version>1.3.19</saaj-impl.version>
-        <jsp-api.version>2.1</jsp-api.version>
-        <xsdlib.version>20060615</xsdlib.version>
-        <authapi.version>2005-08-12</authapi.version>
-        <FastInfoset.version>2006-26-09</FastInfoset.version>
-        <jdmk.version>2007-01-10</jdmk.version>
-        <jsr173_api.version>2004-30-01</jsr173_api.version>
-        <javax.security.auth.message.version>3.1</javax.security.auth.message.version>
-        <freemarker.version>2.3.19</freemarker.version>
-        <java-ipv6.version>0.14</java-ipv6.version>
-        <json.version>20090211</json.version>
-        <hikaricp.version>2.4.1</hikaricp.version>
-        <h2database.version>2.2.220</h2database.version>
-        <activemq.version>5.18.2</activemq.version>
-        <javax.inject.version>1_2</javax.inject.version>
-        <fastinfoset.version>1.2.13</fastinfoset.version>
-        <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
-        <amazon.sns.version>1.10.72</amazon.sns.version>
-        <javax.websocket-api.version>1.1</javax.websocket-api.version>
+        <freemarker.version>2.3.32</freemarker.version>
+        <guice.version>3.0</guice.version>
+        <jackson.version>2.15.2</jackson.version>
+        <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta.security.message-api.version>1.1.3</jakarta.security.message-api.version>
+        <jakarta.inject-api.version>1.0.5</jakarta.inject-api.version>
+        <jakarta.mail-api.version>1.6.7</jakarta.mail-api.version>
+        <jakarta.mail-impl.version>1.6.7</jakarta.mail-impl.version>
+        <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
+        <jakarta.servlet.jsp-api.version>2.3.6</jakarta.servlet.jsp-api.version>
+        <jakarta.servlet.jstl-api.version>1.2.7</jakarta.servlet.jstl-api.version>
+        <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
+        <jakarta.websocket-api.version>1.1.2</jakarta.websocket-api.version>
+        <jakarta.ws.rs-api.version>2.1.5</jakarta.ws.rs-api.version>
+        <jakarta.xml.rpc-api.version>1.1.4</jakarta.xml.rpc-api.version>
+        <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
         <jakarta.xml.soap-api.version>1.4.2</jakarta.xml.soap-api.version>
         <jakarta.xml.ws-api.version>2.3.3</jakarta.xml.ws-api.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <java-ipv6.version>0.17</java-ipv6.version>
+        <javassist.version>3.29.1-GA</javassist.version>
+        <restlet.version>2.4.3</restlet.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <snakeyaml.version>2.2</snakeyaml.version>
+
+        <!-- WS / RS Related Dependencies -->
+        <fastinfoset.version>1.2.18</fastinfoset.version>
+        <jaxb-impl.version>2.3.8</jaxb-impl.version>
+        <jaxb1-impl.version>2.2.5-1</jaxb1-impl.version>
+        <jaxrpc-impl.version>1.1.6</jaxrpc-impl.version>
+        <jaxrpc-spi.version>1.1.6</jaxrpc-spi.version>
+        <jersey-bundle.version>1.19.1</jersey-bundle.version>
+        <jersey-oauth.version>1.19.4</jersey-oauth.version>
+        <saaj-impl.version>1.5.3</saaj-impl.version>
+        <xmlsec.version>2.3.3</xmlsec.version>
+
+        <!-- Database Related Dependencies -->
+        <hikaricp.version>2.4.1</hikaricp.version>
+        <h2database.version>2.2.220</h2database.version>
+
+        <!-- JSP Related Dependencies -->
+        <jetty.jspc.version>9.4.0.M0</jetty.jspc.version>
+
+        <!-- Scripting Support Dependencies -->
+        <groovy.version>2.4.6</groovy.version>
+        <groovy-sandbox.version>1.6</groovy-sandbox.version>
+        <rhino.version>1.7.14</rhino.version>
+
+        <!-- Other Specialized Dependencies -->
+        <activemq.version>5.18.2</activemq.version>
+        <amazon.sns.version>1.10.72</amazon.sns.version>
+        <asciidoctorj.version>2.5.10</asciidoctorj.version>
+        <geoip.version>2.0.0</geoip.version>
+        <json.version>20090211</json.version>
+        <mail.version>1.5.1</mail.version>
+
+        <!-- Deprecated Dependencies (TBD) -->
+        <authapi.version>2005-08-12</authapi.version>
+        <cc-ui.version>2008-08-08</cc-ui.version>
+        <click.version>2.3.0</click.version>
+        <esapiport.version>2013-12-04</esapiport.version>
+        <FastInfoset.version>2006-26-09</FastInfoset.version>
+        <jato.version>2005-05-04</jato.version>
+        <jdmk.version>2007-01-10</jdmk.version>
+        <jsr173_api.version>2004-30-01</jsr173_api.version>
+        <relaxngDatatype.version>20020414</relaxngDatatype.version>
+        <xsdlib.version>20060615</xsdlib.version>
+        <fest-assert.version>1.4</fest-assert.version>
     </properties>
 
     <modules>
@@ -258,6 +283,8 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- BOM Imports -->
+
             <dependency>
                 <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>commons-bom</artifactId>
@@ -267,11 +294,177 @@
             </dependency>
 
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
+
+            <!-- Commons Exclusions -->
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>api-descriptor</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-core</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>org.apache.servicemix.bundles</groupId>
+                        <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-json</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-elasticsearch</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>org.apache.servicemix.bundles</groupId>
+                        <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-json</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>org.apache.servicemix.bundles</groupId>
+                        <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-selfservice-core</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>org.apache.servicemix.bundles</groupId>
+                        <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource-http</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.mail</groupId>
+                        <artifactId>javax.mail</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource-http</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.mail</groupId>
+                        <artifactId>javax.mail</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-web-token</artifactId>
+                <version>${wrensec-commons.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- Module Dependencies -->
 
             <dependency>
                 <groupId>org.wrensecurity.wrenam</groupId>
@@ -346,15 +539,151 @@
             </dependency>
 
             <dependency>
-                <groupId>org.apache.click</groupId>
-                <artifactId>click-extras</artifactId>
-                <version>${click.version}</version>
+                <groupId>org.wrensecurity.wrenam</groupId>
+                <artifactId>openam-test-utils</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
-                <groupId>org.apache.click</groupId>
-                <artifactId>click-nodeps</artifactId>
-                <version>${click.version}</version>
+                <groupId>org.wrensecurity.wrenam</groupId>
+                <artifactId>openam-time-travel</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!-- Standard Dependencies -->
+
+            <!-- TODO upgrade and verify exclusions -->
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sns</artifactId>
+                <version>${amazon.sns.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- TODO upgrade version -->
+            <dependency>
+                <groupId>com.googlecode.java-ipv6</groupId>
+                <artifactId>java-ipv6</artifactId>
+                <version>${java-ipv6.version}</version>
+            </dependency>
+
+            <!-- TODO upgrade version -->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2database.version}</version>
+            </dependency>
+
+            <!-- TODO upgrade and verify exclusions -->
+            <dependency>
+                <groupId>com.maxmind.geoip2</groupId>
+                <artifactId>geoip2</artifactId>
+                <version>${geoip.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-bundle</artifactId>
+                <version>${jersey-bundle.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <!-- Replaced by Jakarta -->
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
+                <artifactId>oauth-client</artifactId>
+                <version>${jersey-oauth.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
+                <artifactId>oauth-server</artifactId>
+                <version>${jersey-oauth.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
+                <artifactId>oauth-signature</artifactId>
+                <version>${jersey-oauth.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.mail</groupId>
+                <artifactId>jakarta.mail</artifactId>
+                <version>${jakarta.mail-impl.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb1-impl</artifactId>
+                <version>${jaxb1-impl.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb-impl.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.fastinfoset</groupId>
+                <artifactId>FastInfoset</artifactId>
+                <version>${fastinfoset.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.messaging.saaj</groupId>
+                <artifactId>saaj-impl</artifactId>
+                <version>${saaj-impl.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.rpc</groupId>
+                <artifactId>jaxrpc-impl</artifactId>
+                <version>${jaxrpc-impl.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.rpc</groupId>
+                <artifactId>jaxrpc-spi</artifactId>
+                <version>${jaxrpc-spi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.zaxxer</groupId>
+                <artifactId>HikariCP</artifactId>
+                <version>${hikaricp.version}</version>
             </dependency>
 
             <dependency>
@@ -412,132 +741,83 @@
             </dependency>
 
             <dependency>
-                <groupId>org.mozilla</groupId>
-                <artifactId>rhino</artifactId>
-                <version>${rhino.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-jsr223</artifactId>
-                <version>${groovy.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy-json</artifactId>
-                <version>${groovy.version}</version>
-            </dependency>
-
-            <!-- FIXME Do we need this dependency? -->
-            <dependency>
-                <!-- MIT licensed: http://groovy-sandbox.kohsuke.org/license.html -->
-                <groupId>org.kohsuke</groupId>
-                <artifactId>groovy-sandbox</artifactId>
-                <version>${groovy-sandbox.version}</version>
-                <!-- Groovy-sandbox depends on Groovy 1.8.5, so ignore that in favour of our version. -->
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- FIXME Do we need this dependency? -->
-            <dependency>
-                <groupId>external</groupId>
-                <artifactId>esapiport</artifactId>
-                <version>${esapiport.version}</version>
-            </dependency>
-
-            <!--
-            <dependency>
-                <groupId>org.owasp.esapi</groupId>
-                <artifactId>esapi</artifactId>
-                <version>2.0.1</version>
-            </dependency>
-            -->
-
-            <dependency>
-                <groupId>com.maxmind.geoip2</groupId>
-                <artifactId>geoip2</artifactId>
-                <version>${geoip.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpcore</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpclient</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk-sns</artifactId>
-                <version>${amazon.sns.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpcore</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.httpcomponents</groupId>
-                        <artifactId>httpclient</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.websocket</groupId>
-                <artifactId>javax.websocket-api</artifactId>
-                <version>${javax.websocket-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb1-impl</artifactId>
-                <version>${jaxb1.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-impl</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.xml</groupId>
-                <artifactId>jaxrpc-api</artifactId>
-                <version>${jaxrpc-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.rpc</groupId>
-                <artifactId>jaxrpc-impl</artifactId>
-                <version>${jaxrpc-impl.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.rpc</groupId>
-                <artifactId>jaxrpc-spi</artifactId>
-                <version>${jaxrpc-spi.version}</version>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation-api.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
+                <version>${jakarta.mail-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.security.auth.message</groupId>
+                <artifactId>jakarta.security.auth.message-api</artifactId>
+                <version>${jakarta.security.message-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
+                <version>${jakarta.servlet.jsp-api.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jakarta.servlet.jstl-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
+                <version>${jakarta.websocket-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta.ws.rs-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.xml.rpc</groupId>
+                <artifactId>jakarta.xml.rpc-api</artifactId>
+                <version>${jakarta.xml.rpc-api.version}</version>
             </dependency>
 
             <dependency>
@@ -553,15 +833,352 @@
             </dependency>
 
             <dependency>
-                <groupId>com.sun.jersey</groupId>
-                <artifactId>jersey-bundle</artifactId>
-                <version>${jersey-bundle.version}</version>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq.version}</version>
+                <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <!-- License: legal/CC-Public-Domain.txt -->
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>2.1.9</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>${xmlsec.version}</version>
+            </dependency>
+
+            <!-- TODO upgrade version and check exclusions -->
+            <dependency>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctorj</artifactId>
+                <version>${asciidoctorj.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.beust</groupId>
+                        <artifactId>jcommander</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-jsr223</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-json</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+
+            <!-- TODO upgrade version -->
+            <dependency>
+                <groupId>org.freemarker</groupId>
+                <artifactId>freemarker</artifactId>
+                <version>${freemarker.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>${javassist.version}</version>
+            </dependency>
+
+            <!-- TODO upgrade version -->
+            <dependency>
+                <groupId>org.jgrapht</groupId>
+                <artifactId>jgrapht-core</artifactId>
+                <version>0.9.1</version>
+            </dependency>
+
+            <!-- TODO upgrade version -->
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>${json.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mozilla</groupId>
+                <artifactId>rhino</artifactId>
+                <version>${rhino.version}</version>
+            </dependency>
+
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.crypto</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.freemarker</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.httpclient</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.jackson</artifactId>
+                <version>${restlet.version}</version>
+
+                <exclusions>
+                    <!-- Replaced by Jakarta -->
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+
+                    <!-- TODO check exclusions -->
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.json</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.net</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.servlet</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.simple</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.slf4j</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.ssl</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.restlet.jee</groupId>
+                <artifactId>org.restlet.ext.xml</artifactId>
+                <version>${restlet.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-bloomfilter-core</artifactId>
+                <version>${wrensec-commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-bloomfilter-monitoring</artifactId>
+                <version>${wrensec-commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>wrensec-guice-core</artifactId>
+                <version>${wrensec-commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>wrensec-guice-servlet</artifactId>
+                <version>${wrensec-commons.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>wrensec-guice-test</artifactId>
+                <version>${wrensec-commons.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.wrends</groupId>
+                <artifactId>opendj-core</artifactId>
+                <version>${wrends.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.wrends</groupId>
+                <artifactId>opendj-grizzly</artifactId>
+                <version>${wrends.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.wrends</groupId>
+                <artifactId>opendj-server</artifactId>
+                <version>${wrends.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.wrends</groupId>
+                <artifactId>opendj-server-legacy</artifactId>
+                <version>${wrends.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <!-- Replaced by Jakarta -->
+                        <groupId>com.sun.mail</groupId>
+                        <artifactId>javax.mail</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <!-- Replaced by Jakarta -->
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>jsr311-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <!-- FIXME Needed to override version from org.restlet.ext.jackson -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+
+           <!-- Maven Plugin Dependencies -->
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>3.9.4</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-plugin-api</artifactId>
+                <version>3.9.4</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>3.9.0</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Legacy / Deprecated Dependencies -->
 
             <dependency>
                 <groupId>com.iplanet.jato</groupId>
                 <artifactId>jato</artifactId>
                 <version>${jato.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+
+            <!-- FIXME do we need this dependency? -->
+            <!-- TODO Upgrade and review exclusion list -->
+            <dependency>
+                <groupId>com.google.inject</groupId>
+                <artifactId>guice</artifactId>
+                <version>${guice.version}</version>
+                <!-- Exclude aopalliance dependency due to ambiguous licensing terms. -->
+                <classifier>no_aop</classifier>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>aopalliance</groupId>
+                        <artifactId>aopalliance</artifactId>
+                    </exclusion>
+
+                    <!-- Exclude javax.inject in favour of servicemix OSGi-compatible version -->
+                    <exclusion>
+                        <groupId>javax.inject</groupId>
+                        <artifactId>javax.inject</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-assistedinject</artifactId>
+                <version>${guice.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.inject.extensions</groupId>
+                <artifactId>guice-multibindings</artifactId>
+                <version>${guice.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.inject</groupId>
+                        <artifactId>guice</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.msv.datatype.xsd</groupId>
+                <artifactId>xsdlib</artifactId>
+                <version>${xsdlib.version}</version>
             </dependency>
 
             <dependency>
@@ -648,455 +1265,82 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>jsr311-api</artifactId>
-                <version>${jsr311-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>jstl</artifactId>
-                <version>${jstl.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
-                <version>${slf4j.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.mail</groupId>
-                <artifactId>javax.mail</artifactId>
-                <version>${mail.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-client</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-server</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.jersey.contribs.jersey-oauth</groupId>
-                <artifactId>oauth-signature</artifactId>
-                <version>${jersey-oauth.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>relaxngDatatype</groupId>
-                <artifactId>relaxngDatatype</artifactId>
-                <version>${relaxngDatatype.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.xml.soap</groupId>
-                <artifactId>saaj-api</artifactId>
-                <version>${saaj-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.messaging.saaj</groupId>
-                <artifactId>saaj-impl</artifactId>
-                <version>${saaj-impl.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.xml.fastinfoset</groupId>
-                <artifactId>FastInfoset</artifactId>
-                <version>${fastinfoset.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>jsp-api</artifactId>
-                <version>${jsp-api.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.msv.datatype.xsd</groupId>
-                <artifactId>xsdlib</artifactId>
-                <version>${xsdlib.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.wrends</groupId>
-                <artifactId>opendj-core</artifactId>
-                <version>${wrends.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.wrends</groupId>
-                <artifactId>opendj-grizzly</artifactId>
-                <version>${wrends.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.wrends</groupId>
-                <artifactId>opendj-server</artifactId>
-                <version>${wrends.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.wrends</groupId>
-                <artifactId>opendj-server-legacy</artifactId>
-                <version>${wrends.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-jdk14</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.servlet</groupId>
-                        <artifactId>javax.servlet-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!-- Legacy External Libraries for Wren:AM -->
-            <!-- We need to eventually ween off of these -->
-
-            <!-- Dependencies for the Build Helper Maven Plugin -->
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-plugin-api</artifactId>
-                <version>3.0.5</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-project</artifactId>
-                <version>3.0-alpha-2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.plugin-tools</groupId>
-                <artifactId>maven-plugin-annotations</artifactId>
-                <version>3.3</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>external</groupId>
                 <artifactId>authapi</artifactId>
                 <version>${authapi.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>external</groupId>
                 <artifactId>FastInfoset</artifactId>
                 <version>${FastInfoset.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>external</groupId>
                 <artifactId>jdmkrt</artifactId>
                 <version>${jdmk.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>external</groupId>
                 <artifactId>jdmktk</artifactId>
                 <version>${jdmk.version}</version>
                 <scope>compile</scope>
             </dependency>
+
+            <!-- FIXME Do we need this dependency? -->
+            <dependency>
+                <groupId>external</groupId>
+                <artifactId>esapiport</artifactId>
+                <version>${esapiport.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>external</groupId>
                 <artifactId>jsr173_api</artifactId>
                 <version>${jsr173_api.version}</version>
             </dependency>
 
-            <!-- Session HA Module Dependencies-->
             <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.jackson</artifactId>
-                <version>${restlet.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>javax.xml.stream</groupId>
-                        <artifactId>stax-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.json</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.xml</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.servlet</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.freemarker</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.ssl</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.simple</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.crypto</artifactId>
-                <version>${restlet.version}</version>
+                <groupId>org.apache.click</groupId>
+                <artifactId>click-extras</artifactId>
+                <version>${click.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.httpclient</artifactId>
-                <version>${restlet.version}</version>
+                <groupId>org.apache.click</groupId>
+                <artifactId>click-nodeps</artifactId>
+                <version>${click.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.net</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.restlet.jee</groupId>
-                <artifactId>org.restlet.ext.slf4j</artifactId>
-                <version>${restlet.version}</version>
-            </dependency>
-
-            <!-- Commons Dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-bloomfilter-core</artifactId>
-                <version>${wrensec-commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-bloomfilter-monitoring</artifactId>
-                <version>${wrensec-commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.0</version>
-            </dependency>
-
-            <!-- JASPIC -->
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.security.auth.message</artifactId>
-                <version>${javax.security.auth.message.version}</version>
-            </dependency>
-
-            <!-- DevicePrint -->
-            <dependency>
-                <groupId>org.freemarker</groupId>
-                <artifactId>freemarker</artifactId>
-                <version>${freemarker.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.googlecode.java-ipv6</groupId>
-                <artifactId>java-ipv6</artifactId>
-                <version>${java-ipv6.version}</version>
-            </dependency>
-            <!-- Native Json Manipulation -->
-            <dependency>
-                <groupId>org.json</groupId>
-                <artifactId>json</artifactId>
-                <version>${json.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.google.inject</groupId>
-                <artifactId>guice</artifactId>
-                <version>${guice.version}</version>
-                <!-- Exclude aopalliance dependency due to ambiguous licensing terms. -->
-                <classifier>no_aop</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>aopalliance</groupId>
-                        <artifactId>aopalliance</artifactId>
-                    </exclusion>
-                    <!-- Exclude javax.inject in favour of servicemix OSGi-compatible version -->
-                    <exclusion>
-                        <groupId>javax.inject</groupId>
-                        <artifactId>javax.inject</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-multibindings</artifactId>
-                <version>${guice.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.inject</groupId>
-                        <artifactId>guice</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-assistedinject</artifactId>
-                <version>${guice.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.inject</groupId>
-                        <artifactId>guice</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>wrensec-guice-core</artifactId>
-                <version>${wrensec-commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>wrensec-guice-servlet</artifactId>
-                <version>${wrensec-commons.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>wrensec-guice-test</artifactId>
-                <version>${wrensec-commons.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <!-- Use OSGi-compatible javax.inject to satisfy commons dependencies -->
-                <groupId>org.apache.servicemix.bundles</groupId>
-                <artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
-                <version>${javax.inject.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jgrapht</groupId>
-                <artifactId>jgrapht-core</artifactId>
-                <version>0.9.1</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctorj</artifactId>
-                <version>2.5.10</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.beust</groupId>
-                        <artifactId>jcommander</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <!--
-              required by the STS and SAML libraries
-              -->
-            <dependency>
-                <groupId>org.apache.santuario</groupId>
-                <artifactId>xmlsec</artifactId>
-                <version>${santuario.xmlsec.version}</version>
-            </dependency>
-
-            <!-- Test dependency -->
-            <dependency>
-                <groupId>org.codehaus.jstestrunner</groupId>
-                <artifactId>jstestrunner-junit</artifactId>
-                <version>1.0.1</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.easytesting</groupId>
                 <artifactId>fest-assert</artifactId>
-                <version>1.4</version>
+                <version>${fest-assert.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- FIXME Do we need this dependency? -->
             <dependency>
-                <groupId>org.easymock</groupId>
-                <artifactId>easymock</artifactId>
-                <version>3.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>httpunit</groupId>
-                <artifactId>httpunit</artifactId>
-                <version>1.7</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mortbay.jetty</groupId>
-                <artifactId>jetty-servlet-tester</artifactId>
-                <version>7.0.0.pre5</version>
-                <scope>test</scope>
+                <!-- MIT licensed: http://groovy-sandbox.kohsuke.org/license.html -->
+                <groupId>org.kohsuke</groupId>
+                <artifactId>groovy-sandbox</artifactId>
+                <version>${groovy-sandbox.version}</version>
+
+                <!-- Groovy-sandbox depends on Groovy 1.8.5, so ignore that in favour of our version. -->
                 <exclusions>
                     <exclusion>
-                        <groupId>org.mortbay.jetty</groupId>
-                        <artifactId>servlet-api</artifactId>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
+
             <dependency>
-                <groupId>javassist</groupId>
-                <artifactId>javassist</artifactId>
-                <version>3.12.1.GA</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.h2database</groupId>
-                <artifactId>h2</artifactId>
-                <version>${h2database.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-client</artifactId>
-                <version>${activemq.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.wrenam</groupId>
-                <artifactId>openam-test-utils</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <!-- License: legal/CC-Public-Domain.txt -->
-                <groupId>org.hdrhistogram</groupId>
-                <artifactId>HdrHistogram</artifactId>
-                <version>2.1.4</version>
-            </dependency>
-            <dependency>
-                <groupId>com.zaxxer</groupId>
-                <artifactId>HikariCP</artifactId>
-                <version>${hikaricp.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wrensecurity.wrenam</groupId>
-                <artifactId>openam-time-travel</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <!-- Needed to override version from org.restlet.ext.jackson -->
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
+                <groupId>relaxngDatatype</groupId>
+                <artifactId>relaxngDatatype</artifactId>
+                <version>${relaxngDatatype.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -1106,10 +1350,12 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -1120,79 +1366,104 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>com.github.searls</groupId>
-                    <artifactId>jasmine-maven-plugin</artifactId>
-                    <version>2.0-alpha-01</version>
-                </plugin>
-                <plugin>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>build-helper-plugin</artifactId>
                     <version>${project.version}</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>1.3.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.portals.jetspeed-2</groupId>
-                    <artifactId>jetspeed-unpack-maven-plugin</artifactId>
-                    <version>2.2.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>net.ju-n.maven.plugins</groupId>
-                    <artifactId>checksum-maven-plugin</artifactId>
-                    <version>1.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>buildnumber-maven-plugin</artifactId>
-                    <version>3.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.bsc.maven</groupId>
-                    <artifactId>maven-processor-plugin</artifactId>
-                    <version>2.2.4</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>xml-maven-plugin</artifactId>
-                    <version>1.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>jslint-maven-plugin</artifactId>
-                    <version>1.0.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>webminifier-maven-plugin</artifactId>
-                    <version>1.0.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty-maven-plugin</artifactId>
-                    <version>8.1.12.v20130726</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>js-import-maven-plugin</artifactId>
-                    <version>1.0.1</version>
-                </plugin>
+
+                <!-- TODO drop -->
                 <plugin>
                     <groupId>com.github.mcheely</groupId>
                     <artifactId>requirejs-maven-plugin</artifactId>
                     <version>2.0.0</version>
                 </plugin>
+
+                <!-- TODO upgrade or drop -->
+                <plugin>
+                    <groupId>com.github.searls</groupId>
+                    <artifactId>jasmine-maven-plugin</artifactId>
+                    <version>2.0-alpha-01</version>
+                </plugin>
+
+                <!-- TODO upgrade or drop -->
+                <plugin>
+                    <groupId>net.ju-n.maven.plugins</groupId>
+                    <artifactId>checksum-maven-plugin</artifactId>
+                    <version>1.2</version>
+                </plugin>
+
+                <!-- TODO upgrade or drop -->
+                <plugin>
+                    <groupId>org.apache.portals.jetspeed-2</groupId>
+                    <artifactId>jetspeed-unpack-maven-plugin</artifactId>
+                    <version>2.2.2</version>
+                </plugin>
+
+                <!-- TODO drop plugin -->
+                <plugin>
+                    <groupId>org.bsc.maven</groupId>
+                    <artifactId>maven-processor-plugin</artifactId>
+                    <version>2.2.4</version>
+                </plugin>
+
+                <!-- TODO upgrade -->
                 <plugin>
                     <groupId>org.codehaus.cargo</groupId>
                     <artifactId>cargo-maven3-plugin</artifactId>
                     <version>1.9.13</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>jaxb2-maven-plugin</artifactId>
+                    <version>2.5.0</version>
+                </plugin>
+
+                <!-- TODO drop -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>js-import-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+
+                <!-- TODO drop -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>jslint-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+
+                <!-- TODO drop -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>webminifier-maven-plugin</artifactId>
+                    <version>1.0.1</version>
+                </plugin>
+
+                <!-- TODO drop? -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>xml-maven-plugin</artifactId>
+                    <version>1.1.0</version>
+                </plugin>
+
+                <!-- TODO drop? -->
+                <plugin>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-maven-plugin</artifactId>
+                    <version>8.1.12.v20130726</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1298,6 +1569,7 @@
                 <configuration>
                     <escapeString>\</escapeString>
                     <encoding>UTF-8</encoding>
+
                     <nonFilteredFileExtensions>
                         <!-- Exclude any binary files based upon File Types. -->
                         <nonFilteredFileExtension>bin</nonFilteredFileExtension>
@@ -1333,7 +1605,9 @@
                         <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
                         <!-- See: http://en.wikipedia.org/wiki/List_of_file_formats -->
                     </nonFilteredFileExtensions>
+
                     <useDefaultDelimiters>false</useDefaultDelimiters>
+
                     <delimiters>
                         <delimiter>${*}</delimiter>
                     </delimiters>
@@ -1343,9 +1617,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+
                 <configuration>
                     <archive>
                         <index>true</index>
+
                         <manifestEntries>
                             <Specification-Title>${project.name}</Specification-Title>
                             <Specification-Version>${project.version} - ${buildNumber}</Specification-Version>
@@ -1377,11 +1653,13 @@
 
                 <configuration>
                     <doclint>all,-missing,-html</doclint>
+
                     <tags>
                         <tag>
                             <name>supported.all.api</name>
                             <placement>a</placement>
                         </tag>
+
                         <tag>
                             <name>supported.api</name>
                             <placement>a</placement>
@@ -1393,6 +1671,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
+
                 <reportSets>
                     <reportSet>
                         <reports>


### PR DESCRIPTION
This PR fixes issues with incorrect dependencies being on classpath. Ideally this should have been done before releasing RC1, but well... here we are.

I have reviewed all dependencies in the top-level POM, ordered them alphabetically and marked few of them as deprecated. Everything seems to be working... major changes are:

* most dependencies are at their newest versions
* Javax artifacts were switched to Jakarta artifacts (getting ready to switch to Jakarta packages :))
   * This was done in Wren:AM before a similar change had been done in Wrensec Commons, so a similar activity needs to be done there as well. There is a dedicated section in parent POM to exclude transitive Javax stuff from Wrensec Commons.
* introduced monkey patch for JAXB1 binary incompatibility regarding `com.sun.xml.bind.Messages` class
   * I did try to migrate that to JAXB2 but that is unfortunately not possible without major rewrite.
* commented out few unnecessary dependencies (will be removed in the future)

There are still few steps that should be considered after merging this PR:

* potentially uploading Restlet JARs to JFrog as they are currently unsigned
   * see https://github.com/restlet/restlet-framework-java/issues/481
* go through various XXX/TODO/FIXMEs inside pom.xml files 
   * check whether marked configuration is still needed (mainly talking about transitive exlusions)
   * upgrade maven plugin versions
* perform at least a simple smoke tests for SAML features (this is one area I have not covered)
