### PR TITLE
Fix substring-based cookie domain matching in CookieUtils

### DIFF
--- a/openam-shared/src/main/java/com/sun/identity/shared/encode/CookieUtils.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/encode/CookieUtils.java
@@ -25,17 +25,19 @@
  * $Id: CookieUtils.java,v 1.6 2009/10/02 00:08:26 ericow Exp $
  *
  * Portions Copyrighted 2014-2016 ForgeRock AS.
- * Portions Copyrighted 2025 Wren Security
+ * Portions Copyrighted 2025-2026 Wren Security
  */
 
 package com.sun.identity.shared.encode;
 
-import static org.forgerock.openam.utils.Time.*;
+import static org.forgerock.openam.utils.Time.currentTimeMillis;
 
 import com.sun.identity.shared.Constants;
 import com.sun.identity.shared.configuration.SystemPropertiesManager;
 import com.sun.identity.shared.debug.Debug;
-
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,10 +49,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
-
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Implements utility methods for handling Cookie.
@@ -453,14 +451,35 @@ public class CookieUtils {
      * @return The set of matching cookie domains. May contain null.
      */
     public static Set<String> getMatchingCookieDomains(HttpServletRequest request, Collection<String> cookieDomains) {
-        String host = request.getServerName();
+        String host = normalizeDomain(request.getServerName());
         Set<String> domains = new HashSet<>();
 
         for (String domain : cookieDomains) {
-            if (domain == null || host.contains(domain)) {
+            if (domain == null || domain.isEmpty()) {
+                domains.add(domain);
+                continue;
+            }
+
+            String normalizedDomain = normalizeDomain(domain);
+            if (host != null && (host.equals(normalizedDomain) || host.endsWith("." + normalizedDomain))) {
                 domains.add(domain);
             }
         }
         return domains;
+    }
+
+    private static String normalizeDomain(String domain) {
+        if (domain == null) {
+            return null;
+        }
+
+        String normalized = domain.toLowerCase(Locale.ROOT);
+        if (normalized.startsWith(".")) {
+            normalized = normalized.substring(1);
+        }
+        if (normalized.endsWith(".")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
     }
 }

--- a/openam-shared/src/test/java/com/sun/identity/shared/encode/CookieUtilsTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/encode/CookieUtilsTest.java
@@ -1,0 +1,101 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security
+ */
+
+package com.sun.identity.shared.encode;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Set;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class CookieUtilsTest {
+
+    @DataProvider(name = "matchingCookieDomains")
+    public Object[][] matchingCookieDomains() {
+        return new Object[][] {
+                // host, cookie domain
+                { "example.com", "example.com" },
+                { "login.example.com", "example.com" },
+                { "LOGIN.EXAMPLE.COM", "Example.Com" },
+                { "example.com", ".example.com" },
+                { "login.example.com", ".EXAMPLE.COM" },
+                { "192.0.2.1", "192.0.2.1" },
+                { "example.com.", "example.com" },
+                { "login.example.com", "example.com." }
+        };
+    }
+
+    @Test(dataProvider = "matchingCookieDomains")
+    public void shouldMatchValidCookieDomains(String host, String domain) {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost(host), Set.of(domain));
+        assertEquals(matchingDomains, Set.of(domain));
+    }
+
+    @DataProvider(name = "nonMatchingCookieDomains")
+    public Object[][] nonMatchingCookieDomains() {
+        return new Object[][] {
+                // host, cookie domain
+                { "notexample.com", "example.com" },
+                { "foo-example.com", "example.com" },
+                { "example.com.attacker.test", "example.com" },
+                { "example.test", "example.com" },
+                { "login.example.com", "invalid domain" }
+        };
+    }
+
+    @Test(dataProvider = "nonMatchingCookieDomains")
+    public void shouldRejectInvalidCookieDomains(String host, String domain) {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost(host), Set.of(domain));
+        assertTrue(matchingDomains.isEmpty());
+    }
+
+    @Test
+    public void shouldAlwaysIncludeHostOnlyCookieDomains() {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost("example.com"), Collections.singleton(null));
+        assertEquals(matchingDomains, Collections.singleton(null));
+    }
+
+    @Test
+    public void shouldPreserveEmptyDomainAsHostOnlyCookieDomain() {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost("example.com"), Set.of(""));
+        assertEquals(matchingDomains, Set.of(""));
+    }
+
+    @Test
+    public void shouldAlwaysIncludeHostOnlyCookieDomainsWithoutServerName() {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost(null), Collections.singleton(null));
+        assertEquals(matchingDomains, Collections.singleton(null));
+    }
+
+    @Test
+    public void shouldRejectCookieDomainsWithoutServerName() {
+        Set<String> matchingDomains = CookieUtils.getMatchingCookieDomains(requestForHost(null), Set.of("example.com"));
+        assertTrue(matchingDomains.isEmpty());
+    }
+
+    private HttpServletRequest requestForHost(String host) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getServerName()).thenReturn(host);
+        return request;
+    }
+
+}


### PR DESCRIPTION
`CookieUtils.getMatchingCookieDomains` used `host.contains(domain)`, so a cookie domain like `example.com` could also match unrelated hosts such as `example.com.attacker.test` or `notexample.com`.

This change replaces it with a proper equals-or-subdomain check (case-insensitive, ignoring leading/trailing dots), and adds unit tests covering the previous false-positive cases.