### PR TITLE
Support SSO cookie prefixes defined in RFC 6265bis

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceUtil.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/session/SessionResourceUtil.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2024 Wren Security.
+ * Portions copyright 2024-2026 Wren Security.
  */
 
 package org.forgerock.openam.core.rest.session;
@@ -32,6 +32,7 @@ import com.sun.identity.idm.AMIdentity;
 import com.sun.identity.idm.IdRepoException;
 import com.sun.identity.shared.Constants;
 import com.sun.identity.shared.debug.Debug;
+import com.sun.identity.shared.encode.CookieUtils;
 import com.sun.identity.sm.DNMapper;
 import java.util.Collection;
 import java.util.List;
@@ -52,7 +53,6 @@ import org.forgerock.openam.utils.StringUtils;
 public class SessionResourceUtil {
 
     private static final Debug LOGGER = Debug.getInstance(SessionConstants.SESSION_DEBUG);
-
 
     public static final String VALID = "valid";
     public static final String IDLE_TIME = "idletime";
@@ -116,7 +116,7 @@ public class SessionResourceUtil {
         }
 
         if (StringUtils.isEmpty(tokenId)) {
-            tokenId = getTokenIdFromHeader(context, cookieName);
+            tokenId = getTokenIdFromHeader(context, CookieUtils.getCookieHeaderName(cookieName));
         }
 
         return StringUtils.isEmpty(tokenId) ? null : tokenId;

--- a/openam-core/src/main/java/org/forgerock/openam/authentication/service/AuthUtilsWrapper.java
+++ b/openam-core/src/main/java/org/forgerock/openam/authentication/service/AuthUtilsWrapper.java
@@ -19,7 +19,7 @@ package org.forgerock.openam.authentication.service;
 import com.iplanet.sso.SSOException;
 import com.sun.identity.authentication.service.AuthUtils;
 import com.sun.identity.authentication.spi.AMPostAuthProcessInterface;
-
+import com.sun.identity.shared.encode.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -35,6 +35,16 @@ public class AuthUtilsWrapper {
      */
     public String getCookieName() {
         return AuthUtils.getCookieName();
+    }
+
+    /**
+     * Get name of the HTTP header that can hold AM cookie value.
+     *
+     * @return The AM cookie header name.
+     */
+    public String getCookieHeaderName() {
+        String cookieName = getCookieName();
+        return cookieName != null ? CookieUtils.getCookieHeaderName(cookieName) : null;
     }
 
     /**

--- a/openam-rest/src/main/java/org/forgerock/openam/notifications/NotificationsWebSocketFilter.java
+++ b/openam-rest/src/main/java/org/forgerock/openam/notifications/NotificationsWebSocketFilter.java
@@ -68,7 +68,7 @@ public final class NotificationsWebSocketFilter implements Filter {
             throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
-        String tokenId = request.getHeader(authUtilsWrapper.getCookieName());
+        String tokenId = request.getHeader(authUtilsWrapper.getCookieHeaderName());
         if (StringUtils.isNotEmpty(tokenId)) {
             SSOToken ssoToken = tokenFactory.getTokenFromId(tokenId);
             if (ssoToken != null) {

--- a/openam-rest/src/main/java/org/forgerock/openam/rest/LocalSSOTokenSessionModule.java
+++ b/openam-rest/src/main/java/org/forgerock/openam/rest/LocalSSOTokenSessionModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 package org.forgerock.openam.rest;
@@ -161,6 +162,7 @@ public class LocalSSOTokenSessionModule implements AsyncServerAuthModule {
                 SSOToken requesterToken = getFactory().getTokenFromId(requester);
                 if (getFactory().isTokenValid(requesterToken)) {
                     Object o = RestrictedTokenContext.doUsing(requesterToken, new RestrictedTokenAction() {
+                        @Override
                         public Object run() throws Exception {
                             return validate(request, messageInfo, clientSubject);
                         }
@@ -173,15 +175,6 @@ public class LocalSSOTokenSessionModule implements AsyncServerAuthModule {
             }
         }
         return validate(request, messageInfo, clientSubject);
-    }
-
-    /**
-     * Gets the AM cookie name, as set by AM.
-     *
-     * @return The AM cookie name.
-     */
-    private String getCookieHeaderName() {
-        return authUtilsWrapper.getCookieName();
     }
 
     /**
@@ -204,7 +197,7 @@ public class LocalSSOTokenSessionModule implements AsyncServerAuthModule {
 
         String tokenId = getRequestUtils().getTokenId(request);
         if (StringUtils.isEmpty(tokenId)) {
-            tokenId = request.getHeader(getCookieHeaderName());
+            tokenId = request.getHeader(authUtilsWrapper.getCookieHeaderName());
         }
         if (!StringUtils.isEmpty(tokenId)) {
             SSOToken ssoToken = getFactory().getTokenFromId(tokenId);

--- a/openam-rest/src/test/java/org/forgerock/openam/notifications/NotificationsWebSocketFilterTest.java
+++ b/openam-rest/src/test/java/org/forgerock/openam/notifications/NotificationsWebSocketFilterTest.java
@@ -97,7 +97,7 @@ public class NotificationsWebSocketFilterTest extends GuiceTestCase {
     public void setUp() throws Exception {
         ssoToken = mock(SSOToken.class);
         identity = mock(AMIdentity.class);
-        when(authUtilsWrapper.getCookieName()).thenReturn(COOKIE_NAME);
+        when(authUtilsWrapper.getCookieHeaderName()).thenReturn(COOKIE_NAME);
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
         filterChain = mock(FilterChain.class);

--- a/openam-shared/src/main/java/com/sun/identity/shared/encode/CookieUtils.java
+++ b/openam-shared/src/main/java/com/sun/identity/shared/encode/CookieUtils.java
@@ -30,30 +30,33 @@
 
 package com.sun.identity.shared.encode;
 
-import static org.forgerock.openam.utils.Time.currentTimeMillis;
-
 import com.sun.identity.shared.Constants;
 import com.sun.identity.shared.configuration.SystemPropertiesManager;
 import com.sun.identity.shared.debug.Debug;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-import java.util.TimeZone;
 
 /**
  * Implements utility methods for handling Cookie.
  */
 public class CookieUtils {
+
+    static final String SECURE_COOKIE_PREFIX = "__Secure-";
+
+    static final String HOST_COOKIE_PREFIX = "__Host-";
+
     static boolean secureCookie =
         (SystemPropertiesManager.get(Constants.AM_COOKIE_SECURE) != null) &&
         (SystemPropertiesManager.get(Constants.AM_COOKIE_SECURE).
@@ -78,7 +81,8 @@ public class CookieUtils {
     static String fedCookieName = SystemPropertiesManager.get(
         Constants.FEDERATION_FED_COOKIE_NAME);
 
-    private static Set cookieDomains = null;
+    private static Set<String> cookieDomains = null;
+
     private static int defAge = -1;
 
     static Debug debug = Debug.getInstance("amCookieUtils");
@@ -90,6 +94,24 @@ public class CookieUtils {
      */
     public static String getAmCookieName() {
         return amCookieName;
+    }
+
+    /**
+     * Get name of a HTTP header that can be used as substitute value holder for a cookie
+     * with the given name.
+     *
+     * @param cookieName name of the cookie
+     * @return suitable HTTP header name
+     */
+    public static String getCookieHeaderName(String cookieName) {
+        String lowercaseName = cookieName.toLowerCase();
+        if (lowercaseName.startsWith(SECURE_COOKIE_PREFIX.toLowerCase())) {
+            return cookieName.substring(SECURE_COOKIE_PREFIX.length());
+        }
+        if (lowercaseName.startsWith(HOST_COOKIE_PREFIX.toLowerCase())) {
+            return cookieName.substring(HOST_COOKIE_PREFIX.length());
+        }
+        return cookieName;
     }
 
     /**
@@ -106,14 +128,14 @@ public class CookieUtils {
      *
      * @return the property value of "com.iplanet.services.cdsso.cookiedomain"
      */
-    public static Set getCdssoCookiedomain() {
+    public static Set<String> getCdssoCookiedomain() {
         if (cookieDomains != null) {
             return cookieDomains;
         }
 
-        Set cookieDomains = new HashSet();
+        Set<String> cookieDomains = new HashSet<>();
         if (cdssoCookiedomain == null || cdssoCookiedomain.length() < 1) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         StringTokenizer st = new StringTokenizer(cdssoCookiedomain, ",");
@@ -124,7 +146,7 @@ public class CookieUtils {
             }
         }
 
-        return cookieDomains.isEmpty() ? Collections.EMPTY_SET : cookieDomains;
+        return cookieDomains.isEmpty() ? Collections.emptySet() : cookieDomains;
     }
 
     /**
@@ -358,12 +380,15 @@ public class CookieUtils {
             cookie.setPath("/");
         }
 
-        if ((domain != null) && (domain.length() > 0)) {
-            cookie.setDomain(domain);
+        if (domain != null && domain.length() > 0) {
+            // Ignore domain when the name has __Host- prefix
+            if (!name.toLowerCase().startsWith(HOST_COOKIE_PREFIX.toLowerCase())) {
+                cookie.setDomain(domain);
+            }
         }
 
+        cookie.setHttpOnly(isCookieHttpOnly());
         cookie.setSecure(isCookieSecure());
-
         return cookie;
     }
 
@@ -397,49 +422,65 @@ public class CookieUtils {
     /**
      * Add cookie to {@link HttpServletResponse}.
      *
-     * @param response HTTP response to update. Never null.
+     * @param response HTTP response to update. Can be null.
      * @param cookie Cookie to add. Never null.
      * @param crossDomain Whether to set the SameSite cookie attribute to <code>None</code>.
      */
     public static void addCookieToResponse(HttpServletResponse response, Cookie cookie, boolean crossDomain) {
         if (cookie == null) {
-            return;
+            return; // This can unfortunately happen (see AuthClientUtils)
         }
 
-        StringBuilder sb = new StringBuilder(150);
-        sb.append(cookie.getName()).append("=").append(cookie.getValue());
+        String cookieString = renderSetCookieValue(cookie, crossDomain);
+        if (debug.messageEnabled()) {
+            debug.message("CookieUtils:addCookieToResponse adds " + cookieString);
+        }
+        response.addHeader("Set-Cookie", cookieString);
+    }
+
+    /**
+     * Render <code>Set-Cookie</code> header valut.
+     *
+     * @param cookie Cookie to render. Never null.
+     * @param crossDomain Whether to set the SameSite cookie attribute to <code>None</code>.
+     * @return Rendered <code>Set-Cookie</code> header value.
+     */
+    public static String renderSetCookieValue(Cookie cookie, boolean crossDomain) {
+        StringBuilder sb = new StringBuilder(150)
+                .append(cookie.getName()).append("=").append(cookie.getValue());
+
         String path = cookie.getPath();
         if (path != null && path.length() > 0) {
             sb.append("; Path=").append(path);
         } else {
             sb.append("; Path=/");
         }
+
         String domain = cookie.getDomain();
         if (domain != null && domain.length() > 0) {
             sb.append("; Domain=").append(domain);
         }
+
         int age = cookie.getMaxAge();
         if (age > -1) {
-            Date date = new Date(currentTimeMillis() + age * 1000l);
-            SimpleDateFormat sdf = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz", Locale.UK);
-            sdf.setTimeZone(TimeZone.getTimeZone("GMT"));
             sb.append("; Max-Age=").append(age);
-            // set Expires as < IE 8 does not support max-age
-            sb.append("; Expires=").append(sdf.format(date));
+            // Support for Expires as < IE 8 does not support max-age
+            ZonedDateTime expires = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(age);
+            sb.append("; Expires=").append(DateTimeFormatter.RFC_1123_DATE_TIME.format(expires));
         }
-        if (isCookieSecure() || cookie.getSecure()) {
+
+        if (cookie.isHttpOnly()) {
+            sb.append("; HttpOnly");
+        }
+
+        if (cookie.getSecure()) {
             sb.append("; Secure");
             if (crossDomain) {
                 sb.append("; SameSite=None");
             }
         }
-        if (isCookieHttpOnly() || cookie.isHttpOnly()) {
-            sb.append("; HttpOnly");
-        }
-        if (debug.messageEnabled()) {
-            debug.message("CookieUtils:addCookieToResponse adds " + sb);
-        }
-        response.addHeader("Set-Cookie", sb.toString());
+
+        return sb.toString();
     }
 
     /**

--- a/openam-shared/src/test/java/com/sun/identity/shared/encode/CookieUtilsTest.java
+++ b/openam-shared/src/test/java/com/sun/identity/shared/encode/CookieUtilsTest.java
@@ -17,11 +17,15 @@
 package com.sun.identity.shared.encode;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collections;
 import java.util.Set;
 import org.testng.annotations.DataProvider;
@@ -96,6 +100,39 @@ public class CookieUtilsTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getServerName()).thenReturn(host);
         return request;
+    }
+
+    @DataProvider(name = "cookieHeaderNames")
+    public Object[][] cookieHeaderNames() {
+        return new Object[][] {
+                // cookie name, header name
+                { "iPlanetDirectoryPro", "iPlanetDirectoryPro" },
+                { "__Host-iPlanetDirectoryPro", "iPlanetDirectoryPro" },
+                { "__HOST-iPlanetDirectoryPro", "iPlanetDirectoryPro" },
+                { "__Secure-iPlanetDirectoryPro", "iPlanetDirectoryPro" },
+                { "__secure-iPlanetDirectoryPro", "iPlanetDirectoryPro" },
+        };
+    }
+
+    @Test(dataProvider = "cookieHeaderNames")
+    public void shouldGetCookieHeaderName(String cookieName, String headerName) {
+        assertEquals(CookieUtils.getCookieHeaderName(cookieName), headerName);
+    }
+
+    @DataProvider(name = "responseCookies")
+    public Object[][] responseCookies() {
+        return new Object[][] {
+            { CookieUtils.newCookie("foo", "bar"), "foo=bar; Path=/" },
+            { CookieUtils.newCookie("foo", "bar", "/hello", "example.org"), "foo=bar; Path=/hello; Domain=example.org" },
+            { CookieUtils.newCookie("__Host-foo", "bar", "/", "example.org"), "__Host-foo=bar; Path=/" }
+        };
+    }
+
+    @Test(dataProvider = "responseCookies")
+    public void shouldAddCookieToResponse(Cookie cookie, String expected) {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        CookieUtils.addCookieToResponse(response, cookie);
+        verify(response, only()).addHeader("Set-Cookie", expected);
     }
 
 }

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/SessionToken.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/user/login/tokens/SessionToken.jsm
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 /**
@@ -27,7 +28,8 @@ function cookieName () {
 }
 
 function cookieDomains () {
-    return Configuration.globalData.auth.cookieDomains;
+    const hostOnly = cookieName().toLowerCase().startsWith("__host-");
+    return hostOnly ? [] : Configuration.globalData.auth.cookieDomains;
 }
 
 function secureCookie () {
@@ -43,5 +45,5 @@ export function get () {
 }
 
 export function remove () {
-    return CookieHelper.deleteCookie(cookieName(), "/", cookieDomains());
+    return CookieHelper.deleteCookie(cookieName(), "/", cookieDomains(), secureCookie());
 }

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <!-- Wren Security Dependencies -->
         <wrends.version>5.1.0</wrends.version>
         <wrensec-commons.version>23.0.1</wrensec-commons.version>
-        <wrensec-ui.version>23.2.5</wrensec-ui.version>
+        <wrensec-ui.version>23.3.0</wrensec-ui.version>
 
         <!-- Test Dependencies -->
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
This PR adds support for cookie name prefixes defined in RFC 6265bis (`__Host-` and `__Secure`).

## How to configure

AM SSO cookie name is still being used verbatim. If the cookie has to have prefix, the cookie name must be configured with such prefix. Different cookie name of course mean that every component that works with the cookie has to be aware of this change.

Using prefixes expects that the cookie is configured with secured flag, otherwise it will get rejected by browsers. I.e. when using prefixed cookie name, always enable _Secure Cookie_ as well.

## Releation to HTTP headers

I have implemented removal of those prefixes when the SSO token ID is being read from a HTTP header. HTTP headers with `__` prefix are problematic. This means that cookie name and HTTP header name can differ when using the prefix.

For example with cookie name `__Host-iPlanetDirectoryPro` the HTTP header name will still be `iPlanetDirectoryPro`.
