### PR TITLE
Fix editing of policy subjects and environments

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrArrayView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ConditionAttrArrayView.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2024 Wren Security.
+ * Portions copyright 2024-2025 Wren Security.
  */
 
 define([
@@ -165,7 +165,7 @@ define([
                         selectize.addOption({ value, text: value });
                     });
                     callback(data.result);
-                }).error(function (e) {
+                }).fail(function (e) {
                     console.error("error", e);
                     callback();
                 });
@@ -187,7 +187,7 @@ define([
                         selectize.addOption({ value: value._id, text: value.name });
                     });
                     callback(data.result);
-                }).error(function (e) {
+                }).fail(function (e) {
                     console.error("error", e);
                     callback();
                 });

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/LegacyListItemView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/LegacyListItemView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 
 define([
@@ -23,25 +24,22 @@ define([
     return AbstractView.extend({
         data: {},
         mode: "append",
-        render (itemData, callback, element, itemID) {
+        render (itemData, element, itemID) {
             this.setElement(element);
             this.data.itemID = itemID;
             this.data.itemData = itemData;
 
             var self = this;
 
-            UIUtils.fillTemplateWithData(
+            return UIUtils.compileTemplate(
                 "templates/admin/views/realms/authorization/policies/conditions/LegacyListItem.html",
-                this.data,
-                function () {
-                    self.setElement(`#legacy_${itemID}`);
-                    self.delegateEvents();
+                this.data
+            ).then(() => {
+                self.setElement(`#legacy_${itemID}`);
+                self.delegateEvents();
 
-                    self.$el.data("itemData", itemData);
-                    if (callback) {
-                        callback();
-                    }
-                });
+                self.$el.data("itemData", itemData);
+            });
         }
     });
 });

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageEnvironmentsView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageEnvironmentsView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 
 define([
@@ -23,7 +24,7 @@ define([
     var ManageEnvironmentsView = ManageRulesView.extend({
         element: "#environmentContainer",
         envEvents: {
-            "change .environment-area .operator > select": "onSelect",
+            "change    #dropOffArea .operator > select": "onSelect",
             "mousedown #operatorEnv_0 li.rule:not(.editing)": "setFocus",
             "mousedown #operatorEnv_0 li.operator:not(.editing)": "setFocus",
 
@@ -93,13 +94,14 @@ define([
                     this.buttons.addOperator.hide();
                 }
 
-                this.buildList();
-                this.initSorting();
-                this.identifyDroppableLogical();
+                this.buildList().done(() => {
+                    this.initSorting();
+                    this.identifyDroppableLogical();
 
-                if (callback) {
-                    callback();
-                }
+                    if (callback) {
+                        callback();
+                    }
+                });
             });
         }
     });

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageSubjectsView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageSubjectsView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 
 define([
@@ -23,7 +24,7 @@ define([
     var ManageSubjectsView = ManageRulesView.extend({
         element: "#subjectContainer",
         subEvents: {
-            "change .subject-area .operator > select": "onSelect",
+            "change    #dropOffArea .operator > select": "onSelect",
             "mousedown #operatorSub_0 li.rule:not(.editing)": "setFocus",
             "mousedown #operatorSub_0 li.operator:not(.editing)": "setFocus",
 
@@ -93,13 +94,14 @@ define([
                     this.buttons.addOperator.hide();
                 }
 
-                this.buildList();
-                this.initSorting();
-                this.identifyDroppableLogical();
+                this.buildList().done(() => {
+                    this.initSorting();
+                    this.identifyDroppableLogical();
 
-                if (callback) {
-                    callback();
-                }
+                    if (callback) {
+                        callback();
+                    }
+                });
             });
         }
     });

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/OperatorRulesView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/OperatorRulesView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Portions copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 
 define([
@@ -35,7 +36,7 @@ define([
 
         operatorI18nKey: "console.authorization.policies.edit.operators.",
 
-        render (args, element, itemID, firstChild, callback) {
+        render (args, element, itemID, firstChild) {
             var self = this;
 
             this.data = $.extend(true, {}, args);
@@ -48,7 +49,7 @@ define([
 
             this.setElement(element);
 
-            UIUtils.fillTemplateWithData(this.template, this.data, function (tpl) {
+            return UIUtils.compileTemplate(this.template, this.data).then((tpl) => {
                 self.$el.append(tpl);
 
                 self.setElement(`#operator${itemID}`);
@@ -60,10 +61,6 @@ define([
                 self.dropbox = self.$el.find(".dropbox");
 
                 self.$el.find('.fa[data-toggle="popover"]').popover();
-
-                if (callback) {
-                    callback();
-                }
             });
         },
 

--- a/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authorization/policies/conditions/ManageRulesTemplate.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authorization/policies/conditions/ManageRulesTemplate.html
@@ -1,5 +1,5 @@
 <div id="condition-management">
-    <ol id="dropOffArea" class="condition-management-group environment-area"></ol>
+    <ol id="dropOffArea" class="condition-management-group"></ol>
 
     <a class="btn btn-default" role="button" id="addCondition" tabindex="0" data-add-condition>
         <span class="fa fa-plus"></span> {{conditionName}}


### PR DESCRIPTION
Some of the previous wrensec-ui ugprades contains upgrade of jQuery (from 2.x to 3.x), which broke edit Policy page, specifically Subjects and Environments sections (see issue #200) I believe the issue are jQuery's Deferred behavior changes (see https://jquery.com/upgrade-guide/3.0/#deferred):

> Another behavior change required for Promises/A+ compliance is that Deferred `.then()` callbacks are always called asynchronously. Previously, if a `.then()` callback was added to a Deferred that was already resolved or rejected, the callback would run immediately and synchronously.

I believe this broke the mentioned sections where we assumed rendering of condition views was synchronous.

This PR fixes the mentioned sections. During my testing I have found some minor issues caused by invalid setting of subjects and environments. These issues were present before mentioned wrensec-ui upgrade, I didn't fix all of them in this PR.

Recording of the fixed sections:
https://github.com/user-attachments/assets/55d78cae-c52e-425e-bd95-fb463f2834f1