### PR TITLE
Add Cisco Duo authentication module.

### DIFF
--- a/openam-authentication/pom.xml
+++ b/openam-authentication/pom.xml
@@ -57,6 +57,7 @@
         <module>openam-auth-saml2</module>
         <module>openam-auth-scripted</module>
         <module>openam-auth-windowsdesktopsso</module>
+        <module>wrenam-auth-duo</module>
     </modules>
 
     <dependencies>

--- a/openam-authentication/wrenam-auth-duo/pom.xml
+++ b/openam-authentication/wrenam-auth-duo/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    The contents of this file are subject to the terms of the Common Development and
+    Distribution License (the License). You may not use this file except in compliance with the
+    License.
+
+    You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+    specific language governing permission and limitations under the License.
+
+    When distributing Covered Software, include this CDDL Header Notice in each file and include
+    the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+    Header, with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions copyright [year] [name of copyright owner]".
+
+    Copyright 2023 Wren Security
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wrensecurity.wrenam</groupId>
+        <artifactId>openam-authentication</artifactId>
+        <version>15.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>wrenam-auth-duo</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Wren:AM - Cisco Duo Authentication Module</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-auth-common</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/Duo.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/Duo.java
@@ -1,0 +1,157 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import com.sun.identity.authentication.spi.AMLoginModule;
+import com.sun.identity.authentication.spi.AuthLoginException;
+import com.sun.identity.authentication.util.ISAuthConstants;
+import com.sun.identity.shared.debug.Debug;
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Cisco Duo authentication module.
+ */
+public class Duo extends AMLoginModule {
+
+    /**
+     * Initial authentication module state.
+     */
+    private static final int INIT_DUO_AUTH_STATE = 1;
+
+    /**
+     * State representing pending authentication status verification.
+     */
+    private static final int VERIFY_DUO_AUTH_STATUS_STATE = 2;
+
+    /**
+     * Attribute indicating whether Cisco Duo authentication should be skipped.
+     */
+    private static final String SKIP_DUO_MFA_ATTR = "skipDuoMFA";
+
+    public static final String SERVICE_KEY = "amAuthDuo";
+
+    private final Debug debug;
+    private Map<String, Set<String>> config;
+    private Map<String, ?> sharedState;
+    private DuoClient duoClient;
+    private String username;
+    private String transactionId;
+    private CompletableFuture<DuoAuthStatus> statusRequest;
+
+    public Duo() {
+        this.debug = Debug.getInstance(SERVICE_KEY);
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void init(Subject subject, Map state, Map options) {
+        sharedState = state;
+        config = (Map<String, Set<String>>) options;
+        duoClient = new DuoClient(DuoClientConfig.fromOptions(config));
+        username = (String) sharedState.get(getUserKey());
+    }
+
+    @Override
+    public int process(Callback[] callbacks, int state) throws AuthLoginException {
+        // Check SKIP PROCESSING configuration
+        if (INIT_DUO_AUTH_STATE == state && shouldSkipProcessing()) {
+            debug.message("Skipping Cisco Duo authentication module.");
+            return ISAuthConstants.LOGIN_IGNORE;
+        }
+        // Verify the user is known
+        if (StringUtils.isBlank(username)) {
+            throw new AuthLoginException(SERVICE_KEY, "missingUsername", null);
+        }
+        switch (state) {
+            case INIT_DUO_AUTH_STATE:
+                // Initialize authentication process
+                debug.message("Initializing Cisco Duo authentication for user '" + username + "'.");
+                try {
+                    transactionId = duoClient.initAuth(username);
+                } catch (Exception e) {
+                    throw new AuthLoginException(SERVICE_KEY, "authFailed", null, e);
+                }
+            case VERIFY_DUO_AUTH_STATUS_STATE:
+                // Verify authentication status
+                if (StringUtils.isBlank(transactionId)) {
+                    throw new AuthLoginException(SERVICE_KEY, "missingTransactionId", null);
+                }
+                debug.message("Checking Cisco Duo authentication status for transaction '" + transactionId + "'.");
+                if (statusRequest == null) {
+                    try {
+                        statusRequest = duoClient.getAuthStatus(transactionId);
+                    } catch (Exception e) {
+                        throw new AuthLoginException(SERVICE_KEY, "authFailed", null, e);
+                    }
+                }
+                DuoAuthStatus status;
+                try {
+                    status = statusRequest.get(2, TimeUnit.SECONDS);
+                } catch (TimeoutException e) {
+                    return VERIFY_DUO_AUTH_STATUS_STATE;
+                } catch (Exception e) {
+                    throw new AuthLoginException(SERVICE_KEY, "authFailed", null, e);
+                }
+                if (DuoAuthStatus.WAITING == status) {
+                    statusRequest = null;
+                    return VERIFY_DUO_AUTH_STATUS_STATE;
+                } else if (DuoAuthStatus.ALLOW == status) {
+                    return ISAuthConstants.LOGIN_SUCCEED;
+                }
+                throw new AuthLoginException(SERVICE_KEY, "authDenied", null);
+            default:
+                debug.error("Invalid state '" + state + "' in Cisco Duo authentication process.");
+                setFailureID(username);
+                throw new AuthLoginException("Invalid state '" + state + "' in Cisco Duo authentication process.");
+        }
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return new DuoPrincipal(username);
+    }
+
+    @Override
+    public void destroyModuleState() {
+        username = null;
+        nullifyUsedVars();
+    }
+
+    @Override
+    public void nullifyUsedVars() {
+        config = null;
+        sharedState = null;
+        duoClient = null;
+        transactionId = null;
+        statusRequest = null;
+    }
+
+    /**
+     * Determine whether the Cisco Duo authentication should be skipped for the checked user.
+     */
+    private boolean shouldSkipProcessing() {
+        return sharedState.containsKey(SKIP_DUO_MFA_ATTR) && (Boolean) sharedState.get(SKIP_DUO_MFA_ATTR);
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthStatus.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthStatus.java
@@ -1,0 +1,35 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+public enum DuoAuthStatus {
+
+    /**
+     * Authentication succeeded. Application should grant access to the user.
+     */
+    ALLOW,
+
+    /**
+     * Authentication denied. Application should deny access to the user.
+     */
+    DENY,
+
+    /**
+     * Authentication is still in-progress. Application should poll again until it finishes.
+     */
+    WAITING
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthorizationResolver.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthorizationResolver.java
@@ -1,0 +1,58 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import java.nio.charset.StandardCharsets;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * Cisco Duo authorization password resolver.
+ */
+public class DuoAuthorizationResolver {
+
+    private final static String SIGN_ALGORITHM = "HmacSHA1";
+
+    private final Mac mac;
+
+    public DuoAuthorizationResolver(String secretKey) {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), SIGN_ALGORITHM);
+        try {
+            this.mac = Mac.getInstance(SIGN_ALGORITHM);
+            this.mac.init(secretKeySpec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to initialize MAC provider.", e);
+        }
+    }
+
+    /**
+     * Resolve authorization password for request with the specified parameters.
+     * @param date Date in RFC 2822 format. Never null.
+     * @param method HTTP method (uppercase). Never null.
+     * @param host Cisco DUO API hostname (lowercase). Never null.
+     * @param path API method's path. Never null.
+     * @param params HTTP query params for GET request, request BODY for POST request. Can be null.
+     * @return
+     */
+    public String resolvePassword(String date, String method, String host, String path, String params) {
+        String request = String.join("\n", date, method, host, path, params);
+        byte[] raw = this.mac.doFinal(request.getBytes(StandardCharsets.UTF_8));
+        this.mac.reset();
+        return Hex.encodeHexString(raw);
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClient.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClient.java
@@ -1,0 +1,223 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Cisco Duo authentication client.
+ */
+public class DuoClient {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final DuoClientConfig config;
+    private final DuoAuthorizationResolver authResolver;
+    private final HttpClient client;
+
+    public DuoClient(DuoClientConfig config) {
+        this.config = config;
+        this.authResolver = new DuoAuthorizationResolver(config.getSecretKey());
+        this.client = HttpClient.newBuilder().build();
+    }
+
+    /**
+     * Initialize second-factor authentication for user with the specified username.
+     * @param username Username of the user to initialize authentication. Never null.
+     * @return Transaction identifier. Never null.
+     */
+    public String initAuth(String username) {
+        URI uri = URI.create(config.getApiBaseUrl() + "/auth/v2/auth");
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("async", "true");
+        params.put("device", "auto");
+        params.put("factor", "push");
+        params.put("username", username);
+        String formData = encodeFormData(params);
+        String date = DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now());
+        // Resolve password for the request
+        String password = authResolver.resolvePassword(date, "POST", uri.getHost(), uri.getPath(), formData);
+        // Prepare HTTP request
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Authorization", resolveAuthorizationHeader(password))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Date", date)
+                .POST(BodyPublishers.ofString(formData))
+                .timeout(Duration.ofSeconds(30))
+                .build();
+        // Perform HTTP request
+        HttpResponse<String> response = sendRequest(request);
+        // Process response body
+        DuoAuthResponse authResponse = checkAuthResponse(response.body());
+        if (StringUtils.isBlank(authResponse.getTransactionId())) {
+            throw new IllegalStateException("Missing transaction ID for '" + username + "'.");
+        }
+        return authResponse.getTransactionId();
+    }
+
+    /**
+     * Get status of authentication for the specified transaction identifier.
+     * @param transactionId Transaction identifier to get status. Never null.
+     * @return Authentication status. Never null.
+     */
+    public CompletableFuture<DuoAuthStatus> getAuthStatus(String transactionId) {
+        URI uri = URI.create(config.getApiBaseUrl() + "/auth/v2/auth_status?txid="
+                + URLEncoder.encode(transactionId, StandardCharsets.UTF_8));
+        String date = DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now());
+        // Resolve password for the request
+        String password = authResolver.resolvePassword(date, "GET", uri.getHost(), uri.getPath(), uri.getQuery());
+        // Prepare HTTP request
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Authorization", resolveAuthorizationHeader(password))
+                .header("Date", date)
+                .GET()
+                .timeout(Duration.ofMinutes(2))
+                .build();
+        // Perform HTTP request
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply(response -> {
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException("Invalid HTTP response status. HTTP status code: '"
+                        + response.statusCode() + "', Response: '" + response.body() + "'.");
+            }
+            DuoAuthResponse authResponse = checkAuthResponse(response.body());
+            if (authResponse.getAuthStatus() == null) {
+                throw new IllegalStateException("Invalid authentication status for '" + transactionId + "'.");
+            }
+            return authResponse.getAuthStatus();
+        });
+    }
+
+    /**
+     * Send the specified HTTP request.
+     * @param request HTTP request to be send. Never null.
+     * @return {@link HttpResponse} instance. Never null.
+     */
+    private HttpResponse<String> sendRequest(HttpRequest request) {
+        HttpResponse<String> response = null;
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to send request to Cisco Duo API'.", e);
+        }
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Invalid HTTP response status. HTTP status code: '"
+                    + response.statusCode() + "', Response: '" + response.body() + "'.");
+        }
+        return response;
+    }
+
+    /**
+     * Check status of Cisco Duo authentication response.
+     * @param response Cisco Duo authentication response serialized in JSON format. Never null.
+     * @return Parsed {@link DuoAuthResponse} when response is valid. Never null.
+     */
+    private DuoAuthResponse checkAuthResponse(String response) {
+        DuoAuthResponse authResponse = null;
+        try {
+            authResponse = mapper.readValue(response, DuoAuthResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to parse authentication response.", e);
+        }
+        if (!authResponse.isOk()) {
+            throw new IllegalStateException("Invalid response status. Response status: '"
+                    + authResponse.getStatus() + "'.");
+        }
+        return authResponse;
+    }
+
+    /**
+     * Serialize specified data as 'x-www-form-urlencoded' value string.
+     */
+    private String encodeFormData(Map<String, String> data) {
+        return data.entrySet().stream()
+                .map(entry -> URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8) + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+    }
+
+    /**
+     * Resolve HTTP authorization header value (i.e. HTTP BASIC authentication value).
+     */
+    private String resolveAuthorizationHeader(String password) {
+        String credentials = config.getIntegrationKey() + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+
+    /**
+     * Class representing Cisco Duo authentication response.
+     */
+    static class DuoAuthResponse {
+
+        @JsonProperty("stat")
+        private String status;
+        private Map<String, String> response;
+
+        public String getStatus() {
+            return status;
+        }
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Map<String, String> getResponse() {
+            return response;
+        }
+        public void setResponse(Map<String, String> response) {
+            this.response = response;
+        }
+
+        @JsonIgnore
+        public boolean isOk() {
+            return "OK".equalsIgnoreCase(status);
+        }
+
+        @JsonIgnore
+        public String getTransactionId() {
+            return response != null ? response.get("txid") : null;
+        }
+
+        @JsonIgnore
+        public DuoAuthStatus getAuthStatus() {
+            if (response == null || StringUtils.isBlank(response.get("result"))) {
+                return null;
+            }
+            return DuoAuthStatus.valueOf(response.get("result").toUpperCase());
+        }
+
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClientConfig.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClientConfig.java
@@ -1,0 +1,64 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import com.sun.identity.shared.datastruct.CollectionHelper;
+import com.sun.identity.shared.datastruct.ValueNotFoundException;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Cisco Duo client configuration.
+ */
+public class DuoClientConfig {
+
+    private static final String API_BASE_URL = "duo-client-api-base-url";
+    private static final String INTEGRATION_KEY = "duo-client-integration-key";
+    private static final String SECRET_KEY = "duo-client-secret-key";
+
+    private final String apiBaseUrl;
+    private final String integrationKey;
+    private final String secretKey;
+
+    public DuoClientConfig(String apiBaseUrl, String integrationKey, String secretKey) {
+        this.apiBaseUrl = apiBaseUrl;
+        this.integrationKey = integrationKey;
+        this.secretKey = secretKey;
+    }
+
+    public static DuoClientConfig fromOptions(Map<String, Set<String>> options) {
+        try {
+            return new DuoClientConfig(CollectionHelper.getMapAttrThrows(options, API_BASE_URL),
+                    CollectionHelper.getMapAttrThrows(options, INTEGRATION_KEY),
+                    CollectionHelper.getMapAttrThrows(options, SECRET_KEY));
+        } catch (ValueNotFoundException e) {
+            throw new IllegalStateException("Failed to create Cisco Duo configuration.", e);
+        }
+    }
+
+    public String getApiBaseUrl() {
+        return apiBaseUrl;
+    }
+
+    public String getIntegrationKey() {
+        return integrationKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoPrincipal.java
+++ b/openam-authentication/wrenam-auth-duo/src/main/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoPrincipal.java
@@ -1,0 +1,64 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import java.io.Serializable;
+import java.security.Principal;
+import java.util.Objects;
+
+/**
+ * Principal authenticated via Cisco Duo module.
+ */
+public class DuoPrincipal implements Principal, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+
+    DuoPrincipal(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("Principal's name cannot be null");
+        }
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "DuoPrincipal: " + name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DuoPrincipal that = (DuoPrincipal) o;
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(DuoPrincipal.class, name);
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/main/resources/amAuthDuo.properties
+++ b/openam-authentication/wrenam-auth-duo/src/main/resources/amAuthDuo.properties
@@ -1,0 +1,27 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2023 Wren Security
+
+duo-service-description=Cisco Duo
+a500=Authentication Level
+a500.help=The authentication level associated with this module.
+a501=API base URL
+a501.help=Cisco Duo API base URL to perform authentication requests (e.g. https://api-xxxxxxxx.duosecurity.com).
+a502=Integration key
+a502.help=Cisco Duo application's integration key.
+a503=Secret key
+a503.help=Cisco Duo application's secret key.
+missingUsername=Missing username
+missingTransactionId=Missing transaction identifier
+authDenied=Authentication denied
+authFailed=Authentication failed

--- a/openam-authentication/wrenam-auth-duo/src/main/resources/amAuthDuo.xml
+++ b/openam-authentication/wrenam-auth-duo/src/main/resources/amAuthDuo.xml
@@ -1,0 +1,83 @@
+<?xml version='1.0' encoding="ISO-8859-1"?>
+<!--
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+-->
+<!DOCTYPE ServicesConfiguration
+        PUBLIC "=//sun//Service Management Services (SMS) 1.0 DTD//EN"
+        "jar://com/sun/identity/sm/sms.dtd">
+
+<ServicesConfiguration>
+    <Service name="sunAMAuthDuoService" version="1.0">
+        <Schema serviceHierarchy="/DSAMEConfig/authentication/sunAMAuthDuoService"
+                i18nFileName="amAuthDuo" i18nKey="duo-service-description"
+                resourceName="duo">
+
+            <Organization>
+                <AttributeSchema name="duo-auth-level"
+                        type="single" syntax="number_range" rangeStart="0" rangeEnd="2147483647"
+                        i18nKey="a500" order="100" resourceName="authenticationLevel">
+                    <DefaultValues>
+                        <Value>0</Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="duo-client-api-base-url"
+                        type="single" i18nKey="a501" order="200" resourceName="apiBaseUrl">
+                    <DefaultValues>
+                        <Value></Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="duo-client-integration-key"
+                        type="single" syntax="password" i18nKey="a502" order="300" resourceName="integrationKey">
+                    <DefaultValues>
+                        <Value></Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <AttributeSchema name="duo-client-secret-key"
+                        type="single" syntax="password" i18nKey="a503" order="400" resourceName="secretKey">
+                    <DefaultValues>
+                        <Value></Value>
+                    </DefaultValues>
+                </AttributeSchema>
+                <SubSchema name="serverconfig" inheritance="multiple" resourceName="USE-PARENT">
+                    <AttributeSchema name="sun-am-auth-duo-auth-level"
+                            type="single" syntax="number_range" rangeStart="0" rangeEnd="2147483647"
+                            i18nKey="a500" order="100" resourceName="authenticationLevel">
+                        <DefaultValues>
+                            <Value>0</Value>
+                        </DefaultValues>
+                    </AttributeSchema>
+                    <AttributeSchema name="duo-client-api-base-url"
+                            type="single" i18nKey="a501" order="200" resourceName="apiBaseUrl">
+                        <DefaultValues>
+                            <Value></Value>
+                        </DefaultValues>
+                    </AttributeSchema>
+                    <AttributeSchema name="duo-client-integration-key"
+                            type="single" syntax="password" i18nKey="a502" order="300" resourceName="integrationKey">
+                        <DefaultValues>
+                            <Value></Value>
+                        </DefaultValues>
+                    </AttributeSchema>
+                    <AttributeSchema name="duo-client-secret-key"
+                            type="single" syntax="password" i18nKey="a503" order="400" resourceName="secretKey">
+                        <DefaultValues>
+                            <Value></Value>
+                        </DefaultValues>
+                    </AttributeSchema>
+                </SubSchema>
+            </Organization>
+        </Schema>
+    </Service>
+</ServicesConfiguration>

--- a/openam-authentication/wrenam-auth-duo/src/test/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthorizationResolverTest.java
+++ b/openam-authentication/wrenam-auth-duo/src/test/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoAuthorizationResolverTest.java
@@ -1,0 +1,50 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link DuoAuthorizationResolver} test case.
+ */
+public class DuoAuthorizationResolverTest {
+
+    private static final String SECRET_KEY = "Zh5eGmUq9zpfQnyUIu5OL9iWoMMv5ZNmk3zLJ4Ep";
+
+    private static DuoAuthorizationResolver resolver;
+
+    @BeforeAll
+    public static void setup() {
+        resolver = new DuoAuthorizationResolver(SECRET_KEY);
+    }
+
+    @Test
+    public void testResolvePassword() {
+        String date = "Tue, 21 Aug 2012 17:29:18 -0000";
+        String method = "POST";
+        String host = "api-XXXXXXXX.duosecurity.com";
+        String path = "/auth/v2/auth";
+        String body = "device=auto&factor=push&hostname=wks01&ipaddr=10.2.3.4&username=narroway";
+        String expectedPassword = "8fe4d3186932175914dd8e97ae4b8cf3ad4653f1";
+        assertEquals(expectedPassword, resolver.resolvePassword(date, method, host, path, body));
+        // Check whether resolver correctly performs reset
+        assertEquals(expectedPassword, resolver.resolvePassword(date, method, host, path, body));
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/test/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClientTest.java
+++ b/openam-authentication/wrenam-auth-duo/src/test/java/org/wrensecurity/wrenam/authentication/modules/duo/DuoClientTest.java
@@ -1,0 +1,96 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2023 Wren Security
+ */
+package org.wrensecurity.wrenam.authentication.modules.duo;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+
+@WireMockTest
+public class DuoClientTest {
+
+    //~ Common test parameters
+    private static final String INTEGRATION_KEY = "intg";
+    private static final String USERNAME = "user1";
+    private static final String TRANSACTION_ID = "transaction-id1";
+
+    @Test
+    public void testInitAuth(WireMockRuntimeInfo runtimeInfo) {
+        String baseUrl = "/auth/v2/auth";
+        // Stub HTTP endpoint
+        stubFor(post(baseUrl).willReturn(ok().withBodyFile("duo-endpoint-auth-init-response.json")));
+        // Perform HTTP request
+        DuoClient client = new DuoClient(new DuoClientConfig(runtimeInfo.getHttpBaseUrl(), INTEGRATION_KEY, "sec"));
+        // Verify performed request
+        assertEquals(TRANSACTION_ID, client.initAuth(USERNAME));
+        verify(1, postRequestedFor(urlEqualTo(baseUrl))
+                .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+                .withHeader("Date", matching(".*"))
+                .withRequestBody(containing("username=" + USERNAME))
+                .withRequestBody(containing("async=true"))
+                .andMatching(request -> checkAuthorizationHeader(request)));
+
+    }
+
+    @Test
+    public void testAuthStatus(WireMockRuntimeInfo runtimeInfo) throws Exception {
+        String baseUrl = "/auth/v2/auth_status";
+        // Stub HTTP endpoint
+        stubFor(get(urlPathEqualTo(baseUrl)).willReturn(ok().withBodyFile("duo-endpoint-auth-status-response.json")));
+        // Perform HTTP request
+        DuoClient client = new DuoClient(new DuoClientConfig(runtimeInfo.getHttpBaseUrl(), INTEGRATION_KEY, "sec"));
+        // Verify performed request
+        assertEquals(DuoAuthStatus.ALLOW, client.getAuthStatus(TRANSACTION_ID).get());
+        verify(1, getRequestedFor(urlPathEqualTo(baseUrl))
+                .withHeader("Date", matching(".*"))
+                .withQueryParam("txid", equalTo(TRANSACTION_ID))
+                .andMatching(request -> checkAuthorizationHeader(request)));
+
+    }
+
+    /**
+     * Check authorization header of the specified request.
+     */
+    private MatchResult checkAuthorizationHeader(Request request) {
+        if (!request.containsHeader("Authorization")) {
+            MatchResult.noMatch();
+        }
+        String value = request.getHeader("Authorization");
+        if (!value.startsWith("Basic ")) {
+            MatchResult.noMatch();
+        }
+        String credentials = new String(Base64.getDecoder().decode(value.substring(6)));
+        return MatchResult.of(credentials.startsWith(INTEGRATION_KEY));
+    }
+
+}

--- a/openam-authentication/wrenam-auth-duo/src/test/resources/__files/duo-endpoint-auth-init-response.json
+++ b/openam-authentication/wrenam-auth-duo/src/test/resources/__files/duo-endpoint-auth-init-response.json
@@ -1,0 +1,6 @@
+{
+  "stat": "OK",
+  "response": {
+    "txid": "transaction-id1"
+  }
+}

--- a/openam-authentication/wrenam-auth-duo/src/test/resources/__files/duo-endpoint-auth-status-response.json
+++ b/openam-authentication/wrenam-auth-duo/src/test/resources/__files/duo-endpoint-auth-status-response.json
@@ -1,0 +1,8 @@
+{
+  "stat": "OK",
+  "response": {
+    "result": "allow",
+    "status": "allow",
+    "status_msg": "Success. Logging you in..."
+  }
+}

--- a/openam-core/src/main/resources/debugfiles.properties
+++ b/openam-core/src/main/resources/debugfiles.properties
@@ -40,6 +40,7 @@ amAuthConfig=Authentication
 amAuthContext=Authentication
 amAuthContextLocal=Authentication
 amAuthDataStore=Authentication
+amAuthDuo=Authentication
 amAuthPersistentCookie=Authentication
 amAuthPush=Authentication
 amAuthDevicePrint=Authentication

--- a/openam-server-only/pom.xml
+++ b/openam-server-only/pom.xml
@@ -733,14 +733,14 @@
         </dependency>
 
         <dependency>
-        	<groupId>org.wrensecurity.wrenam</groupId>
-        	<artifactId>openam-radius-common</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-radius-common</artifactId>
             <version>${project.version}</version>
         </dependency>
 
         <dependency>
-        	<groupId>org.wrensecurity.wrenam</groupId>
-        	<artifactId>openam-radius-server</artifactId>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>openam-radius-server</artifactId>
             <version>${project.version}</version>
         </dependency>
 
@@ -934,6 +934,12 @@
         <dependency>
             <artifactId>openam-auth-oidc</artifactId>
             <groupId>org.wrensecurity.wrenam</groupId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wrensecurity.wrenam</groupId>
+            <artifactId>wrenam-auth-duo</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/openam-server-only/src/main/resources/amServiceTable.properties
+++ b/openam-server-only/src/main/resources/amServiceTable.properties
@@ -25,10 +25,10 @@
 # $Id: amServiceTable.properties,v 1.5 2009/06/19 02:38:05 bigfatrat Exp $
 #
 # Portions Copyrighted 2011-2017 ForgeRock AS.
-#
+# Portions Copyrighted 2023 Wren Security
 
 #
-# This properties map the service name to the table of which it is 
+# This properties map the service name to the table of which it is
 # displayed in the Configuration tab.
 #
 # . means that service should be hidden.
@@ -55,6 +55,7 @@ iPlanetAMAuthSecurIDService=Authentication
 iPlanetAMAuthWindowsDesktopSSOService=Authentication
 sunAMAuthOAuthService=Authentication
 sunAMAuthAdaptiveService=Authentication
+sunAMAuthDuoService=Authentication
 
 iPlanetAMPasswordResetService=Global
 iPlanetAMPolicyConfigService=Global

--- a/openam-server-only/src/main/resources/config/serviceNames.properties
+++ b/openam-server-only/src/main/resources/config/serviceNames.properties
@@ -25,6 +25,7 @@
 # $Id: serviceNames.properties,v 1.16 2009/11/19 00:07:39 qcheng Exp $
 #
 # Portions copyright 2011-2017 ForgeRock AS.
+# Portions Copyrighted 2023 Wren Security
 
 # service names that are prefix with * means that it will not be tagswapped by configurator
 # prior to registering them.
@@ -32,8 +33,8 @@
 serviceNames=dashboardService.xml amEntrySpecific.xml amAuthConfig.xml amAuthHTTPBasic.xml amAdminConsole.xml \
   idRepoService.xml amAuth.xml amAuthAD.xml amAuthAdaptive.xml amAuthAnonymous.xml amAuthCert.xml amAuthDataStore.xml \
   amAuthPersistentCookie.xml amAuthJDBC.xml amAuthLDAP.xml amAuthMSISDN.xml \
-  amAuthMembership.xml amAuthNT.xml amAuthOAuth.xml amAuthWindowsDesktopSSO.xml amAuthOpenIdConnect.xml amClientData.xml \
-  amClientDetection.xml amDelegation.xml amFilteredRole.xml amG11NSettings.xml amLogging.xml amNaming.xml \
+  amAuthMembership.xml amAuthNT.xml amAuthOAuth.xml amAuthWindowsDesktopSSO.xml amAuthDuo.xml amAuthOpenIdConnect.xml \
+  amClientData.xml amClientDetection.xml amDelegation.xml amFilteredRole.xml amG11NSettings.xml amLogging.xml amNaming.xml \
   amPlatform.xml amPolicy.xml amPolicyConfig.xml amRealmService.xml amSession.xml amWebAgent.xml crestPolicyService.xml \
   amUser.xml identityLocaleService.xml amAgent70.xml amPasswordReset.xml amAuthRadius.xml amAuthHOTP.xml \
   ${auth.securID.xml} amMonitoring.xml *AgentService.xml policyIndex.xml entitlement.xml openProvisioning.xml banking.xml \

--- a/openam-server-only/src/main/resources/services/amAuth.xml
+++ b/openam-server-only/src/main/resources/services/amAuth.xml
@@ -2,9 +2,9 @@
 
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-  
+
     Copyright (c) 2006 Sun Microsystems Inc. All Rights Reserved
-  
+
     The contents of this file are subject to the terms
     of the Common Development and Distribution License
     (the License). You may not use this file except in
@@ -27,6 +27,7 @@
     $Id: amAuth.xml,v 1.16 2009/11/25 12:06:32 manish_rustagi Exp $
 
     Portions Copyrighted 2011-2017 ForgeRock AS.
+    Portions Copyrighted 2023 Wren Security
 -->
 
 <!DOCTYPE ServicesConfiguration
@@ -76,6 +77,7 @@
                         <Value>org.forgerock.openam.authentication.modules.push.AuthenticatorPush</Value>
                         <Value>org.forgerock.openam.authentication.modules.push.registration.AuthenticatorPushRegistration</Value>
                         <Value>org.forgerock.openam.authentication.modules.amster.Amster</Value>
+                        <Value>org.wrensecurity.wrenam.authentication.modules.duo.Duo</Value>
                     </DefaultValues>
                 </AttributeSchema>
                 <AttributeSchema name="iplanet-am-auth-ldap-connection-pool-size"

--- a/openam-server-only/src/main/webapp/config/auth/default/Duo.xml
+++ b/openam-server-only/src/main/webapp/config/auth/default/Duo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    The contents of this file are subject to the terms of the Common Development and
+    Distribution License (the License). You may not use this file except in compliance with the
+    License.
+
+    You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+    specific language governing permission and limitations under the License.
+
+    When distributing Covered Software, include this CDDL Header Notice in each file and include
+    the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+    Header, with the fields enclosed by brackets [] replaced by your own identifying
+    information: "Portions copyright [year] [name of copyright owner]".
+
+    Copyright 2023 Wren Security
+-->
+<!DOCTYPE ModuleProperties PUBLIC "=//iPlanet//Authentication Module Properties XML Interface 1.0 DTD//EN"
+        "jar://com/sun/identity/authentication/Auth_Module_Properties.dtd">
+
+<ModuleProperties moduleName="Duo">
+    <Callbacks length="0" order="1" timeout="3600" header="#WILL NOT BE SHOWN#" />
+    <Callbacks length="1" order="2" timeout="3600" header="Login" >
+        <TextOutputCallback>Please confirm authentication in your Cisco Duo mobile application.</TextOutputCallback>
+    </Callbacks>
+</ModuleProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.9</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.12</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
 
         <!-- Source code has to be Java 8 compliant (code base is not JPMS ready) -->


### PR DESCRIPTION
This PR adds a brand new authentication module using Cisco Duo Security multi-factor authentication. The module requires 3 configuration parameters (API base url, integration key and secret key). 
The module has two stages:

* init stage - initializes authentication process using username
* verify stage - verifies the authentication status of the transaction from the init stage

The choice of factor (`push`, `phone`, ...) is entirely up to the Duo service (authentication module sends option `auto`). See https://duo.com/docs/authapi#/auth for more information.