### PR TITLE
Add JSON debug log format

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/setup/SetupProgress.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/SetupProgress.java
@@ -25,6 +25,7 @@
  * $Id: SetupProgress.java,v 1.10 2008/08/31 06:56:18 hengming Exp $
  *
  * Portions Copyrighted 2011-2017 ForgeRock AS.
+ * Portions Copyrighted 2025 Wren Security.
  */
 
 package com.sun.identity.setup;

--- a/openam-core/src/main/java/com/sun/identity/setup/SetupProgress.java
+++ b/openam-core/src/main/java/com/sun/identity/setup/SetupProgress.java
@@ -29,7 +29,7 @@
 
 package com.sun.identity.setup;
 
-import static com.sun.identity.shared.debug.DebugConstants.DEBUG_DATE_FORMAT;
+import static com.sun.identity.shared.debug.DebugConstants.DEBUG_DATE_FORMATTER;
 import static org.forgerock.openam.utils.Time.newDate;
 
 import org.forgerock.openam.utils.IOUtils;
@@ -204,9 +204,7 @@ public class SetupProgress {
 
     private static void reportDebug(String istr) {
 
-        synchronized (DEBUG_DATE_FORMAT) {
-            istr = DEBUG_DATE_FORMAT.format(newDate()) + ": " + istr;
-        }
+        istr = DEBUG_DATE_FORMATTER.format(newDate().toInstant()) + ": " + istr;
 
         try {
                 InstallLog.getInstance().write(istr + "\n");

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
@@ -12,11 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
- * Portions Copyright 2022 Wren Security
+ * Portions Copyright 2022-2025 Wren Security
  */
 package com.sun.identity.shared.debug;
 
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Debug constant
@@ -58,7 +59,10 @@ public final class DebugConstants {
      */
     public static final String CONFIG_DEBUG_PROVIDER = "com.sun.identity.util.debug.provider";
 
-    public static final SimpleDateFormat DEBUG_DATE_FORMAT = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss:SSS a zzz");
+    public static final DateTimeFormatter DEBUG_DATE_FORMATTER =
+        DateTimeFormatter
+            .ofPattern("MM/dd/yyyy hh:mm:ss:SSS a zzz")
+            .withZone(ZoneId.systemDefault());
 
     private DebugConstants() {
 

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
@@ -43,6 +43,14 @@ public final class DebugConstants {
 
     public static final String CONFIG_DEBUG_LOGFILE_MAX_SIZE = "org.forgerock.openam.debug.rotation.maxsize";
 
+    /**
+     * Control the type of formatter created by the debug formatter factory.
+     *
+     * <p>Set this property to {@code json} to use the JSON formatter,
+     * or leave it empty to use the legacy plain text formatter.
+     */
+    public static final String CONFIG_DEBUG_LOGFILE_FORMAT = "org.forgerock.openam.debug.format";
+
     public static final String DEFAULT_DEBUG_SUFFIX_FORMAT = "-yyyy-MM-dd'T'HH-mm-ss.SSSXX";
 
     public static final String CONFIG_DEBUG_LEVEL = "com.iplanet.services.debug.level";

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/DebugConstants.java
@@ -43,7 +43,7 @@ public final class DebugConstants {
 
     public static final String CONFIG_DEBUG_LOGFILE_MAX_SIZE = "org.forgerock.openam.debug.rotation.maxsize";
 
-    public static final String DEFAULT_DEBUG_SUFFIX_FORMAT = "-yyyy.MM.dd-HH.mm.ss";
+    public static final String DEFAULT_DEBUG_SUFFIX_FORMAT = "-yyyy-MM-dd'T'HH-mm-ss.SSSXX";
 
     public static final String CONFIG_DEBUG_LEVEL = "com.iplanet.services.debug.level";
 
@@ -60,9 +60,7 @@ public final class DebugConstants {
     public static final String CONFIG_DEBUG_PROVIDER = "com.sun.identity.util.debug.provider";
 
     public static final DateTimeFormatter DEBUG_DATE_FORMATTER =
-        DateTimeFormatter
-            .ofPattern("MM/dd/yyyy hh:mm:ss:SSS a zzz")
-            .withZone(ZoneId.systemDefault());
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.systemDefault());
 
     private DebugConstants() {
 

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/file/DebugFile.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/file/DebugFile.java
@@ -12,9 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2015 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 package com.sun.identity.shared.debug.file;
 
+import com.sun.identity.shared.debug.format.DebugRecord;
 import java.io.IOException;
 
 
@@ -41,14 +43,12 @@ import java.io.IOException;
 public interface DebugFile {
 
     /**
-     * Write message into file
+     * Write debug log record into file.
      *
-     * @param prefix Message prefix
-     * @param msg    Message to be recorded.
-     * @param th     the optional <code>java.lang.Throwable</code> which if
-     *               present will be used to record the stack trace.
+     * @param logRecord Debug log record to be written.
+     *
      * @throws IOException
      */
-    public void writeIt(String prefix, String msg, Throwable th) throws IOException;
+    public void write(DebugRecord logRecord) throws IOException;
 
 }

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/file/impl/DebugConfigurationFromProperties.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/file/impl/DebugConfigurationFromProperties.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 package com.sun.identity.shared.debug.file.impl;
 
@@ -19,12 +20,14 @@ import static org.forgerock.openam.utils.Time.*;
 
 import com.sun.identity.shared.debug.DebugConstants;
 import com.sun.identity.shared.debug.file.DebugConfiguration;
+import java.time.ZoneId;
 import org.forgerock.openam.utils.IOUtils;
 import org.forgerock.openam.utils.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Properties;
 
@@ -184,12 +187,13 @@ public class DebugConfigurationFromProperties implements DebugConfiguration {
      */
     private boolean validateSuffix(int field, int amount) throws IllegalArgumentException {
         // Check the rotation and suffix consistency
-        SimpleDateFormat dateFormat = new SimpleDateFormat(getDebugSuffix());
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(getDebugSuffix())
+            .withZone(ZoneId.systemDefault());
         Calendar cal = getCalendarInstance();
         cal.setTimeInMillis(0);
-        String initialSuffix = dateFormat.format(cal.getTime());
+        String initialSuffix = dateTimeFormatter.format(Instant.ofEpochMilli(cal.getTimeInMillis()));
         cal.add(field, amount);
-        String suffixAfterOneRotation = dateFormat.format(cal.getTime());
+        String suffixAfterOneRotation = dateTimeFormatter.format(Instant.ofEpochMilli(cal.getTimeInMillis()));
         return suffixAfterOneRotation.equals(initialSuffix);
     }
 

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/file/impl/StdDebugFile.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/file/impl/StdDebugFile.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security.
  */
 package com.sun.identity.shared.debug.file.impl;
 
@@ -23,8 +24,6 @@ import com.sun.identity.shared.debug.file.DebugFile;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 
 /**
  * Debug file dedicated to std out
@@ -71,9 +70,8 @@ public class StdDebugFile implements DebugFile {
      * @param ex        the exception (can be null)
      */
     public static void printError(String debugName, String message, Throwable ex) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss:SSS a zzz");
-        String prefix = debugName + ":" + dateFormat.format(newDate()) + ": " + Thread.currentThread().toString() +
-                "\n";
+        String timestamp = DebugConstants.DEBUG_DATE_FORMATTER.format(newDate().toInstant());
+        String prefix = debugName + ":" + timestamp + ": " + Thread.currentThread() + "\n";
 
         System.err.println(prefix + message);
         if (ex != null) {

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/format/DebugFormatter.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/format/DebugFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2025 Wren Security. All rights reserved.
+ */
+package com.sun.identity.shared.debug.format;
+
+/**
+ * Convert {@link DebugRecord} instances into their string representations
+ * using a defined formatting strategy.
+ */
+public interface DebugFormatter {
+
+    /**
+     * Formats the provided {@link DebugRecord} according to the implementation's rules.
+     *
+     * @param logRecord the debug record to format
+     * @return a string representation of the debug record
+     */
+    String format(DebugRecord logRecord);
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/format/DebugRecord.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/format/DebugRecord.java
@@ -1,0 +1,45 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2025 Wren Security. All rights reserved.
+ */
+package com.sun.identity.shared.debug.format;
+
+import com.sun.identity.shared.debug.DebugLevel;
+import java.time.Instant;
+
+/**
+ * Represent an immutable value object containing all data used to write a single debug log entry.
+ */
+public class DebugRecord {
+
+    public final Instant timestamp;
+    public final DebugLevel level;
+    public final String thread;
+    public final String logger;
+    public final String message;
+    public final String transactionId;
+    public final Throwable throwable;
+
+    public DebugRecord(Instant timestamp, DebugLevel level, String thread, String logger,
+        String message, String transactionId, Throwable throwable) {
+        this.timestamp = timestamp;
+        this.level = level;
+        this.thread = thread;
+        this.logger = logger;
+        this.message = message;
+        this.transactionId = transactionId;
+        this.throwable = throwable;
+    }
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/DebugFormatterFactory.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/DebugFormatterFactory.java
@@ -1,0 +1,46 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2025 Wren Security. All rights reserved.
+ */
+package com.sun.identity.shared.debug.format.impl;
+
+import com.sun.identity.shared.configuration.SystemPropertiesManager;
+import com.sun.identity.shared.debug.DebugConstants;
+import com.sun.identity.shared.debug.format.DebugFormatter;
+
+/**
+ * Expose a singleton {@link DebugFormatter} determined by the
+ * {@value DebugConstants#CONFIG_DEBUG_LOGFILE_FORMAT} system property.
+ */
+public class DebugFormatterFactory {
+
+    private static final DebugFormatter formatterInstance;
+
+    static {
+        String logFileFormat = SystemPropertiesManager.get(DebugConstants.CONFIG_DEBUG_LOGFILE_FORMAT);
+        formatterInstance =
+            "json".equalsIgnoreCase(logFileFormat) ? new JsonDebugFormatter() : new PlainTextDebugFormatter();
+    }
+
+    private DebugFormatterFactory() {
+    }
+
+    /**
+     * Return the formatter instance selected for the current run.
+     */
+    public static DebugFormatter getInstance() {
+        return formatterInstance;
+    }
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/JsonDebugFormatter.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/JsonDebugFormatter.java
@@ -1,0 +1,65 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2025 Wren Security. All rights reserved.
+ */
+package com.sun.identity.shared.debug.format.impl;
+
+import com.sun.identity.shared.debug.DebugConstants;
+import com.sun.identity.shared.debug.format.DebugFormatter;
+import com.sun.identity.shared.debug.format.DebugRecord;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.forgerock.json.JsonValue;
+
+/**
+ * Format {@link DebugRecord DebugRecords} as a serialized JSON object.
+ */
+public class JsonDebugFormatter implements DebugFormatter {
+
+    @Override
+    public String format(DebugRecord logRecord) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("timestamp", DebugConstants.DEBUG_DATE_FORMATTER.format(logRecord.timestamp));
+        message.put("level", logRecord.level.getName());
+        message.put("thread", logRecord.thread);
+        message.put("logger", logRecord.logger);
+        message.put("message", logRecord.message);
+        message.put("transactionId", logRecord.transactionId);
+
+        if (logRecord.throwable != null) {
+            Map<String, Object> exception = getExceptionJson(logRecord);
+            message.put("exception", exception);
+        }
+
+        return new JsonValue(message).toString();
+    }
+
+    private Map<String, Object> getExceptionJson(DebugRecord logRecord) {
+        Map<String, Object> exception = new LinkedHashMap<>();
+        Throwable throwable = logRecord.throwable;
+        exception.put("class", throwable.getClass().getName());
+        if (throwable.getMessage() != null) {
+            exception.put("message", throwable.getMessage());
+        }
+        StringWriter stringBuffer = new StringWriter(DebugConstants.MAX_BUFFER_SIZE_EXCEPTION);
+        PrintWriter stackTraceStream = new PrintWriter(stringBuffer);
+        throwable.printStackTrace(stackTraceStream);
+        stackTraceStream.flush();
+        exception.put("stackTrace", stringBuffer.toString());
+        return exception;
+    }
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/PlainTextDebugFormatter.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/format/impl/PlainTextDebugFormatter.java
@@ -1,0 +1,59 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2025 Wren Security. All rights reserved.
+ */
+package com.sun.identity.shared.debug.format.impl;
+
+import com.sun.identity.shared.debug.DebugConstants;
+import com.sun.identity.shared.debug.format.DebugFormatter;
+import com.sun.identity.shared.debug.format.DebugRecord;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+/**
+ * Format {@link DebugRecord DebugRecords} in the legacy plain text layout.
+ */
+public class PlainTextDebugFormatter implements DebugFormatter {
+
+    @Override public String format(DebugRecord logRecord) {
+        StringBuilder buffer = new StringBuilder()
+            .append(logRecord.logger)
+            .append(':').append(DebugConstants.DEBUG_DATE_FORMATTER.format(logRecord.timestamp))
+            .append(": ").append(logRecord.thread)
+            .append(": TransactionId[").append(logRecord.transactionId).append(']')
+            .append('\n');
+
+        switch (logRecord.level) {
+            case WARNING:
+                buffer.append("WARNING: ");
+                break;
+            case ERROR:
+                buffer.append("ERROR: ");
+                break;
+            default:
+                break;
+        }
+        buffer.append(logRecord.message);
+
+        if (logRecord.throwable != null) {
+            StringWriter stringBuffer = new StringWriter(DebugConstants.MAX_BUFFER_SIZE_EXCEPTION);
+            PrintWriter stackTraceStream = new PrintWriter(stringBuffer);
+            logRecord.throwable.printStackTrace(stackTraceStream);
+            stackTraceStream.flush();
+            buffer.append('\n').append(stringBuffer);
+        }
+        return buffer.toString();
+    }
+
+}

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/impl/DebugImpl.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/impl/DebugImpl.java
@@ -25,10 +25,11 @@
  * $Id: DebugImpl.java,v 1.4 2009/03/07 08:01:53 veiming Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
+ * Portions Copyrighted 2025 Wren Security.
  */
 package com.sun.identity.shared.debug.impl;
 
-import static com.sun.identity.shared.debug.DebugConstants.DEBUG_DATE_FORMAT;
+import static com.sun.identity.shared.debug.DebugConstants.DEBUG_DATE_FORMATTER;
 import static org.forgerock.openam.utils.StringUtils.isNotEmpty;
 import static org.forgerock.openam.utils.Time.*;
 
@@ -40,12 +41,12 @@ import com.sun.identity.shared.debug.IDebug;
 import com.sun.identity.shared.debug.file.DebugFile;
 import com.sun.identity.shared.debug.file.DebugFileProvider;
 import com.sun.identity.shared.debug.file.impl.StdDebugFile;
+import java.time.Instant;
 import org.forgerock.openam.audit.context.AuditRequestContext;
 import org.forgerock.openam.utils.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Properties;
@@ -238,10 +239,7 @@ public class DebugImpl implements IDebug {
     private void record(String msg, Throwable th) {
 
         StringBuilder prefix = new StringBuilder();
-        String dateFormatted;
-        synchronized (DEBUG_DATE_FORMAT) {
-            dateFormatted = DEBUG_DATE_FORMAT.format(newDate());
-        }
+        String dateFormatted = DEBUG_DATE_FORMATTER.format(newDate().toInstant());
         prefix.append(debugName)
                 .append(":").append(dateFormatted)
                 .append(": ").append(Thread.currentThread().toString())

--- a/openam-shared/src/main/java/com/sun/identity/shared/debug/impl/DebugImpl.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/debug/impl/DebugImpl.java
@@ -29,7 +29,6 @@
  */
 package com.sun.identity.shared.debug.impl;
 
-import static com.sun.identity.shared.debug.DebugConstants.DEBUG_DATE_FORMATTER;
 import static org.forgerock.openam.utils.StringUtils.isNotEmpty;
 import static org.forgerock.openam.utils.Time.*;
 
@@ -41,7 +40,8 @@ import com.sun.identity.shared.debug.IDebug;
 import com.sun.identity.shared.debug.file.DebugFile;
 import com.sun.identity.shared.debug.file.DebugFileProvider;
 import com.sun.identity.shared.debug.file.impl.StdDebugFile;
-import java.time.Instant;
+import com.sun.identity.shared.debug.format.DebugRecord;
+import java.util.Date;
 import org.forgerock.openam.audit.context.AuditRequestContext;
 import org.forgerock.openam.utils.IOUtils;
 
@@ -208,7 +208,7 @@ public class DebugImpl implements IDebug {
      */
     public void message(String message, Throwable th) {
         if (messageEnabled()) {
-            record(message, th);
+            record(DebugLevel.MESSAGE, message, th);
         }
     }
 
@@ -220,7 +220,7 @@ public class DebugImpl implements IDebug {
      */
     public void warning(String message, Throwable th) {
         if (warningEnabled()) {
-            record("WARNING: " + message, th);
+            record(DebugLevel.WARNING, message, th);
         }
     }
 
@@ -232,20 +232,8 @@ public class DebugImpl implements IDebug {
      */
     public void error(String message, Throwable th) {
         if (errorEnabled()) {
-            record("ERROR: " + message, th);
+            record(DebugLevel.ERROR, message, th);
         }
-    }
-
-    private void record(String msg, Throwable th) {
-
-        StringBuilder prefix = new StringBuilder();
-        String dateFormatted = DEBUG_DATE_FORMATTER.format(newDate().toInstant());
-        prefix.append(debugName)
-                .append(":").append(dateFormatted)
-                .append(": ").append(Thread.currentThread().toString())
-                .append(": TransactionId[").append(getAuditTransactionId()).append("]");
-
-        writeIt(prefix.toString(), msg, th);
     }
 
     /**
@@ -262,15 +250,23 @@ public class DebugImpl implements IDebug {
     }
 
     /**
-     * Write message on Debug file. If it failed, it try to print it on the Sdtout Debug file.
-     * If both failed, it prints in System.out
+     * Write message on Debug file. If it failed, try to print it on the stdout debug file.
+     * If both failed, print in System.out via {@link StdDebugFile#printError}.
      *
-     * @param prefix Message prefix
-     * @param msg    Message to be recorded.
-     * @param th     the optional <code>java.lang.Throwable</code> which if
-     *               present will be used to record the stack trace.
+     * @param level     debug level
+     * @param message   message to be recorded
+     * @param throwable the optional <code>java.lang.Throwable</code> which if
+     *                  present will be used to record the stack trace
      */
-    private void writeIt(String prefix, String msg, Throwable th) {
+    private void record(DebugLevel level, String message, Throwable throwable) {
+        DebugRecord logRecord = new DebugRecord(
+            new Date().toInstant(),
+            level,
+            Thread.currentThread().getName(),
+            debugName,
+            message,
+            getAuditTransactionId(),
+            throwable);
 
         //we create the debug file only if we need to write on it
         if (debugFile == null) {
@@ -280,11 +276,11 @@ public class DebugImpl implements IDebug {
 
         try {
             if (this.debugLevel == DebugLevel.ON) {
-                stdoutDebugFile.writeIt(prefix, msg, th);
+                stdoutDebugFile.write(logRecord);
             } else {
 
                 try {
-                    this.debugFile.writeIt(prefix, msg, th);
+                    this.debugFile.write(logRecord);
                 } catch (IOException e) {
                     /*
                      * In order to have less logs for this kind of issue. It's waiting an interval of time before
@@ -292,9 +288,10 @@ public class DebugImpl implements IDebug {
                      */
                     if (lastDirectoryIssue + DIR_ISSUE_ERROR_INTERVAL_IN_MS < currentTimeMillis()) {
                         lastDirectoryIssue = currentTimeMillis();
-                        stdoutDebugFile.writeIt(prefix, "Debug file can't be written : " + e.getMessage(), null);
+                        StdDebugFile.printError(DebugImpl.class.getSimpleName(),
+                            "Debug file can't be written : " + e.getMessage(), null);
                     }
-                    stdoutDebugFile.writeIt(prefix, msg, th);
+                    stdoutDebugFile.write(logRecord);
 
                 }
             }

--- a/openam-shared/src/test/java/com/sun/identity/shared/debug/format/JsonDebugFormatterTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/debug/format/JsonDebugFormatterTest.java
@@ -1,0 +1,99 @@
+package com.sun.identity.shared.debug.format;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.identity.shared.debug.DebugLevel;
+import com.sun.identity.shared.debug.format.impl.JsonDebugFormatter;
+import java.time.Instant;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link JsonDebugFormatter}, verifying that
+ * {@link DebugRecord} instances are correctly serialized to JSON.
+ */
+public class JsonDebugFormatterTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final JsonDebugFormatter FORMATTER = new JsonDebugFormatter();
+
+    private static final Instant TIMESTAMP = Instant.parse("2025-08-08T12:34:56Z");
+
+    private static final String THREAD = "https-jsse-nio-443-exec-8";
+
+    private static final String LOGGER = "RestApis";
+
+    private static final String TRANSACTION_ID = "94c1578f-8289-48f9-9ade-96849f8da56f-207";
+
+    private static DebugRecord record(DebugLevel level, String message, Throwable throwable) {
+        return new DebugRecord(TIMESTAMP, level, THREAD, LOGGER, message, TRANSACTION_ID, throwable);
+    }
+
+    @Test
+    public void producesValidJson() {
+        Throwable throwable = new IllegalStateException("Foobar");
+        DebugRecord debugRecord = record(DebugLevel.ERROR, "Unrecognized or invalid syntax", throwable);
+        try {
+            MAPPER.readTree(FORMATTER.format(debugRecord));
+        } catch (JsonProcessingException e) {
+            fail("Expected valid JSON but parsing threw an exception", e);
+        }
+    }
+
+    @Test
+    public void formatsFieldsIncludingException() throws Exception {
+        // Given
+        Throwable throwable = new IllegalStateException("Foobar");
+        DebugRecord debugRecord = record(DebugLevel.ERROR, "Unrecognized or invalid syntax", throwable);
+
+        // When
+        Map<String, Object> root = MAPPER.readValue(FORMATTER.format(debugRecord),
+                new TypeReference<Map<String, Object>>() {
+                });
+
+        // Then
+        assertEquals(root.get("level"), "error");
+        assertEquals(root.get("thread"), THREAD);
+        assertEquals(root.get("logger"), LOGGER);
+        assertEquals(root.get("message"), "Unrecognized or invalid syntax");
+        assertEquals(root.get("transactionId"), TRANSACTION_ID);
+        assertNotNull(root.get("timestamp"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> e = (Map<String, Object>) root.get("exception");
+        assertNotNull(e, "Exception must be present");
+        assertEquals(e.get("class"), "java.lang.IllegalStateException");
+        assertEquals(e.get("message"), "Foobar");
+
+        String stack = String.valueOf(e.get("stackTrace"));
+        assertNotNull(stack);
+        assertTrue(stack.contains("java.lang.IllegalStateException"));
+        assertTrue(stack.contains("Foobar"));
+        assertTrue(stack.contains("at "));
+    }
+
+    @Test
+    public void omitsExceptionWhenNull() throws Exception {
+        // Given
+        DebugRecord debugRecord = record(DebugLevel.MESSAGE, "Initialized event listener", null);
+
+        // When
+        Map<String, Object> root = MAPPER.readValue(FORMATTER.format(debugRecord),
+                new TypeReference<Map<String, Object>>() {
+                });
+
+        // Then
+        assertEquals(root.get("level"), "message");
+        assertEquals(root.get("message"), "Initialized event listener");
+        assertFalse(root.containsKey("exception"), "Exception must be absent when throwable is null");
+    }
+
+}


### PR DESCRIPTION
This PR addresses part of #214 by introducing a new `DebugRecord` value object to encapsulate log entry data, and a `DebugFormatter` abstraction with `PlainTextDebugFormatter` (legacy format) and `JsonDebugFormatter` (structured output) implementations. The active formatter is selected via the new `org.forgerock.openam.debug.format` system property; for example, setting `-Dorg.forgerock.openam.debug.format=json` enables JSON-formatted debug output, while omitting it defaults to the legacy plain text format.

It also replaces the legacy `SimpleDateFormat` with the thread-safe `DateTimeFormatter` and updates date/time formats to better align with the ISO-8601 standard.