### PR TITLE
Add missing redux-actions path to standalone XUI entry points

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/main-authorize.js
+++ b/openam-ui/openam-ui-ria/src/main/js/main-authorize.js
@@ -37,6 +37,7 @@ require.config({
         "jquery": "libs/jquery",
         "lodash": "libs/lodash",
         "redux": "libs/redux",
+        "redux-actions": "libs/redux-actions",
         "text": "libs/text",
         "underscore": "libs/underscore"
     },

--- a/openam-ui/openam-ui-ria/src/main/js/main-device.js
+++ b/openam-ui/openam-ui-ria/src/main/js/main-device.js
@@ -28,6 +28,7 @@ require.config({
         "jquery": "libs/jquery",
         "lodash": "libs/lodash",
         "redux": "libs/redux",
+        "redux-actions": "libs/redux-actions",
         "text": "libs/text",
         "underscore": "libs/underscore"
     },

--- a/openam-ui/openam-ui-ria/src/main/js/main-end-session.js
+++ b/openam-ui/openam-ui-ria/src/main/js/main-end-session.js
@@ -27,6 +27,7 @@ require.config({
         "jquery": "libs/jquery",
         "lodash": "libs/lodash",
         "redux": "libs/redux",
+        "redux-actions": "libs/redux-actions",
         "text": "libs/text"
     },
     shim: {


### PR DESCRIPTION
### Problem

The OAuth2 consent page fails to load, leaving the authorization flow stuck. The device verification and end session pages fail in the same way.

```
Uncaught Error: Script error for "redux-actions", needed by:
store/modules/remote/config/realm/identities/groups/instances,
store/modules/remote/config/realm/identities/groups/schema,
store/modules/local/config/realm/identities/groups/values
```

### Cause

Unlike the rest of XUI, these three pages are not served from the bundled `main.js`. Each has its own entry point with its own RequireJS configuration and loads every dependency separately at runtime, so every library has to be listed in that configuration. `redux-actions` is not.

Nothing on these pages uses `redux-actions` directly. It arrives through the Redux store, which needs its complete reducer tree the moment it is created:

```
main-authorize.js              requires ThemeManager
└─ ThemeManager                reads state.server.realm
   └─ store/index              createStore(rootReducer)
      └─ store/reducers/index  combineReducers(...)
         └─ 20 store modules, including
            .../identities/groups/{instances,schema,values}
            └─ import { createAction, handleActions } from "redux-actions"
```

The three group modules were added in cdf5d5dab4, which is when the missing path started to matter.

### Fix

Add `redux-actions` to the paths of all three entry points, matching the configuration already present in `main.js`.
