### PR TITLE
Fix authenticated goto parameter handling

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/RESTLoginHelper.js
@@ -128,7 +128,7 @@ define([
         const promise = $.Deferred();
         let context = "";
 
-        const goto = query.parseParameters(URIUtils.getCurrentFragmentQueryString()).goto;
+        const goto = query.parseParameters(URIUtils.getCurrentCompositeQueryString()).goto;
 
         if (goto) {
             AuthNService.validateGotoUrl(goto).then((data) => {


### PR DESCRIPTION
This PR fixes goto parameter handling when the user is already authenticated (i.e. has valid SSO session).
Without this fix user is redirected to the default success URL.