### PR TITLE
Fix REST SMS route refresh

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRequestHandler.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsRequestHandler.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2022-2023 Wren Security
+ * Portions copyright 2022-2026 Wren Security
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -371,11 +372,14 @@ public class SmsRequestHandler implements RequestHandler, SMSObjectListener, Ser
     @Override
     public void allObjectsChanged() {
         try {
+            write.lock();
+            removeServices();
             createServices();
-        } catch (SSOException e) {
+            notifyDescriptorChange();
+        } catch (SSOException | SMSException e) {
             debug.error("Could not recreate SMS REST services", e);
-        } catch (SMSException e) {
-            debug.error("Could not recreate SMS REST services", e);
+        } finally {
+            write.unlock();
         }
     }
 
@@ -414,6 +418,13 @@ public class SmsRequestHandler implements RequestHandler, SMSObjectListener, Ser
         }
 
         this.serviceRoutes = serviceRoutes;
+    }
+
+    /**
+     * Remove all service routes.
+     */
+    private void removeServices() {
+        new HashSet<>(serviceRoutes.keySet()).forEach(this::removeService);
     }
 
     /**

--- a/openam-server-only/src/main/resources/amServiceTable.properties
+++ b/openam-server-only/src/main/resources/amServiceTable.properties
@@ -25,7 +25,7 @@
 # $Id: amServiceTable.properties,v 1.5 2009/06/19 02:38:05 bigfatrat Exp $
 #
 # Portions Copyrighted 2011-2017 ForgeRock AS.
-# Portions Copyrighted 2023 Wren Security
+# Portions Copyrighted 2023-2026 Wren Security
 
 #
 # This properties map the service name to the table of which it is
@@ -93,3 +93,4 @@ RestSecurityTokenService=.
 SoapSecurityTokenService=.
 iPlanetAMAuthScriptedService=.
 iPlanetAMAuthDeviceIdMatchService=.
+sunIdentityFilteredRoleService=.


### PR DESCRIPTION
Fixes REST SMS route refresh after SMS reports that all objects have changed.

The filtered role service is not intended to be exposed through the SMS REST API or the legacy console service configuration views. However, because it was not listed as hidden in `amServiceTable.properties`, it could be added to the REST SMS route tree during a full route rebuild.

`sunIdentityFilteredRoleService` only exposes a dynamic schema with an empty REST resource name. During route rebuild, it could therefore register an empty route under the services tree and override the route handler for `realm-config/services`. As a result, querying `realm-config/services` could fail after the configuration store was reconnected.

The refresh also kept previously registered service routes in the route tree, so stale route handlers could remain after full rebuilds.

This change:

- excludes `sunIdentityFilteredRoleService` from generic REST SMS routes by marking it as hidden in `amServiceTable.properties`
- removes previously registered REST SMS service routes before recreating them when `allObjectsChanged()` is received
- notifies API descriptor listeners after the route set is rebuilt