### PR TITLE
Fix account lockout

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/common/AccountLockoutInfo.java
+++ b/openam-core/src/main/java/com/sun/identity/common/AccountLockoutInfo.java
@@ -24,6 +24,7 @@
  *
  * $Id: AccountLockoutInfo.java,v 1.3 2008/06/25 05:42:24 qcheng Exp $
  *
+ * Portions Copyrighted 2025 Wren Security.
  */
 
 package com.sun.identity.common;
@@ -46,6 +47,8 @@ public class AccountLockoutInfo {
     private String userToken = null;
 
     private long actualLockoutDuration=0;
+
+    private int noOfTimesLocked;
 
     /**
      * Returns the current failure count stored in this object.
@@ -177,4 +180,21 @@ public class AccountLockoutInfo {
     public String getUserToken() {
         return userToken;
     }
+
+    /**
+     * Gets the number of times the account was locked.
+     * <p>
+     * This counter has to be reset to 0 after successful login.
+     */
+    public int getNoOfTimesLocked() {
+        return noOfTimesLocked;
+    }
+
+    /**
+     * Sets the number of times the account was locked.
+     */
+    public void setNoOfTimesLocked(int noOfTimesLocked) {
+        this.noOfTimesLocked = noOfTimesLocked;
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue when accounts could not be repeatedly locked out for some period of time.

It also introduces a new element in XML that stores the lockout data - `NoOfTimesLocked`. The element contains the value of how many times the account has been locked. Its name is based on ForgeRock's AM behavior for compatibility reasons.