### PR TITLE
Fix Monitoring Service startup

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/cts/CoreTokenServiceGuiceModule.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/CoreTokenServiceGuiceModule.java
@@ -12,10 +12,10 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 package org.forgerock.openam.cts;
 
-import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -55,7 +55,6 @@ import org.forgerock.openam.sm.datalayer.api.DataLayer;
 import org.forgerock.openam.sm.datalayer.api.DataLayerConstants;
 import org.forgerock.openam.sm.datalayer.api.DataLayerException;
 import org.forgerock.openam.sm.datalayer.api.QueueConfiguration;
-import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.util.Option;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -125,7 +124,7 @@ public class CoreTokenServiceGuiceModule extends PrivateModule {
         // Enable monitoring of all CTS operations
         bind(ResultHandlerFactory.class).to(MonitoredResultHandlerFactory.class);
 
-        /**
+        /*
          * Core Token Service bindings are divided into a number of logical groups.
          */
         MapBinder<Option<?>, LdapOptionFunction> optionFunctionMapBinder = MapBinder.newMapBinder(binder(),
@@ -136,9 +135,12 @@ public class CoreTokenServiceGuiceModule extends PrivateModule {
 
         expose(Debug.class).annotatedWith(Names.named(CoreTokenConstants.CTS_DEBUG));
         expose(Debug.class).annotatedWith(Names.named(CoreTokenConstants.CTS_ASYNC_DEBUG));
+        expose(Debug.class).annotatedWith(Names.named(CoreTokenConstants.CTS_MONITOR_DEBUG));
         expose(new TypeLiteral<Map<Option<?>, LdapOptionFunction>>() {});
         expose(CoreTokenConfig.class);
         expose(CTSPersistentStore.class);
+        expose(CTSOperationsMonitoringStore.class);
+        expose(CTSReaperMonitoringStore.class);
         expose(CTSConnectionMonitoringStore.class);
         expose(ExecutorService.class).annotatedWith(Names.named(CoreTokenConstants.CTS_WORKER_POOL));
         expose(ObjectMapper.class).annotatedWith(Names.named(CoreTokenConstants.OBJECT_MAPPER));


### PR DESCRIPTION
The Monitoring Service was not starting due to some missing CTS Guice dependencies.

This patch exposes `Debug`, `CTSOperationsMonitoringStore` and `CTSReaperMonitoringStore` instances so they are available in the impacted classes from the package `org.forgerock.openam.monitoring.cts`.

Additionally, unused imports have been removed and an incorrect comment block style was updated to improve clarity.


Wren:AM logged following error: <details><summary>CoreSystem debug log</summary>
```log
amMonitoring:04/08/2025 04:43:08:802 PM CEST: Thread[RMI TCP Connection(2)-127.0.0.1,5,RMI Runtime]: TransactionId[b3e1b51f-db81-4267-9a78-58008c2ea3d8-0]
ERROR: ConfigMonitoring.getMonServiceAttrs: error reading Monitoring attributes: 
javax.management.RuntimeMBeanException: RuntimeException thrown in preRegister method
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.throwMBeanRegistrationException(DefaultMBeanServerInterceptor.java:979)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.preRegister(DefaultMBeanServerInterceptor.java:1003)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:913)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:895)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:320)
        at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:523)
        at com.sun.identity.monitoring.Agent.startAgent(Agent.java:623)
        at com.sun.identity.common.ConfigMonitoring.getMonServiceAttrs(ConfigMonitoring.java:1121)
        at com.sun.identity.common.ConfigMonitoring.configureMonitoring(ConfigMonitoring.java:123)
        at com.sun.identity.common.MonitoringConfiguration.init(MonitoringConfiguration.java:64)
        at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:1161)
        at org.apache.catalina.core.StandardWrapper.loadServlet(StandardWrapper.java:1114)
        at org.apache.catalina.core.StandardWrapper.load(StandardWrapper.java:1007)
        at org.apache.catalina.core.StandardContext.loadOnStartup(StandardContext.java:4948)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5256)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:726)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:698)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:696)
        at org.apache.catalina.startup.HostConfig.manageApp(HostConfig.java:1782)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:293)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:814)
        at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:802)
        at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:460)
        at org.apache.catalina.mbeans.MBeanFactory.createStandardContext(MBeanFactory.java:408)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.apache.tomcat.util.modeler.BaseModelMBean.invoke(BaseModelMBean.java:293)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:814)
        at java.management/com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:802)
        at java.management/com.sun.jmx.remote.security.MBeanServerAccessController.invoke(MBeanServerAccessController.java:472)
        at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1472)
        at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1310)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
        at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1412)
        at java.management.rmi/javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
        at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
        at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
        at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: com.google.inject.ConfigurationException: Guice configuration errors:

1) Unable to create binding for com.sun.identity.shared.debug.Debug annotated with @com.google.inject.name.Named(value=amCoreTokenMonitorService). It was already configured on one or more child injectors or private modules
    bound at org.forgerock.openam.cts.CoreTokenServiceGuiceModule.configure(CoreTokenServiceGuiceModule.java:99)
  If it was in a PrivateModule, did you forget to expose the binding?
  while locating com.sun.identity.shared.debug.Debug annotated with @com.google.inject.name.Named(value=amCoreTokenMonitorService)

1 error
        at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:1004)
        at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1009)
        at org.forgerock.guice.core.InjectorHolder.getInstance(InjectorHolder.java:97)
        at org.forgerock.openam.monitoring.cts.CtsMonitoringImpl.init(CtsMonitoringImpl.java:127)
        at org.forgerock.openam.monitoring.cts.CtsMonitoringImpl.<init>(CtsMonitoringImpl.java:95)
        at org.forgerock.openam.monitoring.cts.FORGEROCK_OPENAM_CTS_MIBImpl.createCtsMonitoringMBean(FORGEROCK_OPENAM_CTS_MIBImpl.java:74)
        at org.forgerock.openam.monitoring.cts.FORGEROCK_OPENAM_CTS_MIB.initCtsMonitoring(FORGEROCK_OPENAM_CTS_MIB.java:149)
        at org.forgerock.openam.monitoring.cts.FORGEROCK_OPENAM_CTS_MIB.populate(FORGEROCK_OPENAM_CTS_MIB.java:100)
        at org.forgerock.openam.monitoring.cts.FORGEROCK_OPENAM_CTS_MIB.preRegister(FORGEROCK_OPENAM_CTS_MIB.java:76)
        at java.management/com.sun.jmx.mbeanserver.MBeanSupport.preRegister(MBeanSupport.java:167)
        at java.management/com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.preRegister(DefaultMBeanServerInterceptor.java:1001)
        ... 57 more

```
</details>