### PR TITLE
Ignore push event on dependabot branches

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'backport/**'
+      - 'dependabot/**'
   pull_request:
 
 permissions:


### PR DESCRIPTION
Dependabot creates a branch and a PR. Actions will be triggered for both without this change.