### PR TITLE
Fix modification of advanced properties

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/EditRow.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/EditRow.html
@@ -15,7 +15,7 @@
 {{/each}}
 <td class="fr-col-btn-2">
     <div class="btn-group">
-        <button class="btn btn-link" data-save-row title="{{t 'common.form.update'}}"><i class="fa fa-check"></i></button>
-        <button class="btn btn-link" data-undo-edit-row title="{{t 'common.form.cancel'}}"><i class="fa fa-undo"></i></button>
+        <button class="btn btn-link" type="button" data-save-row title="{{t 'common.form.update'}}"><i class="fa fa-check"></i></button>
+        <button class="btn btn-link" type="button" data-undo-edit-row title="{{t 'common.form.cancel'}}"><i class="fa fa-undo"></i></button>
     </div>
 </td>

--- a/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/NewRow.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/NewRow.html
@@ -15,6 +15,6 @@
 {{/each}}
 <td class="fr-col-btn-2">
     <div class="btn-group">
-        <button class="btn btn-link" data-add-row title="{{t 'common.form.add'}}"><i class="fa fa-plus"></i></button>
+        <button class="btn btn-link" type="button" data-add-row title="{{t 'common.form.add'}}"><i class="fa fa-plus"></i></button>
     </div>
 </td>

--- a/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/ReadOnlyRow.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/common/components/table/ReadOnlyRow.html
@@ -1,7 +1,7 @@
 {{#each columns}}<td>{{this.data}}</td>{{/each}}
 <td class="fr-col-btn-2">
     <div class="btn-group">
-        <button class="btn btn-link" data-edit-row title="{{t 'common.form.edit'}}"><i class="fa fa-pencil"></i></button>
-        <button class="btn btn-link" data-delete-row title="{{t 'common.form.delete'}}"><i class="fa fa-close"></i></button>
+        <button class="btn btn-link" type="button" data-edit-row title="{{t 'common.form.edit'}}"><i class="fa fa-pencil"></i></button>
+        <button class="btn btn-link" type="button" data-delete-row title="{{t 'common.form.delete'}}"><i class="fa fa-close"></i></button>
     </div>
 </td>


### PR DESCRIPTION
This PR eliminates the unwanted page reload that occurs when trying to add, modify, or remove a property from the advanced properties table.