### PR TITLE
Add ability to SessionResource to read tokenId from request body

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceUtil.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceUtil.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import org.forgerock.http.header.CookieHeader;
 import org.forgerock.http.protocol.Cookie;
 import org.forgerock.json.JsonValue;
+import org.forgerock.json.resource.ActionRequest;
 import org.forgerock.json.resource.Request;
 import org.forgerock.json.resource.http.HttpContext;
 import org.forgerock.openam.core.rest.session.query.SessionQueryManager;
@@ -89,6 +90,7 @@ public class SessionResourceUtil {
      * <ol>
      *     <li>Path of the request</li>
      *     <li>URL parameters of the request</li>
+     *     <li>Request body property</li>
      *     <li>Cookies</li>
      *     <li>HTTP headers</li>
      * </ol>
@@ -103,6 +105,10 @@ public class SessionResourceUtil {
 
         if (StringUtils.isEmpty(tokenId)) {
             tokenId = getTokenIdFromUrlParam(request);
+        }
+
+        if (StringUtils.isEmpty(tokenId) && request instanceof ActionRequest) {
+            tokenId = getTokenIdFromRequest((ActionRequest) request);
         }
 
         if (StringUtils.isEmpty(tokenId)) {
@@ -122,6 +128,11 @@ public class SessionResourceUtil {
 
     private static String getTokenIdFromUrlParam(Request request) {
         return request.getAdditionalParameter("tokenId");
+    }
+
+    private static String getTokenIdFromRequest(ActionRequest request) {
+        JsonValue tokenId = request.getContent().get("tokenId");
+        return tokenId.isString() ? tokenId.asString() : null;
     }
 
     private static String getTokenIdFromCookie(HttpContext context, String cookieName) {

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceV2.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceV2.java
@@ -89,7 +89,7 @@ import org.forgerock.util.promise.Promise;
  *     <li>[server-id] - Lists the sessions for that server instance.</li>
  *     <li>[session-id] - Details opf the session information </li>
  * </ul>
- * 
+ *
  *
  * This resources acts as a read only resource.
  */
@@ -163,9 +163,6 @@ public class SessionResourceV2 implements CollectionResourceProvider {
         @Action(
             operationDescription = @Operation(
                 description = SESSION_RESOURCE + GET_SESSION_INFO_ACTION_ID + "." + ACTION_DESCRIPTION,
-                parameters = @Parameter(name = TOKEN_PARAM_NAME, type = "string",
-                        description = SESSION_RESOURCE + TOKEN_PARAM_NAME + "." + PARAMETER_DESCRIPTION,
-                        source = ParameterSource.ADDITIONAL),
                 errors = {
                     @ApiError(
                         code = 401,
@@ -174,14 +171,12 @@ public class SessionResourceV2 implements CollectionResourceProvider {
                 }
             ),
             name = GET_SESSION_INFO_ACTION_ID,
+            request = @Schema(schemaResource = "SessionResource.tokenId.request.schema.json"),
             response = @Schema(fromType = PartialSession.class)
         ),
         @Action(
             operationDescription = @Operation(
                 description = SESSION_RESOURCE + LOGOUT_ACTION_ID + "." + ACTION_DESCRIPTION,
-                parameters = @Parameter(name = TOKEN_PARAM_NAME, type = "string",
-                        description = SESSION_RESOURCE + TOKEN_PARAM_NAME + "." + PARAMETER_DESCRIPTION,
-                        source = ParameterSource.ADDITIONAL),
                 errors = {
                     @ApiError(
                         code = 401,
@@ -190,14 +185,12 @@ public class SessionResourceV2 implements CollectionResourceProvider {
                 }
             ),
             name = LOGOUT_ACTION_ID,
+            request = @Schema(schemaResource = "SessionResource.tokenId.request.schema.json"),
             response = @Schema(schemaResource = "SessionResource.properties.names.schema.json")
         ),
         @Action(
             operationDescription = @Operation(
                 description = SESSION_RESOURCE + REFRESH_ACTION_ID + "." + ACTION_DESCRIPTION,
-                parameters = @Parameter(name = TOKEN_PARAM_NAME, type = "string",
-                        description = SESSION_RESOURCE + TOKEN_PARAM_NAME + "." + PARAMETER_DESCRIPTION,
-                        source = ParameterSource.ADDITIONAL),
                 errors = {
                     @ApiError(
                         code = 401,
@@ -206,14 +199,12 @@ public class SessionResourceV2 implements CollectionResourceProvider {
                 }
             ),
             name = REFRESH_ACTION_ID,
+            request = @Schema(schemaResource = "SessionResource.tokenId.request.schema.json"),
             response = @Schema(schemaResource = "SessionResource.properties.names.schema.json")
         ),
         @Action(
             operationDescription = @Operation(
                 description = SESSION_RESOURCE + GET_SESSION_PROPERTIES_ACTION_ID + "." + ACTION_DESCRIPTION,
-                parameters = @Parameter(name = TOKEN_PARAM_NAME, type = "string",
-                        description = SESSION_RESOURCE + TOKEN_PARAM_NAME + "." + PARAMETER_DESCRIPTION,
-                        source = ParameterSource.ADDITIONAL),
                 errors = {
                     @ApiError(
                         code = 401,
@@ -222,14 +213,12 @@ public class SessionResourceV2 implements CollectionResourceProvider {
                 }
             ),
             name = GET_SESSION_PROPERTIES_ACTION_ID,
+            request = @Schema(schemaResource = "SessionResource.tokenId.request.schema.json"),
             response = @Schema(schemaResource = "SessionResource.properties.names.schema.json")
         ),
         @Action(
             operationDescription = @Operation(
                 description = SESSION_RESOURCE + UPDATE_SESSION_PROPERTIES_ACTION_ID + "." + ACTION_DESCRIPTION,
-                parameters = @Parameter(name = TOKEN_PARAM_NAME, type = "string",
-                        description = SESSION_RESOURCE + TOKEN_PARAM_NAME + "." + PARAMETER_DESCRIPTION,
-                        source = ParameterSource.ADDITIONAL),
                 errors = {
                     @ApiError(
                         code = 401,
@@ -238,6 +227,7 @@ public class SessionResourceV2 implements CollectionResourceProvider {
                 }
             ),
             name = UPDATE_SESSION_PROPERTIES_ACTION_ID,
+            request = @Schema(schemaResource = "SessionResource.tokenId.request.schema.json"),
             response = @Schema(schemaResource = "SessionResource.properties.names.schema.json")
         ),
         @Action(

--- a/openam-core-rest/src/main/resources/org/forgerock/openam/core/rest/session/SessionResource.tokenId.request.schema.json
+++ b/openam-core-rest/src/main/resources/org/forgerock/openam/core/rest/session/SessionResource.tokenId.request.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "i18n:api-descriptor/SessionResource#tokenId.request.schema.title",
+  "description": "i18n:api-descriptor/SessionResource#tokenId.request.schema.description",
+  "properties": {
+    "tokenId": {
+      "title": "i18n:api-descriptor/SessionResource#tokenId.request.schema.tokenId.title",
+      "description": "i18n:api-descriptor/SessionResource#tokenId.request.schema.tokenId.description",
+      "type": "string"
+    }
+  }
+}

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/session/SessionResourceTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/session/SessionResourceTest.java
@@ -230,6 +230,7 @@ public class SessionResourceTest {
 
         given(context.asContext(HttpContext.class)).willReturn(httpContext);
         given(request.getAction()).willReturn(VALIDATE_ACTION_ID);
+        given(request.getContent()).willReturn(JsonValue.json(null));
 
         //When
         Promise<ActionResponse, ResourceException> promise = sessionResource.actionCollection(context, request);
@@ -251,6 +252,7 @@ public class SessionResourceTest {
         given(context.asContext(HttpContext.class)).willReturn(httpContext);
         given(httpContext.getHeader("cookie")).willReturn(List.of("iPlanetDirectoryPro=SSO_TOKEN_ID"));
         given(request.getAction()).willReturn(VALIDATE_ACTION_ID);
+        given(request.getContent()).willReturn(JsonValue.json(null));
         given(tokenContext.getCallerSSOToken()).willReturn(ssoToken);
         given(ssoTokenManager.isValidToken(ssoToken)).willReturn(true);
         given(ssoToken.getTokenID()).willReturn(ssoTokenId);

--- a/openam-i18n/src/main/resources/api-descriptor/SessionResource.properties
+++ b/openam-i18n/src/main/resources/api-descriptor/SessionResource.properties
@@ -39,6 +39,11 @@ schema.property.maxSessionExpirationTime.title=Max Session Expiration Time
 schema.property.maxSessionExpirationTime.description= The timestamp of when the session would time out regardless of \
   activity.
 
+tokenId.request.schema.title=User session request
+tokenId.request.schema.description=User session request
+tokenId.request.schema.tokenId.title=The user session token id
+tokenId.request.schema.tokenId.description=The user session token id
+
 tokenId.parameter.description=The user session token id
 
 validate.response.schema.title=Validate session response

--- a/openam-radius/openam-radius-server/src/test/java/org/forgerock/openam/radius/server/RadiusRequestHandlerTest.java
+++ b/openam-radius/openam-radius-server/src/test/java/org/forgerock/openam/radius/server/RadiusRequestHandlerTest.java
@@ -65,7 +65,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
+        String url = "example.org";
         InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);
@@ -101,7 +101,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
+        String url = "example.org";
         InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);
@@ -138,7 +138,7 @@ public class RadiusRequestHandlerTest {
         // given
         final RadiusRequestContext reqCtx = mock(RadiusRequestContext.class);
         final ClientConfig clientConfig = mock(ClientConfig.class);
-        String url = "forgerock.org";
+        String url = "example.org";
         InetSocketAddress socketAddress = new InetSocketAddress(Inet4Address.getByName(url), 6836);
 
         when(reqCtx.getClientConfig()).thenReturn(clientConfig);


### PR DESCRIPTION
This adds the ability to read `tokenId` parameter from the request body. This improves security as the tokenId is sensitive information that should not be used in the URL.

I have also updated API descriptor for SessionResourceV2 -> request body is the preferred way how to pass the tokenId. This might seem like a breaking change, however it only updates the descriptor and not the endpoint behavior.

UPDATE: there is an unrelated fix for the RADIUS unit test that had invalid hostname causing the tests to fail on `java.net.UnknownHostException`.