### PR TITLE
Fix session invalidation

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/SessionsService.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/SessionsService.jsm
@@ -12,10 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 /**
- * @module org/forgerock/openam/ui/admin/services/global/SessionsService
+ * @module org/forgerock/openam/ui/admin/services/realm/SessionsService
  */
 
 import AbstractDelegate from "org/forgerock/commons/ui/common/main/AbstractDelegate";

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/UsersService.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/UsersService.jsm
@@ -12,10 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 /**
- * @module org/forgerock/openam/ui/admin/services/global/UsersService
+ * @module org/forgerock/openam/ui/admin/services/realm/UsersService
  */
 
 import AbstractDelegate from "org/forgerock/commons/ui/common/main/AbstractDelegate";
@@ -24,9 +25,16 @@ import fetchUrl from "org/forgerock/openam/ui/common/services/fetchUrl";
 
 const obj = new AbstractDelegate(`${Constants.host}/${Constants.context}/json`);
 
-export function getByIdStartsWith (id) {
+/**
+ * Fetch a list of users from the realm that start with the prefix.
+ *
+ * @param {string} id User ID prefix.
+ * @param {(string|boolean)} [realm=false] Realm.
+ * @returns {Promise<Array.<string>>} Promise with list of users.
+ */
+export function getByIdStartsWith (id, realm = false) {
     return obj.serviceCall({
-        url: fetchUrl(`/users?_queryId=${id}*`, { realm: false }),
+        url: fetchUrl(`/users?_queryId=${id}*`, { realm }),
         headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" }
     }).then((response) => response.result);
 }

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/sessions/SessionsView.jsx
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/sessions/SessionsView.jsx
@@ -22,8 +22,8 @@ import Select from "react-select";
 import {
     getByUserIdAndRealm,
     invalidateByHandles
-} from "org/forgerock/openam/ui/admin/services/global/SessionsService";
-import { getByIdStartsWith } from "org/forgerock/openam/ui/admin/services/global/UsersService";
+} from "org/forgerock/openam/ui/admin/services/realm/SessionsService";
+import { getByIdStartsWith } from "org/forgerock/openam/ui/admin/services/realm/UsersService";
 import CallToAction from "components/CallToAction";
 import PageDescription from "components/PageDescription";
 import SessionsTable from "./SessionsTable";
@@ -31,11 +31,11 @@ import SimplePageHeader from "components/SimplePageHeader";
 import withRouter from "org/forgerock/commons/ui/common/components/hoc/withRouter";
 import withRouterPropType from "org/forgerock/commons/ui/common/components/hoc/withRouterPropType";
 
-const fetchUsersByPartialId = _.debounce((userId, callback) => {
+const fetchUsersByPartialId = _.debounce((userId, realm, callback) => {
     if (_.isEmpty(userId)) {
         callback(null, { options: [] });
     } else {
-        getByIdStartsWith(userId).then((response) => {
+        getByIdStartsWith(userId, realm).then((response) => {
             callback(null, {
                 options: _.map(response, (user) => ({ label: user, value: user }))
             });
@@ -108,7 +108,7 @@ class SessionsView extends Component {
                             id: "findAUser"
                         } }
                         isLoading
-                        loadOptions={ fetchUsersByPartialId }
+                        loadOptions={ (userId, cb) => fetchUsersByPartialId(userId, this.props.router.params[0], cb) }
                         noResultsText={ t("console.sessions.search.noResults") }
                         onChange={ this.handleSelectAsyncOnChange }
                         placeholder={ t("console.sessions.search.placeholder") }


### PR DESCRIPTION
Sessions could not be invalidated in XUI in some cases due to user search being limited to the ROOT realm in the web admin context.