### PR TITLE
Fix auth_time handling and CTS mapping for better performance

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/cts/adapters/OAuthValues.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/adapters/OAuthValues.java
@@ -12,6 +12,8 @@
  * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Portions copyright 2025 Wren Security
  */
 package org.forgerock.openam.cts.adapters;
 
@@ -55,20 +57,12 @@ public class OAuthValues {
     }
 
     /**
-     * @param values A Collection containing a single timestamp to convert.
-     *               The timestamp must be in milliseconds from the epoch.
+     * @param timestamp Timestamp to convert (must be in milliseconds from the epoch).
      * @return A Calendar that represents this timestamp.
      */
-    public Calendar getDateValue(Collection<String> values) {
-        if (values == null || values.size() != 1) {
-            throw new IllegalArgumentException();
-        }
-        String dateString = values.iterator().next();
-        long timestamp = Long.parseLong(dateString);
-
+    public Calendar getDateValue(long timestamp) {
         Calendar calendar = getCalendarInstance(TimeUtils.UTC);
         calendar.setTimeInMillis(timestamp);
-
         return calendar;
     }
 

--- a/openam-core/src/main/java/org/forgerock/openam/cts/api/fields/OAuthTokenField.java
+++ b/openam-core/src/main/java/org/forgerock/openam/cts/api/fields/OAuthTokenField.java
@@ -12,6 +12,8 @@
  * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Portions copyright 2025 Wren Security
  */
 package org.forgerock.openam.cts.api.fields;
 
@@ -49,7 +51,7 @@ public enum OAuthTokenField {
     SESSION_ID(OAuth2Constants.Custom.SSO_TOKEN_ID, CoreTokenField.STRING_THIRTEEN),
     DEVICE_USER_CODE(OAuth2Constants.DeviceCode.USER_CODE, CoreTokenField.STRING_FOURTEEN),
     AUTH_GRANT_ID(OAuth2Constants.CoreTokenParams.AUTH_GRANT_ID, CoreTokenField.STRING_FIFTEEN),
-    AUTH_TIME(OAuth2Constants.CoreTokenParams.AUTH_TIME, CoreTokenField.DATE_TWO);
+    AUTH_TIME(OAuth2Constants.CoreTokenParams.AUTH_TIME, CoreTokenField.DATE_THREE);
 
     private final String oAuthField;
     private final CoreTokenField coreTokenField;

--- a/openam-core/src/test/java/org/forgerock/openam/cts/adapters/OAuthValuesTest.java
+++ b/openam-core/src/test/java/org/forgerock/openam/cts/adapters/OAuthValuesTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security
  */
 package org.forgerock.openam.cts.adapters;
 
@@ -25,21 +26,24 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 
-
+/**
+ * {@link OAuthValues} test case.
+ */
 public class OAuthValuesTest {
+
     @Test
     public void shouldStoreDateValue() {
         // Given
-        String date = "1370259234252";
+        long timestamp = 1370259234252L;
         OAuthValues values = new OAuthValues();
 
         // When
-        Calendar calendar = values.getDateValue(Arrays.asList(date));
+        Calendar calendar = values.getDateValue(timestamp);
         Collection<String> result = values.fromDateValue(calendar);
 
         // Then
         assertEquals(1, result.size());
-        assertThat(result).contains(date);
+        assertThat(result).contains(String.valueOf(timestamp));
     }
 
     @Test

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/GrantTypeAccessTokenGenerator.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/GrantTypeAccessTokenGenerator.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security
  */
 
 package org.forgerock.oauth2.core;
@@ -21,7 +22,6 @@ import static com.sun.identity.shared.DateUtils.stringToDate;
 import javax.inject.Inject;
 import java.text.ParseException;
 import java.util.Set;
-
 import com.iplanet.sso.SSOException;
 import com.iplanet.sso.SSOToken;
 import com.iplanet.sso.SSOTokenManager;
@@ -58,7 +58,7 @@ public class GrantTypeAccessTokenGenerator {
                 try {
                     final SSOTokenManager ssoTokenManager = SSOTokenManager.getInstance();
                     final SSOToken token = ssoTokenManager.createSSOToken(sessionId);
-                    authTime = stringToDate(token.getProperty(ISAuthConstants.AUTH_INSTANT)).getTime();
+                    authTime = stringToDate(token.getProperty(ISAuthConstants.AUTH_INSTANT)).getTime() / 1000;
                 } catch (SSOException | ParseException e) {
                     logger.error("Error retrieving session from AuthorizationCode", e);
                 }

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/StatefulAccessToken.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/StatefulAccessToken.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security
  */
 
 package org.forgerock.oauth2.core;
@@ -20,7 +21,6 @@ import static java.lang.String.valueOf;
 import static org.forgerock.json.JsonValueFunctions.setOf;
 import static org.forgerock.openam.oauth2.OAuth2Constants.Bearer.BEARER;
 import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.AUDIT_TRACKING_ID;
-import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.AUTH_TIME;
 import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.CLIENT_ID;
 import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.CONFIRMATION_KEY;
 import static org.forgerock.openam.oauth2.OAuth2Constants.CoreTokenParams.EXPIRE_TIME;
@@ -135,7 +135,7 @@ public class StatefulAccessToken extends StatefulToken implements AccessToken {
      * @param realm The realm.
      * @param claims The requested claims.
      * @param auditTrackingId The tracking ID, used for tracking tokens throughout the audit logs.
-     * @param authTime The end user's original auth time.
+     * @param authTime The end user's original auth time in seconds since epoch.
      * @param confirmationKey JSON confirmation key
      */
     public StatefulAccessToken(String id, String authorizationCode, String resourceOwnerId, String clientId,
@@ -308,6 +308,7 @@ public class StatefulAccessToken extends StatefulToken implements AccessToken {
      *
      * @return The realm.
      */
+    @Override
     public String getRealm() {
         return getStringProperty(REALM);
     }
@@ -387,6 +388,7 @@ public class StatefulAccessToken extends StatefulToken implements AccessToken {
         return (String) extraData.get(SSO_TOKEN_ID);
     }
 
+    @Override
     protected long defaultExpireTime() {
         return 0;
     }
@@ -505,23 +507,6 @@ public class StatefulAccessToken extends StatefulToken implements AccessToken {
     @Override
     public String getAuditTrackingId() {
         return getStringProperty(AUDIT_TRACKING_ID);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void setAuthTime(long authTime) {
-        setStringProperty(AUTH_TIME, valueOf(authTime));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getAuthTimeSeconds() {
-        final String value = getStringProperty(OAuth2Constants.CoreTokenParams.AUTH_TIME);
-        return value == null ? TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis()) : Long.parseLong(value);
     }
 
     @Override

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/StatefulRefreshToken.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/StatefulRefreshToken.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions copyright 2025 Wren Security
  */
 
 package org.forgerock.oauth2.core;
@@ -102,7 +103,7 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
      * @param acr The authentication context.
      * @param auditId The audit id, used for tracking tokens throughout the audit logs.
      * @param authGrantId The authorization grant id.
-     * @param authTime The end user's original auth time in seconds.
+     * @param authTime The end user's original auth time in seconds since epoch.
      */
     public StatefulRefreshToken(String id, String resourceOwnerId, String clientId, String redirectUri, Set<String> scope,
             long expiryTime, String tokenType, String tokenName, String grantType, String realm,
@@ -139,6 +140,7 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
      *
      * @return The claims.
      */
+    @Override
     public String getClaims() {
         return getStringProperty(OAuth2Constants.Custom.CLAIMS);
     }
@@ -171,6 +173,7 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
     /**
      * Gets the realm.
      */
+    @Override
     public String getRealm() {
         return this.getStringProperty(OAuth2Constants.CoreTokenParams.REALM);
     }
@@ -253,6 +256,7 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
         return ! isNeverExpires() && super.isExpired();
     }
 
+    @Override
     protected long defaultExpireTime() {
         return -1;
     }
@@ -302,6 +306,7 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
         return getStringProperty(AUTH_GRANT_ID);
     }
 
+    @Override
     protected Long getTimeLeft() {
         if (isNeverExpires()) {
             return null;
@@ -341,23 +346,6 @@ public class StatefulRefreshToken extends StatefulToken implements RefreshToken 
     @Override
     public String getAuditTrackingId() {
         return getStringProperty(AUDIT_TRACKING_ID);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void setAuthTime(long authTime) {
-        setStringProperty(AUTH_TIME, valueOf(authTime));;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getAuthTimeSeconds() {
-        final String value = getStringProperty(OAuth2Constants.CoreTokenParams.AUTH_TIME);
-        return value == null ? TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis()) : Long.parseLong(value);
     }
 
     @Override


### PR DESCRIPTION
When a refresh token is renewed its `authTime` value in seconds gets misinterpreted as value in milliseconds.

The commit also contains changed CTS mapping of `authTime` from `coreTokenDate02` to `coreTokenDate03` as the former is already used for `maxSessionIdleTime` and makes the search performed by the session reaper process too slow.