### PR TITLE
Prevent UI builds from modifying npm-shrinkwrap.json files

### DIFF
--- a/openam-ui/openam-ui-api/pom.xml
+++ b/openam-ui/openam-ui-api/pom.xml
@@ -13,7 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018-2024 Wren Security.
+ * Portions Copyright 2018-2026 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -108,12 +108,16 @@
                     </execution>
 
                     <execution>
-                        <id>npm-install</id>
+                        <id>npm-ci</id>
                         <phase>initialize</phase>
 
                         <goals>
                             <goal>npm</goal>
                         </goals>
+
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
 
                     <execution>

--- a/openam-ui/openam-ui-ria/pom.xml
+++ b/openam-ui/openam-ui-ria/pom.xml
@@ -13,7 +13,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2017 ForgeRock AS.
- * Portions Copyright 2018-2024 Wren Security.
+ * Portions Copyright 2018-2026 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -143,12 +143,16 @@
                     </execution>
 
                     <execution>
-                        <id>npm-install</id>
+                        <id>npm-ci</id>
                         <phase>initialize</phase>
 
                         <goals>
                             <goal>npm</goal>
                         </goals>
+
+                        <configuration>
+                            <arguments>ci</arguments>
+                        </configuration>
                     </execution>
 
                     <execution>


### PR DESCRIPTION
This PR configures both UI modules to install their npm dependencies with `npm ci` during the Maven initialize phase.

The Maven frontend plugin previously used its default `npm install` command for both UI modules. With the configured npm 11.4.1, building `openam-ui-ria` rewrote the committed `npm-shrinkwrap.json` by removing 39 `libc` metadata lines from the platform-specific Rollup packages. This left the working tree dirty after a normal build.

Both UI modules now explicitly use `npm ci`. This installs the dependencies recorded in their shrinkwrap files, fails when a shrinkwrap is inconsistent with `package.json`, and does not modify the dependency files during a build.