### PR TITLE
Fix build by forcing Chrome without sandbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN \
 # Configure headless Chromium for Puppeteer
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
-# Use '--no-sandbox' option for Puppeteer's Chromium because of incompatibility with Docker
-ENV DISABLE_PUPPETEER_SANDBOX=true
 
 # Copy project files
 WORKDIR /project

--- a/openam-ui/openam-ui-ria/karma.conf.js
+++ b/openam-ui/openam-ui-ria/karma.conf.js
@@ -37,7 +37,7 @@ module.exports = function (config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: [process.env.DISABLE_PUPPETEER_SANDBOX ? "ChromeHeadlessNoSandbox" : "ChromeHeadless"],
+        browsers: ["ChromeHeadlessNoSandbox"],
         singleRun: false,
         customLaunchers: {
             ChromeHeadlessNoSandbox: {


### PR DESCRIPTION
This PR fixes the failing build of openam-ui-ria module on Ubuntu 23.10 and newer.

The issue was caused by disabled unprivileged user namespaces with AppArmor.