### PR TITLE
Fix Oauth2 Provider service configuration

### DIFF
--- a/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
@@ -12,6 +12,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2016 ForgeRock AS.
+# Portions Copyright 2025 Wren Security
 #
 
 coreOAuth2Config=statelessTokensEnabled
@@ -58,6 +59,7 @@ advancedOIDCConfig=forgerock-oauth2-provider-generate-registration-access-tokens
 advancedOIDCConfig=alwaysAddClaimsToToken
 advancedOIDCConfig=forgerock-oauth2-provider-claims-parameter-supported
 advancedOIDCConfig=forgerock-oauth2-provider-jkws-uri
+advancedOIDCConfig=oidcSsoProviderEnabled
 
 deviceCodeConfig=verificationUrl
 deviceCodeConfig=completionUrl


### PR DESCRIPTION
This PR fixes the "Invalid attribute" error that occurs when attempting to modify any attribute of the OAuth2 Provider global service. See the image below for reference.

<img width="1326" height="676" alt="image" src="https://github.com/user-attachments/assets/f55df150-facd-482a-b2a6-f382a088b362" />
