### PR TITLE
Fix choice value i18n lookup

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
@@ -345,11 +345,13 @@ public abstract class SmsResourceProvider implements Describable<ApiDescription,
 
     private LocalizableString getSchemaI18N(String i18nKey, LocalizableString defaultValue) {
         String i18NFileName = schema.getI18NFileName();
-        return new LocalizableString(TRANSLATION_KEY_PREFIX + i18NFileName + "#"+ i18nKey, CLASS_LOADER, defaultValue);
+        return new LocalizableString(TRANSLATION_KEY_PREFIX + i18NFileName + "#"+ URLEncDec.encode(i18nKey),
+                CLASS_LOADER, defaultValue);
     }
 
     private LocalizableString getConsoleI18N(String i18nKey, LocalizableString defaultValue) {
-        return new LocalizableString(TRANSLATION_KEY_PREFIX + "amConsole" + "#" + URLEncDec.encode(i18nKey), CLASS_LOADER, defaultValue);
+        return new LocalizableString(TRANSLATION_KEY_PREFIX + "amConsole" + "#" + URLEncDec.encode(i18nKey),
+                CLASS_LOADER, defaultValue);
     }
 
     JsonValue createSchema(Optional<Context> context) {
@@ -614,13 +616,8 @@ public abstract class SmsResourceProvider implements Describable<ApiDescription,
             Map<String, String> valuesMap = attribute.getChoiceValuesMap(environment);
             for (Map.Entry<String, String> value : valuesMap.entrySet()) {
                 values.add(value.getKey());
-                if (AttributeSchema.UIType.SCRIPTSELECT.equals(attribute.getUIType())
-                        || AttributeSchema.UIType.GLOBALSCRIPTSELECT.equals(attribute.getUIType())) {
-                    descriptions.add(getConsoleI18N(value.getValue(), new LocalizableString(value.getValue())));
-                } else {
-                    descriptions.add(getConsoleI18N(value.getValue() == null ? value.getKey() : value.getValue(),
-                            new LocalizableString(value.getKey())));
-                }
+                String i18nKey = value.getValue() == null ? value.getKey() : value.getValue();
+                descriptions.add(getSchemaI18N(i18nKey, getConsoleI18N(i18nKey, new LocalizableString(i18nKey))));
             }
             jsonValue.add(ENUM, values);
             jsonValue.putPermissive(new JsonPointer("options/enum_titles"), descriptions);


### PR DESCRIPTION
This PR changes how the SELECT choice value localization is being performed.

The main reason for looking into this was untranslated iPlanetAMAuthService service dynamic profile field translation. The translation of values for this field is being stored in schema localization. However the code was using amConsole localization bundle for choice translation.

**Original behavior:**

* always use amConsole localization for select choice values with fallback to the choice value itself

**Updated behavior:**

* use owner schema localization for select choice values with fallback to amConsole and the choice value itself
   * fallback to amConsole is there as some translations are global and not service-specific (e.g. SCRIPT selection label, boolean value translation true=Yes/false=No)
* removed special behavior for SCRIPT select choice (TBH I am not sure why it was there in the first place)

**Side-effects of my change:**

* every schema choice is now localized if it is actually being localized in service schema
* schema localizations are mostly written as descriptions (i.e. full sentences)

**Status of this PR / steps before merging:**

* A bunch of new "strange" translations appeared in the UI due to the fact, that service schema translations were written more as full-blown sentences rather than value labels.
* I would like to make report / list of all changes that happened due to this change. Only then we can make a decision whether to approve this PR.
