### PR TITLE
Remove unused --add-exports for java.base/sun.security.x509

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ ENV \
   WRENAM_HOME="/srv/wrenam" \
   JAVA_OPTS=" \
     --add-exports=java.base/sun.security.tools.keytool=ALL-UNNAMED \
-    --add-exports=java.base/sun.security.x509=ALL-UNNAMED \
     --add-exports=java.management/sun.management=ALL-UNNAMED \
     --add-exports=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED \
     --add-opens=java.base/java.io=ALL-UNNAMED \

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
             --add-opens java.base/java.util=ALL-UNNAMED
             --add-exports java.base/sun.security.jca=ALL-UNNAMED
             --add-exports java.base/sun.security.util=ALL-UNNAMED
-            --add-exports java.base/sun.security.x509=ALL-UNNAMED
             --add-exports java.base/jdk.internal.util=ALL-UNNAMED
             --add-exports java.base/jdk.internal.util.random=ALL-UNNAMED
             -Duser.language=en -Duser.region=US


### PR DESCRIPTION
The internal sun.security.x509 API is no longer used in the project code or any of its runtime/test dependencies. The only remaining usage is in the standalone jwt-generator tool, which is not part of the build.