### PR TITLE
Do not cache realm lookup failure for transient LDAP connection issues

### DIFF
--- a/openam-core/src/main/java/com/sun/identity/sm/ServiceUnavailableException.java
+++ b/openam-core/src/main/java/com/sun/identity/sm/ServiceUnavailableException.java
@@ -1,0 +1,72 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security
+ */
+package com.sun.identity.sm;
+
+/**
+ * The <code>ServiceUnavailableException</code> is thrown when the SMS backend is unavailable (i.e. there
+ * is nothing wrong with the request, the underlying storage can not be reached or refuses to process the
+ * request due to resource limitations).
+ *
+ * <p>
+ * This exception allows callers to distinguish between persistent cacheable errors and transient errors
+ * where it makes sense to retry the operation later.
+ *
+ * @supported.all.api
+ */
+public class ServiceUnavailableException extends SMSException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Create new exception instance without any detail message.
+     */
+    public ServiceUnavailableException() {
+        super();
+    }
+
+    /**
+     * Create new exception instance with the specified detail message.
+     *
+     * @param message  the detail message.
+     */
+    public ServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Create new exception with the given message and error code that will be used to resolve the
+     * localized error message.
+     *
+     * @param message the message provided by the object which is throwing the exception
+     * @param errorCode error code or message ID used to locate the localized message variant
+     */
+    public ServiceUnavailableException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+
+    /**
+     * Create new exception with the specified error code that will be used to resolve the localized
+     * error message.
+     *
+     * @param rbName resource Bundle name where the localized error message is located
+     * @param errorCode error code or message ID to be used for to resolve the localized error message
+     * @param args any arguments to be used for error message formatting
+     */
+    public ServiceUnavailableException(String rbName, String errorCode, Object[] args) {
+        super(rbName, errorCode, args);
+    }
+
+}

--- a/openam-core/src/main/java/com/sun/identity/sm/ldap/SMSLdapObject.java
+++ b/openam-core/src/main/java/com/sun/identity/sm/ldap/SMSLdapObject.java
@@ -25,7 +25,7 @@
  * $Id: SMSLdapObject.java,v 1.27 2009/11/20 23:52:56 ww203982 Exp $
  *
  * Portions Copyrighted 2011-2016 ForgeRock AS.
- * Portions Copyrighted 2017-2023 Wren Security
+ * Portions Copyrighted 2017-2026 Wren Security
  */
 
 package com.sun.identity.sm.ldap;
@@ -49,6 +49,7 @@ import com.sun.identity.sm.SMSNotificationManager;
 import com.sun.identity.sm.SMSObjectDB;
 import com.sun.identity.sm.SMSObjectListener;
 import com.sun.identity.sm.SMSUtils;
+import com.sun.identity.sm.ServiceUnavailableException;
 import java.security.AccessController;
 import java.security.Principal;
 import java.text.MessageFormat;
@@ -255,6 +256,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * Reads in the object from persistent store, assuming that the guid and the
      * SSOToken are valid
      */
+    @Override
     public Map<String, Set<String>> read(SSOToken token, String dn) throws SMSException,
             SSOException {
         if (dn == null || dn.length() == 0) {
@@ -322,6 +324,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
     /**
      * Create an entry in the directory
      */
+    @Override
     public void create(SSOToken token, String dn, Map attrs)
             throws SMSException, SSOException {
         int retry = 0;
@@ -368,6 +371,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * Save the entry using the token provided. The principal provided will be
      * used to get the proxy connection.
      */
+    @Override
     public void modify(SSOToken token, String dn, ModificationItem[] mods)
             throws SMSException, SSOException {
         int retry = 0;
@@ -403,6 +407,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
     /**
      * Delete the entry in the directory. This will delete sub-entries also!
      */
+    @Override
     public void delete(SSOToken token, String dn) throws SMSException,
             SSOException {
         SMSAuditor auditor = newAuditor(token, dn, readCurrentState(dn));
@@ -467,6 +472,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * The paramter <code>numOfEntries</code> identifies the number of entries
      * to return, if <code>0</code> returns all the entries.
      */
+    @Override
     public Set<String> subEntries(SSOToken token, String dn, String filter,
             int numOfEntries, boolean sortResults, boolean ascendingOrder)
             throws SMSException, SSOException {
@@ -558,6 +564,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * The paramter <code>numOfEntries</code> identifies the number of entries
      * to return, if <code>0</code> returns all the entries.
      */
+    @Override
     public Set<String> schemaSubEntries(SSOToken token, String dn, String filter,
             String sidFilter, int numOfEntries, boolean sortResults,
             boolean ascendingOrder) throws SMSException, SSOException {
@@ -572,6 +579,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
                 sortResults, ascendingOrder);
     }
 
+    @Override
     public String toString() {
         return ("SMSLdapObject");
     }
@@ -592,7 +600,8 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
         }
         if (conn == null) {
             debug.error("SMSLdapObject: Unable to get connection to LDAP server for the principal: {}", p);
-            throw new SMSException(bundle.getString(IUMSConstants.SMS_SERVER_DOWN), "sms-SERVER_DOWN");
+            throw new ServiceUnavailableException(bundle.getString(IUMSConstants.SMS_SERVER_DOWN),
+                    "sms-SERVER_DOWN");
         }
         return conn;
     }
@@ -601,6 +610,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * Returns LDAP entries that match the filter, using the start DN provided
      * in method
      */
+    @Override
     public Iterator<SMSDataEntry> search(SSOToken token, String startDN, String filter,
             int numOfEntries, int timeLimit, boolean sortResults,
             boolean ascendingOrder, Set<String> excludes)
@@ -656,6 +666,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * Returns LDAP entries that match the filter, using the start DN provided
      * in method
      */
+    @Override
     public Set<String> search(SSOToken token, String startDN, String filter,
             int numOfEntries, int timeLimit, boolean sortResults,
             boolean ascendingOrder) throws SSOException, SMSException {
@@ -809,11 +820,13 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
     /**
      * Registration of Notification Callbacks
      */
+    @Override
     public void registerCallbackHandler(SMSObjectListener changeListener)
             throws SMSException {
         LDAPEventManager.addObjectChangeListener(changeListener);
     }
 
+    @Override
     public void deregisterCallbackHandler(String id) {
         LDAPEventManager.removeObjectChangeListener();
     }
@@ -855,6 +868,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
         return modifyRequest;
     }
 
+    @Override
     public void objectChanged(String dn, int type) {
         dn = DN.valueOf(dn).toString().toLowerCase();
         if (type == DELETE) {
@@ -867,6 +881,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
         }
     }
 
+    @Override
     public void allObjectsChanged() {
         // Not clear why this class is implemeting the SMSObjectListener
         // interface.
@@ -884,6 +899,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * the number of entries to return, if <code>0</code> returns all the
      * entries.
      */
+    @Override
     public Set<String> searchSubOrgNames(SSOToken token, String dn, String filter,
             int numOfEntries, boolean sortResults, boolean ascendingOrder,
             boolean recursive) throws SMSException, SSOException {
@@ -979,6 +995,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
      * the number of entries to return, if <code>0</code> returns all the
      * entries.
      */
+    @Override
     public Set<String> searchOrganizationNames(SSOToken token, String dn,
             int numOfEntries, boolean sortResults, boolean ascendingOrder,
             String serviceName, String attrName, Set values)
@@ -1008,7 +1025,7 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
          * (sunxmlkeyvalue=ATTR_NAME=VALUE1))
          * (|(sunxmlkeyvalue=SERVICE_NAME-ATTR_NAME=VALUE2)
          * (sunxmlkeyvalue=ATTR_NAME=VALUE2))(...))
-         * 
+         *
          */
 
         StringBuilder sb = new StringBuilder();
@@ -1044,7 +1061,8 @@ public class SMSLdapObject extends SMSObjectDB implements SMSObjectListener {
         }
         return getOrgNames(token, dn, sfilter, numOfEntries, sortResults, ascendingOrder);
     }
-    
+
+    @Override
     public void shutdown() {
         if (!enableProxy && (smdlayer != null)) {
             smdlayer.shutdown();

--- a/openam-core/src/main/java/org/forgerock/openam/core/realms/DefaultRealmLookup.java
+++ b/openam-core/src/main/java/org/forgerock/openam/core/realms/DefaultRealmLookup.java
@@ -12,18 +12,10 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 package org.forgerock.openam.core.realms;
-
-import jakarta.inject.Inject;
-import jakarta.inject.Named;
-import jakarta.inject.Provider;
-import jakarta.inject.Singleton;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
 
 import com.iplanet.am.sdk.AMException;
 import com.iplanet.am.sdk.AMOrganization;
@@ -36,6 +28,15 @@ import com.sun.identity.sm.OrganizationConfigManager;
 import com.sun.identity.sm.OrganizationConfigManagerFactory;
 import com.sun.identity.sm.SMSException;
 import com.sun.identity.sm.ServiceManager;
+import com.sun.identity.sm.ServiceUnavailableException;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
 import org.forgerock.openam.ldap.LDAPUtils;
 import org.forgerock.openam.utils.CollectionUtils;
 import org.forgerock.openam.utils.StringUtils;
@@ -164,7 +165,9 @@ class DefaultRealmLookup implements RealmLookup {
                 }
             } catch (SMSException | SSOException e) {
                 logger.trace("DefaultRealms:lookup Exception in getting org name from SMS", e);
-                throw new NoRealmFoundException(realmName);
+                throw e instanceof ServiceUnavailableException
+                        ? new RealmLookupException(e)
+                        : new NoRealmFoundException(realmName);
             }
         }
         logger.trace("DefaultRealms:lookup Search for OrgIdentifier:{} returning realm DN: {}", realmName, id);


### PR DESCRIPTION
When the config store is down during realm lookup, the failed lookup attempt gets cached and is never retried (unless the configuration changes). This PR introduces new SMS exception that allows for the code to distinguish when the underlying exception is not related to the request itself.

Btw. I thought about fixing this in a different way -> firing config-changed event when the persistent search is established with the config store, which will force `CachingRealmLookup` to drop cached responses, but it felt a bit more complex with much more potential side effects.