### PR TITLE
Ignore backport branches when building project with push event

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -2,6 +2,8 @@ name: Build project
 
 on:
   push:
+    branches-ignore:
+      - 'backport/**'
   pull_request:
 
 permissions:


### PR DESCRIPTION
Right now when we use backport workflow that creates backport/** branch, the build-project workflow is being run twice - once for the `pull_request` event and once for the `push` event (unnecessary).