### PR TITLE
Fix OIDC claims script error handling

### DIFF
--- a/openam-oauth2/src/test/java/org/forgerock/openam/openidconnect/OidcClaimsExtensionTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/openidconnect/OidcClaimsExtensionTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 package org.forgerock.openam.openidconnect;
@@ -23,6 +24,7 @@ import static org.mockito.Mockito.*;
 
 import com.iplanet.sso.SSOToken;
 import com.sun.identity.idm.AMIdentity;
+import com.sun.identity.idm.IdRepoException;
 import com.sun.identity.shared.debug.Debug;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -190,6 +192,24 @@ public class OidcClaimsExtensionTest {
             }
             assertThat(e.getMessage()).isEqualTo("No selection logic for given_name defined. Values: [george, fred]");
         }
+    }
+
+    @Test
+    public void testIdRepoExceptionHandledGracefully() throws Exception {
+        // Given
+        Bindings variables = testBindings(asSet("profile"));
+        when(identity.getAttribute("givenname")).thenThrow(new IdRepoException());
+        when(identity.getAttribute("sn")).thenReturn(asSet("bloggs"));
+        when(identity.getAttribute("preferredtimezone")).thenReturn(asSet("Europe/London"));
+        when(identity.getAttribute("preferredlocale")).thenReturn(asSet("en"));
+        when(identity.getAttribute("cn")).thenReturn(asSet("Joe Bloggs"));
+
+        // When
+        UserInfoClaims result = scriptEvaluator.evaluateScript(script, variables);
+
+        // Then - given_name should be absent due to IdRepoException, other claims should be present
+        assertThat(result.getValues()).doesNotContainKey("given_name");
+        assertThat(result.getValues()).containsKeys("family_name", "name", "zoneinfo", "locale");
     }
 
     private Bindings testBindings(Set<String> scopes) {

--- a/openam-oauth2/src/test/resources/oidc-claims-extension.groovy
+++ b/openam-oauth2/src/test/resources/oidc-claims-extension.groovy
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2016 ForgeRock AS.
+* Portions Copyright 2026 Wren Security
 */
 import com.iplanet.sso.SSOException
 import com.sun.identity.idm.IdRepoException
@@ -89,16 +90,17 @@ if (logger.messageEnabled()) {
 
 def computeClaim = { claim, requestedValues ->
     try {
-        [ claim, claimAttributes.get(claim)(claim, identity, requestedValues) ]
+        return [ claim, claimAttributes.get(claim)(claim, identity, requestedValues) ]
     } catch (IdRepoException e) {
         if (logger.warningEnabled()) {
-            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve attribute=$attribute", e);
+            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve claim=$claim", e);
         }
     } catch (SSOException e) {
         if (logger.warningEnabled()) {
-            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve attribute=$attribute", e);
+            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve claim=$claim", e);
         }
     }
+    [ claim, null ]
 }
 
 def computedClaims = scopes.findAll { s -> !"openid".equals(s) && scopeClaimsMap.containsKey(s) }.inject(claims) { map, s ->

--- a/openam-scripting/src/main/groovy/oidc-claims-extension.groovy
+++ b/openam-scripting/src/main/groovy/oidc-claims-extension.groovy
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2014-2016 ForgeRock AS.
+* Portions Copyright 2026 Wren Security
 */
 import com.iplanet.sso.SSOException
 import com.sun.identity.idm.IdRepoException
@@ -89,16 +90,17 @@ if (logger.messageEnabled()) {
 
 def computeClaim = { claim, requestedValues ->
     try {
-        [ claim, claimAttributes.get(claim)(claim, identity, requestedValues) ]
+        return [ claim, claimAttributes.get(claim)(claim, identity, requestedValues) ]
     } catch (IdRepoException e) {
         if (logger.warningEnabled()) {
-            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve attribute=$attribute", e);
+            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve claim=$claim", e);
         }
     } catch (SSOException e) {
         if (logger.warningEnabled()) {
-            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve attribute=$attribute", e);
+            logger.warning("OpenAMScopeValidator.getUserInfo(): Unable to retrieve claim=$claim", e);
         }
     }
+    [ claim, null ]
 }
 
 def computedClaims = scopes.findAll { s -> !"openid".equals(s) && scopeClaimsMap.containsKey(s) }.inject(claims) { map, s ->


### PR DESCRIPTION
There was an apparent bug in the default oidc-claims-extension.groovy script in error handling of attribute retrieval. I have added unit test for this and fixed the issue.