### PR TITLE
Fix policy subjects and environments edit pages not working correctly.

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/CreatedResourcesView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/CreatedResourcesView.js
@@ -147,6 +147,8 @@ define([
         },
 
         deleteResource (e) {
+            e.stopPropagation();
+
             if (e.type === "keyup" && e.keyCode !== 13) {
                 return;
             }

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditEnvironmentView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditEnvironmentView.js
@@ -53,7 +53,7 @@ define([
 
             this.setElement(element);
 
-            this.data = $.extend(true, [], schema);
+            this.data = $.extend(true, {}, schema);
             this.data.itemID = itemID;
 
             _.each(this.data.conditions, function (condition) {

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditSubjectView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/EditSubjectView.js
@@ -40,7 +40,7 @@ define([
             var self = this;
             this.setElement(element);
 
-            this.data = $.extend(true, [], schema);
+            this.data = $.extend(true, {}, schema);
             this.data.itemID = itemID;
 
             _.each(this.data.subjects, function (subj) {
@@ -73,8 +73,8 @@ define([
         createListItem (allSubjects, item) {
             var self = this,
                 itemToDisplay = null,
-                itemData = item.data(),
-                hiddenData = item.data(),
+                itemData = item.data().itemData,
+                hiddenData = item.data().hiddenData,
                 type,
                 list,
                 mergedData = _.merge({}, itemData, hiddenData);

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageRulesView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authorization/policies/conditions/ManageRulesView.js
@@ -267,7 +267,7 @@ define([
             var self = this,
                 editRuleView = self.getNewRule(),
                 properties = self.getProperties(),
-                itemData = item.data(),
+                itemData = item.data().itemData,
                 disabledConditions;
 
             editRuleView.render(properties, item.parent(), self.idCount, itemData, true).then(() => {


### PR DESCRIPTION
This PR fixes policy subjects and environment edit pages behaving incorrectly (see #230) and another issue when deleting a policy resource would also open policy delete dialog unintentionally. 