### PR TITLE
Upgrade Jakarta Apache CXF HTTP Transport bundle

### DIFF
--- a/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
+++ b/openam-sts/openam-soap-sts/openam-soap-sts-server/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
-            <version>${cxf.version}-jakarta1</version>
+            <version>${cxf.version}-jakarta2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.8.5-SNAPSHOT</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.9.0</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
 
         <!-- Source code has to be Java 8 compliant (code base is not JPMS ready) -->


### PR DESCRIPTION
This PR upgrades the Jakarta Apache CXF HTTP Transport bundle. The previous version had broken dependencies in the POM file.