### PR TITLE
Remove duplicate dependency entry within parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,26 +430,6 @@
                 </exclusions>
             </dependency>
 
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource-http</artifactId>
-                <version>${wrensec-commons.version}</version>
-
-                <exclusions>
-                    <!-- Replaced by Jakarta -->
-                    <exclusion>
-                        <groupId>com.sun.mail</groupId>
-                        <artifactId>javax.mail</artifactId>
-                    </exclusion>
-
-                    <exclusion>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-osgi</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>org.wrensecurity.commons</groupId>
                 <artifactId>json-web-token</artifactId>


### PR DESCRIPTION
This PR removes a duplicate dependency entry for the `json-resource-http` artifact in the parent POM. While it's a minor change, I was motivated to address it because IntelliJ IDEA flagged it during every Maven project reload.