### PR TITLE
Support for skipping the logout confirmation page

### DIFF
--- a/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
+++ b/openam-core/src/main/java/org/forgerock/openam/oauth2/OAuth2Constants.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2012-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2026 Wren Security.
  */
 
 package org.forgerock.openam.oauth2;
@@ -826,6 +826,7 @@ public class OAuth2Constants {
         public static final String PHONE_MAPPING = "org-forgerock-oidc-phone-attribute-mapping";
         public static final String STORE_OPS_TOKENS = "storeOpsTokens";
         public static final String CLIENTS_CAN_SKIP_CONSENT = "clientsCanSkipConsent";
+        public static final String REQUIRE_LOGOUT_CONFIRMATION = "requireLogoutConfirmation";
         public static final String OIDC_SSOPROVIDER_ENABLED = "oidcSsoProviderEnabled";
 
         public static final String SUPPORTED_CLAIMS = "forgerock-oauth2-provider-supported-claims";
@@ -916,6 +917,7 @@ public class OAuth2Constants {
         public static final String CLIENT_SESSION_URI = "com.forgerock.openam.oauth2provider.clientSessionURI";
         public static final String CLIENT_NAME = "com.forgerock.openam.oauth2provider.clientName";
         public static final String IS_CONSENT_IMPLIED = "isConsentImplied";
+        public static final String REQUIRE_LOGOUT_CONFIRMATION = "requireLogoutConfirmation";
 
         public static final String JWKS_URI = "com.forgerock.openam.oauth2provider.jwksURI";
         public static final String JWKS = "com.forgerock.openam.oauth2provider.jwks";

--- a/openam-core/src/main/resources/agentService.properties
+++ b/openam-core/src/main/resources/agentService.properties
@@ -27,6 +27,7 @@
 #
 # Portions Copyrighted 2011-2016 ForgeRock AS.
 # Portions Copyrighted 2013-2016 Nomura Research Institute, Ltd.
+# Portions Copyrighted 2026 Wren Security
 
 label.Empty=---EMPTY----
 a10=USER_ID
@@ -804,6 +805,10 @@ JWT Token Lifetime of the OAuth2 Provider is used instead of.
 a758=Implied consent
 a758.help=When enabled, the resource owner will not be asked for consent during authorization flows. The OAuth2 \
   Provider must be configured to allow clients to skip consent.
+a759=Require logout confirmation
+a759.help=When enabled, the end user is asked to confirm this client's RP-Initiated Logout requests even when they \
+  carry a valid ID Token referencing the current user session. Requests without such a token are always confirmed, \
+  as are all requests when the OAuth2 Provider requires logout confirmation.
 a7001=OAuth2 Clients
 a7002=Web Agents
 a7003=J2EE Agents

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/AgentOAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/AgentOAuth2ProviderSettings.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2022 Wren Security
+ * Portions copyright 2022-2026 Wren Security
  */
 package org.forgerock.oauth2.core;
 
@@ -368,6 +368,11 @@ public class AgentOAuth2ProviderSettings implements OAuth2ProviderSettings {
     @Override
     public boolean clientsCanSkipConsent() throws ServerException {
         return true;
+    }
+
+    @Override
+    public boolean isLogoutConfirmationRequired() throws ServerException {
+        return false;
     }
 
     @Override

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/ClientRegistration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/ClientRegistration.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2014-2016 ForgeRock AS.
+ * Portions Copyright 2026 Wren Security
  */
 
 package org.forgerock.oauth2.core;
@@ -149,4 +150,13 @@ public interface ClientRegistration {
      * @return true if the client is configured to skip resource owner consent.
      */
     boolean isConsentImplied();
+
+    /**
+     * Gets whether the client requires the end user to confirm its RP-Initiated Logout requests even when they are
+     * trusted, that is, when they carry a valid ID Token referencing the current user session.
+     *
+     * @return {@code true} if logout confirmation is required for the client.
+     */
+    boolean isLogoutConfirmationRequired();
+
 }

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/OAuth2ProviderSettings.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security
  */
 package org.forgerock.oauth2.core;
 
@@ -539,6 +540,18 @@ public interface OAuth2ProviderSettings {
      * @throws ServerException If the setting could not be retrieved.
      */
     boolean clientsCanSkipConsent() throws ServerException;
+
+    /**
+     * Whether the end user must confirm every RP-Initiated Logout request, regardless of the client configuration.
+     * <p>
+     * When this is not required, a client may still opt in to confirmation of its own logout requests. Requests that
+     * carry no valid ID Token for the current user session are always confirmed.
+     * </p>
+     *
+     * @return {@code true} if logout confirmation is required for all clients of this provider.
+     * @throws ServerException If the setting could not be retrieved.
+     */
+    boolean isLogoutConfirmationRequired() throws ServerException;
 
     /**
      * Whether OpenID Connect ID Tokens are accepted as SSOTokens in this realm or not.

--- a/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
+++ b/openam-oauth2/src/main/java/org/forgerock/oauth2/core/RealmOAuth2ProviderSettings.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyright 2023 Wren Security.
+ * Portions Copyright 2023-2026 Wren Security.
  */
 
 package org.forgerock.oauth2.core;
@@ -937,6 +937,11 @@ public class RealmOAuth2ProviderSettings implements OAuth2ProviderSettings {
     @Override
     public boolean clientsCanSkipConsent() throws ServerException {
         return Boolean.parseBoolean(getStringSettingValue(OAuth2Constants.OAuth2ProviderService.CLIENTS_CAN_SKIP_CONSENT));
+    }
+
+    @Override
+    public boolean isLogoutConfirmationRequired() throws ServerException {
+        return Boolean.parseBoolean(getStringSettingValue(OAuth2Constants.OAuth2ProviderService.REQUIRE_LOGOUT_CONFIRMATION));
     }
 
     @Override

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/AgentClientRegistration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/AgentClientRegistration.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2022 Wren Security
+ * Portions copyright 2022-2026 Wren Security
  */
 package org.forgerock.openam.oauth2;
 
@@ -205,6 +205,17 @@ public class AgentClientRegistration implements OpenIdConnectClientRegistration 
     @Override
     public boolean isConsentImplied() {
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Confirmation is not required for agents' OpenId Connect client registration.
+     * </p>
+     */
+    @Override
+    public boolean isLogoutConfirmationRequired() {
+        return false;
     }
 
     /**

--- a/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OpenAMClientRegistration.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openam/oauth2/OpenAMClientRegistration.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyrighted 2022 Wren Security
+ * Portions Copyrighted 2022-2026 Wren Security
  */
 
 package org.forgerock.openam.oauth2;
@@ -668,6 +668,11 @@ public class OpenAMClientRegistration implements OpenIdConnectClientRegistration
     @Override
     public boolean isConsentImplied() {
         return Boolean.parseBoolean(getAttribute(OAuth2Constants.OAuth2Client.IS_CONSENT_IMPLIED));
+    }
+
+    @Override
+    public boolean isLogoutConfirmationRequired() {
+        return Boolean.parseBoolean(getAttribute(OAuth2Constants.OAuth2Client.REQUIRE_LOGOUT_CONFIRMATION));
     }
 
     private boolean verifyJwtBySharedSecret(final OAuth2Jwt jwt) {

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/EndSessionService.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/EndSessionService.java
@@ -30,6 +30,7 @@ import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.oauth2.core.ClientRegistration;
 import org.forgerock.oauth2.core.ClientRegistrationStore;
 import org.forgerock.oauth2.core.CsrfProtection;
+import org.forgerock.oauth2.core.OAuth2ProviderSettingsFactory;
 import org.forgerock.oauth2.core.OAuth2Request;
 import org.forgerock.oauth2.core.exceptions.BadRequestException;
 import org.forgerock.oauth2.core.exceptions.CsrfException;
@@ -54,6 +55,7 @@ public class EndSessionService {
     private final SSOTokenManager ssoTokenManager;
     private final ClientRegistrationStore clientRegistrationStore;
     private final CsrfProtection csrfProtection;
+    private final OAuth2ProviderSettingsFactory providerSettingsFactory;
 
     /**
      * Constructs a new EndSessionService.
@@ -63,16 +65,19 @@ public class EndSessionService {
      * @param ssoTokenManager An instance of the SSOTokenManager.
      * @param clientRegistrationStore An instance of the ClientRegistrationStore.
      * @param csrfProtection An instance of the CsrfProtection.
+     * @param providerSettingsFactory An instance of the OAuth2ProviderSettingsFactory.
      */
     @Inject
     public EndSessionService(EndSessionParametersValidator parametersValidator,
             OpenIDConnectProvider openIDConnectProvider, SSOTokenManager ssoTokenManager,
-            ClientRegistrationStore clientRegistrationStore, CsrfProtection csrfProtection) {
+            ClientRegistrationStore clientRegistrationStore, CsrfProtection csrfProtection,
+            OAuth2ProviderSettingsFactory providerSettingsFactory) {
         this.parametersValidator = parametersValidator;
         this.openIDConnectProvider = openIDConnectProvider;
         this.ssoTokenManager = ssoTokenManager;
         this.clientRegistrationStore = clientRegistrationStore;
         this.csrfProtection = csrfProtection;
+        this.providerSettingsFactory = providerSettingsFactory;
     }
 
     /**
@@ -103,10 +108,9 @@ public class EndSessionService {
             throws BadRequestException, ServerException {
         JwtClaimsSet claims = params.getClaims()
                 .orElseThrow(() -> new BadRequestException("The endSession endpoint requires a valid id_token_hint parameter"));
-        String opsId = (String) claims.getClaim(OAuth2Constants.JWTTokenParams.OPS);
-        if (opsId == null) {
-            opsId = (String) claims.getClaim(OAuth2Constants.JWTTokenParams.LEGACY_OPS);
-        }
+        // The proprietary "ops" claim is used instead of the standard "sid" because ID tokens do not issue "sid" yet.
+        String opsId = resolveOpsId(params)
+                .orElseThrow(() -> new BadRequestException("id_token_hint does not reference a session"));
         // Expose the ID Token on the OAuth2 request so the access audit filter can attribute the logout.
         request.setToken(OpenIdConnectToken.class, new OpenIdConnectToken(claims));
         openIDConnectProvider.destroySession(opsId);
@@ -118,13 +122,45 @@ public class EndSessionService {
      * @param request The servlet request carrying the SSO token.
      * @return The session, or {@link Optional#empty()} if there is no active session.
      */
-    public Optional<SSOToken> currentSession(HttpServletRequest request) {
+    public Optional<SSOToken> getCurrentSession(HttpServletRequest request) {
         try {
             return Optional.of(ssoTokenManager.createSSOToken(request));
         } catch (SSOException e) {
             logger.debug("No active session on the request", e);
             return Optional.empty();
         }
+    }
+
+    /**
+     * Determines whether user confirmation may be skipped for an RP-Initiated Logout request.
+     *
+     * @param request The OAuth2 request.
+     * @param params The end session parameters.
+     * @param session The user's current SSO session, or {@code null} if there is none.
+     * @return {@code true} if the confirmation page may be skipped.
+     * @throws OAuth2Exception If the client or provider settings cannot be resolved.
+     */
+    public boolean canSkipLogoutConfirmation(OAuth2Request request, EndSessionParameters params, SSOToken session)
+            throws OAuth2Exception {
+        if (session == null || params.getIdTokenHint().isEmpty()) {
+            return false;
+        }
+        Optional<String> clientId = params.getTokenClientId();
+        if (clientId.isEmpty()) {
+            return false;
+        }
+        // The proprietary "ops" claim is used instead of the standard "sid" because ID tokens do not issue "sid" yet.
+        Optional<String> opsId = resolveOpsId(params);
+        if (opsId.isEmpty()) {
+            return false;
+        }
+        ClientRegistration client = clientRegistrationStore.get(clientId.get(), request);
+        request.setClientRegistration(client);
+        if (providerSettingsFactory.get(request).isLogoutConfirmationRequired()
+                || client.isLogoutConfirmationRequired()) {
+            return false;
+        }
+        return openIDConnectProvider.isOpsTokenForSession(opsId.get(), session);
     }
 
     /**
@@ -198,6 +234,12 @@ public class EndSessionService {
         return request.getClaims()
                 .flatMap(claims -> claimAsString(claims, OAuth2Constants.JWTTokenParams.SUB))
                 .or(() -> Optional.ofNullable(session).flatMap(this::identityName));
+    }
+
+    private Optional<String> resolveOpsId(EndSessionParameters params) {
+        return params.getClaims()
+                .flatMap(claims -> claimAsString(claims, OAuth2Constants.JWTTokenParams.OPS)
+                        .or(() -> claimAsString(claims, OAuth2Constants.JWTTokenParams.LEGACY_OPS)));
     }
 
     private Optional<ClientRegistration> resolveClientRegistration(String realm, EndSessionParameters request)

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProvider.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/OpenIDConnectProvider.java
@@ -103,8 +103,7 @@ public class OpenIDConnectProvider {
 
             JsonValue idTokenUserSessionToken = tokenAdapter.fromToken(opsToken);
             cts.delete(opsId);
-            String sessionId = getFirstItem(idTokenUserSessionToken.get(OAuth2Constants.JWTTokenParams.LEGACY_OPS)
-                    .asCollection(String.class));
+            String sessionId = getSessionId(idTokenUserSessionToken);
 
             // for some grant type, there is no OpenAM session associated with a id_token
             if (sessionId != null) {
@@ -118,5 +117,34 @@ public class OpenIDConnectProvider {
             logger.error("Unable to get SsoTokenManager", e);
             throw new ServerException("Unable to get SsoTokenManager");
         }
+    }
+
+    /**
+     * Determines whether the given ops token references the given SSO session.
+     *
+     * @param opsId The ops token id, as carried by an ID Token's {@code ops} claim.
+     * @param session The SSO session to match against, usually the current one.
+     * @return {@code true} if the ops token references the given SSO session.
+     */
+    public boolean isOpsTokenForSession(String opsId, SSOToken session) {
+        if (opsId == null || session == null) {
+            return false;
+        }
+        try {
+            Token opsToken = cts.read(opsId);
+            if (opsToken == null) {
+                return false;
+            }
+            String sessionId = getSessionId(tokenAdapter.fromToken(opsToken));
+            return sessionId != null && sessionId.equals(session.getTokenID().toString());
+        } catch (Exception e) {
+            logger.debug("Unable to verify the session referenced by the id_token_hint", e);
+            return false;
+        }
+    }
+
+    private String getSessionId(JsonValue idTokenUserSessionToken) {
+        return getFirstItem(idTokenUserSessionToken.get(OAuth2Constants.JWTTokenParams.LEGACY_OPS)
+                .asCollection(String.class));
     }
 }

--- a/openam-oauth2/src/main/java/org/forgerock/openidconnect/restlet/EndSession.java
+++ b/openam-oauth2/src/main/java/org/forgerock/openidconnect/restlet/EndSession.java
@@ -86,23 +86,11 @@ public class EndSession extends ServerResource {
     }
 
     /**
-     * Handles GET requests to display the OpenId Connect end session confirmation page.
+     * Handles GET requests to the OpenID Connect end session endpoint.
      */
     @Get
-    public Representation showConfirmation() throws OAuth2RestletException {
-        try {
-            EndSessionParameters params = EndSessionParameters.from(getServletRequest());
-            OAuth2Request request = requestFactory.create(getRequest());
-            validateRequest(request, params);
-            SSOToken session = endSessionService.currentSession(getServletRequest()).orElse(null);
-            if (params.getIdTokenHint().isEmpty() && session == null) {
-                // Nothing to log out
-                return getTemplate("done");
-            }
-            return getTemplate("confirmation", getConfirmationDataModel(params, session));
-        } catch (OAuth2Exception e) {
-            throw new OAuth2RestletException(e.getStatusCode(), e.getError(), e.getMessage(), null);
-        }
+    public Representation endSession() throws OAuth2RestletException {
+        return handleLogoutRequest();
     }
 
     /**
@@ -116,22 +104,50 @@ public class EndSession extends ServerResource {
         String decision = getServletRequest().getParameter("decision");
 
         if ("logout".equals(decision)) {
-            EndSessionParameters params = EndSessionParameters.from(getServletRequest());
-            OAuth2Request request = requestFactory.create(getRequest());
-            validateRequest(request, params);
-            return processLogout(request, params);
-        } else if ("cancel".equals(decision)) {
+            return handleConfirmedLogout();
+        }
+        if ("cancel".equals(decision)) {
             return getTemplate("canceled");
         }
 
-        return showConfirmation();
+        return handleLogoutRequest();
     }
 
-    private Representation processLogout(OAuth2Request request, EndSessionParameters params)
-            throws OAuth2RestletException {
-        SSOToken session = endSessionService.currentSession(getServletRequest()).orElse(null);
+    private Representation handleLogoutRequest() throws OAuth2RestletException {
+        try {
+            EndSessionParameters params = EndSessionParameters.from(getServletRequest());
+            OAuth2Request request = requestFactory.create(getRequest());
+            validateRequest(request, params);
+            SSOToken session = endSessionService.getCurrentSession(getServletRequest()).orElse(null);
+            if (params.getIdTokenHint().isEmpty() && session == null) {
+                // Nothing to log out
+                return getTemplate("done");
+            }
+            if (endSessionService.canSkipLogoutConfirmation(request, params, session)) {
+                return performLogout(request, params, session);
+            }
+            return getTemplate("confirmation", getConfirmationDataModel(params, session));
+        } catch (OAuth2Exception e) {
+            throw new OAuth2RestletException(e.getStatusCode(), e.getError(), e.getMessage(), null);
+        }
+    }
+
+    private Representation handleConfirmedLogout() throws OAuth2RestletException {
+        EndSessionParameters params = EndSessionParameters.from(getServletRequest());
+        OAuth2Request request = requestFactory.create(getRequest());
+        validateRequest(request, params);
+        SSOToken session = endSessionService.getCurrentSession(getServletRequest()).orElse(null);
         try {
             endSessionService.verifyCsrf(request, session);
+            return performLogout(request, params, session);
+        } catch (OAuth2Exception e) {
+            throw new OAuth2RestletException(e.getStatusCode(), e.getError(), e.getMessage(), null);
+        }
+    }
+
+    private Representation performLogout(OAuth2Request request, EndSessionParameters params, SSOToken session)
+            throws OAuth2RestletException {
+        try {
             if (params.getIdTokenHint().isPresent()) {
                 endSessionService.endSession(request, params);
                 if (params.getPostLogoutRedirectUri().isPresent()) {
@@ -172,21 +188,21 @@ public class EndSession extends ServerResource {
         return representation;
     }
 
-    private Map<String, Object> getConfirmationDataModel(EndSessionParameters request, SSOToken session)
+    private Map<String, Object> getConfirmationDataModel(EndSessionParameters params, SSOToken session)
             throws InvalidClientException, NotFoundException {
         Map<String, Object> dataModel = new HashMap<>();
 
-        endSessionService.resolveClientName(getRealm(), request, getLocale())
+        endSessionService.resolveClientName(getRealm(), params, getLocale())
                 .ifPresent(clientName -> dataModel.put("clientName", clientName));
-        endSessionService.resolveUserName(request, session)
+        endSessionService.resolveUserName(params, session)
                 .ifPresent(userName -> dataModel.put("userName", userName));
         endSessionService.resolveCsrfToken(session)
                 .ifPresent(csrf -> dataModel.put("csrf", csrf));
-        request.getIdTokenHint()
+        params.getIdTokenHint()
                 .ifPresent(idTokenHint -> dataModel.put("idTokenHint", idTokenHint));
-        request.getPostLogoutRedirectUri()
+        params.getPostLogoutRedirectUri()
                 .ifPresent(redirectUri -> dataModel.put("postLogoutRedirectUri", redirectUri));
-        request.getState()
+        params.getState()
                 .ifPresent(state -> dataModel.put("state", state));
 
         return dataModel;
@@ -202,9 +218,9 @@ public class EndSession extends ServerResource {
         exceptionHandler.handle(throwable, getResponse(), error -> getTemplate("error", new HashMap<>(error)));
     }
 
-    private Representation handleRedirect(EndSessionParameters request) {
-        String target = request.getPostLogoutRedirectUri().orElseThrow();
-        Optional<String> state = request.getState();
+    private Representation handleRedirect(EndSessionParameters params) {
+        String target = params.getPostLogoutRedirectUri().orElseThrow();
+        Optional<String> state = params.getState();
         if (state.isPresent()) {
             target = UriBuilder.fromUri(URI.create(target))
                     .queryParam("state", "{state}")

--- a/openam-oauth2/src/main/resources/OAuth2Provider.properties
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.properties
@@ -24,6 +24,7 @@
 
 #
 # Portions Copyrighted 2014-2016 Nomura Research Institute, Ltd.
+# Portions Copyrighted 2026 Wren Security
 #
 
 forgerock-oauth2-provider-description=OAuth2 Provider
@@ -265,5 +266,11 @@ a137.help=When this setting is enable /oauth2/idtokeninfo endpoint requires clie
 a139=Allow ID Tokens as SSOTokens
 a139.help=Whether to allow ID Tokens issued by OpenAM to be used as SSOTokens in REST calls.
 a139.help.txt=If enabled Store Ops Tokens must also be enabled.
+a140=Require logout confirmation
+a140.help=When enabled, the end user is asked to confirm every RP-Initiated Logout request, regardless of the client \
+  configuration. When disabled, a client may still require confirmation of its own logout requests.
+a140.help.txt=Requests that carry no valid ID Token referencing the current user session are always confirmed. \
+  Skipping confirmation therefore also requires Store Ops Tokens to be enabled, because without it ID Tokens carry \
+  no session reference.
 i18nTrue=Yes
 i18nFalse=No

--- a/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.section.properties
@@ -12,7 +12,7 @@
 # information: "Portions copyright [year] [name of copyright owner]".
 #
 # Copyright 2016 ForgeRock AS.
-# Portions Copyright 2025 Wren Security
+# Portions Copyright 2025-2026 Wren Security
 #
 
 coreOAuth2Config=statelessTokensEnabled
@@ -50,6 +50,7 @@ coreOIDCConfig=forgerock-oauth2-provider-supported-claims
 coreOIDCConfig=forgerock-oauth2-provider-oidc-claims-extension-script
 
 advancedOIDCConfig=storeOpsTokens
+advancedOIDCConfig=requireLogoutConfirmation
 advancedOIDCConfig=forgerock-oauth2-provider-amr-mappings
 advancedOIDCConfig=forgerock-oauth2-provider-default-acr
 advancedOIDCConfig=forgerock-oauth2-provider-loa-mapping
@@ -65,4 +66,3 @@ deviceCodeConfig=verificationUrl
 deviceCodeConfig=completionUrl
 deviceCodeConfig=deviceCodeLifetime
 deviceCodeConfig=devicePollInterval
-

--- a/openam-oauth2/src/main/resources/OAuth2Provider.xml
+++ b/openam-oauth2/src/main/resources/OAuth2Provider.xml
@@ -17,6 +17,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2012-2016 ForgeRock AS.
+ * Portions Copyrighted 2026 Wren Security
  */
 -->
 
@@ -624,8 +625,18 @@
                     </DefaultValues>
                 </AttributeSchema>
 
+                <AttributeSchema name="requireLogoutConfirmation" type="single" syntax="boolean" i18nKey="a140" order="430">
+                    <BooleanValues>
+                        <BooleanTrueValue i18nKey="i18nTrue">true</BooleanTrueValue>
+                        <BooleanFalseValue i18nKey="i18nFalse">false</BooleanFalseValue>
+                    </BooleanValues>
+                    <DefaultValues>
+                        <Value>false</Value>
+                    </DefaultValues>
+                </AttributeSchema>
+
                 <AttributeSchema name="oidcSsoProviderEnabled" type="single" syntax="boolean" i18nKey="a139"
-                    order="430">
+                    order="440">
                     <BooleanValues>
                         <BooleanTrueValue i18nKey="i18nTrue">true</BooleanTrueValue>
                         <BooleanFalseValue i18nKey="i18nFalse">false</BooleanFalseValue>

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AgentClientRegistrationTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/AgentClientRegistrationTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2021 Wren Security.
+ * Portions Copyright 2021-2026 Wren Security.
  */
 package org.forgerock.openam.oauth2;
 
@@ -151,6 +151,11 @@ public class AgentClientRegistrationTest {
     @Test
     public void consentIsImplied() {
         assertThat(agentClientRegistration.isConsentImplied()).isEqualTo(true);
+    }
+
+    @Test
+    public void logoutConfirmationIsNotRequired() {
+        assertThat(agentClientRegistration.isLogoutConfirmationRequired()).isFalse();
     }
 
     @Test

--- a/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/OpenAMClientRegistrationTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openam/oauth2/OpenAMClientRegistrationTest.java
@@ -13,7 +13,7 @@
  *
  * Copyright 2014-2016 ForgeRock AS.
  * Portions Copyrighted 2015 Nomura Research Institute, Ltd.
- * Portions Copyright 2021 Wren Security.
+ * Portions Copyright 2021-2026 Wren Security.
  */
 
 package org.forgerock.openam.oauth2;
@@ -141,6 +141,18 @@ public class OpenAMClientRegistrationTest extends AbstractMockBasedTest {
         setUpAgentToThrowExceptionForAttribute(OAuth2Constants.OAuth2Client.POST_LOGOUT_URI);
 
         clientRegistration.getPostLogoutRedirectUris();
+    }
+
+    @Test
+    public void logoutConfirmationRequirementReflectsClientConfiguration() throws Exception {
+        setUpAgentWithAttribute(OAuth2Constants.OAuth2Client.REQUIRE_LOGOUT_CONFIRMATION, "true");
+
+        assertThat(clientRegistration.isLogoutConfirmationRequired()).isTrue();
+    }
+
+    @Test
+    public void logoutConfirmationIsNotRequiredByDefault() {
+        assertThat(clientRegistration.isLogoutConfirmationRequired()).isFalse();
     }
 
     @Test

--- a/openam-oauth2/src/test/java/org/forgerock/openidconnect/EndSessionServiceTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openidconnect/EndSessionServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,9 +46,12 @@ import org.forgerock.json.jose.jwt.JwtClaimsSet;
 import org.forgerock.oauth2.core.ClientRegistration;
 import org.forgerock.oauth2.core.ClientRegistrationStore;
 import org.forgerock.oauth2.core.CsrfProtection;
+import org.forgerock.oauth2.core.OAuth2ProviderSettings;
+import org.forgerock.oauth2.core.OAuth2ProviderSettingsFactory;
 import org.forgerock.oauth2.core.OAuth2Request;
 import org.forgerock.oauth2.core.exceptions.CsrfException;
 import org.forgerock.openam.oauth2.OAuth2Constants;
+import org.mockito.InOrder;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -64,6 +68,8 @@ public class EndSessionServiceTest {
     private SSOTokenManager ssoTokenManager;
     private ClientRegistrationStore clientRegistrationStore;
     private CsrfProtection csrfProtection;
+    private OAuth2ProviderSettingsFactory providerSettingsFactory;
+    private OAuth2ProviderSettings providerSettings;
     private OAuth2Request request;
     private EndSessionService service;
 
@@ -74,9 +80,11 @@ public class EndSessionServiceTest {
         ssoTokenManager = mock(SSOTokenManager.class);
         clientRegistrationStore = mock(ClientRegistrationStore.class);
         csrfProtection = mock(CsrfProtection.class);
+        providerSettingsFactory = mock(OAuth2ProviderSettingsFactory.class);
+        providerSettings = mock(OAuth2ProviderSettings.class);
         request = mock(OAuth2Request.class);
         service = new EndSessionService(parametersValidator, openIDConnectProvider, ssoTokenManager,
-                clientRegistrationStore, csrfProtection);
+                clientRegistrationStore, csrfProtection, providerSettingsFactory);
     }
 
     private EndSessionParameters endSessionParameters(String idTokenHint) {
@@ -172,14 +180,119 @@ public class EndSessionServiceTest {
         HttpServletRequest servletRequest = mock(HttpServletRequest.class);
         SSOToken ssoToken = mock(SSOToken.class);
         given(ssoTokenManager.createSSOToken(servletRequest)).willReturn(ssoToken);
-        assertThat(service.currentSession(servletRequest)).isEqualTo(Optional.of(ssoToken));
+        assertThat(service.getCurrentSession(servletRequest)).isEqualTo(Optional.of(ssoToken));
     }
 
     @Test
     public void currentSession_noSession_returnsEmpty() throws Exception {
         HttpServletRequest servletRequest = mock(HttpServletRequest.class);
         given(ssoTokenManager.createSSOToken(servletRequest)).willThrow(new SSOException("no session"));
-        assertThat(service.currentSession(servletRequest)).isEqualTo(Optional.empty());
+        assertThat(service.getCurrentSession(servletRequest)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_trustedCurrentSession_returnsTrue() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.OPS, "ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+        given(openIDConnectProvider.isOpsTokenForSession("ops-id", session)).willReturn(true);
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isTrue();
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_providerRequiresConfirmation_returnsFalse() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.OPS, "ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(providerSettings.isLogoutConfirmationRequired()).willReturn(true);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isFalse();
+
+        verify(openIDConnectProvider, never()).isOpsTokenForSession(any(String.class), any(SSOToken.class));
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_clientRequiresConfirmation_returnsFalse() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.OPS, "ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+        given(client.isLogoutConfirmationRequired()).willReturn(true);
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isFalse();
+
+        verify(openIDConnectProvider, never()).isOpsTokenForSession(any(String.class), any(SSOToken.class));
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_tokenForDifferentSession_returnsFalse() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.OPS, "ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isFalse();
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_attachesClientRegistrationBeforeResolvingSettings() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.OPS, "ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+
+        service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session);
+
+        // The provider settings depend on the kind of client, which the end session endpoint does not authenticate.
+        InOrder inOrder = inOrder(request, providerSettingsFactory);
+        inOrder.verify(request).setClientRegistration(client);
+        inOrder.verify(providerSettingsFactory).get(request);
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_idTokenWithoutOpsClaim_returnsFalse() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims().build());
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isFalse();
+
+        verify(clientRegistrationStore, never()).get(any(String.class), eq(request));
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_withoutHintOrSession_returnsFalse() throws Exception {
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(null), sessionWithId("session-id")))
+                .isFalse();
+        assertThat(service.canSkipLogoutConfirmation(request,
+                endSessionParameters(buildHmacIdToken(CLIENT_SECRET, azpClaims().build())), null)).isFalse();
+
+        verify(providerSettingsFactory, never()).get(any(OAuth2Request.class));
+    }
+
+    @Test
+    public void canSkipLogoutConfirmation_legacyOpsClaim_isSupported() throws Exception {
+        SSOToken session = sessionWithId("session-id");
+        ClientRegistration client = mock(ClientRegistration.class);
+        String idToken = buildHmacIdToken(CLIENT_SECRET, azpClaims()
+                .claim(OAuth2Constants.JWTTokenParams.LEGACY_OPS, "legacy-ops-id").build());
+        given(providerSettingsFactory.get(request)).willReturn(providerSettings);
+        given(clientRegistrationStore.get(CLIENT_ID, request)).willReturn(client);
+        given(openIDConnectProvider.isOpsTokenForSession("legacy-ops-id", session)).willReturn(true);
+
+        assertThat(service.canSkipLogoutConfirmation(request, endSessionParameters(idToken), session)).isTrue();
     }
 
     @Test

--- a/openam-oauth2/src/test/java/org/forgerock/openidconnect/OpenIDConnectProviderTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openidconnect/OpenIDConnectProviderTest.java
@@ -1,0 +1,104 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security
+ */
+package org.forgerock.openidconnect;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.iplanet.sso.SSOToken;
+import com.iplanet.sso.SSOTokenID;
+import com.iplanet.sso.SSOTokenManager;
+import java.util.List;
+import java.util.Map;
+import org.forgerock.json.JsonValue;
+import org.forgerock.openam.cts.CTSPersistentStore;
+import org.forgerock.openam.cts.adapters.TokenAdapter;
+import org.forgerock.openam.cts.api.tokens.Token;
+import org.forgerock.openam.oauth2.IdentityManager;
+import org.forgerock.openam.oauth2.OAuth2Constants;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class OpenIDConnectProviderTest {
+
+    private CTSPersistentStore cts;
+    private TokenAdapter<JsonValue> tokenAdapter;
+    private OpenIDConnectProvider provider;
+
+    @BeforeMethod
+    @SuppressWarnings("unchecked")
+    public void setup() {
+        cts = mock(CTSPersistentStore.class);
+        tokenAdapter = mock(TokenAdapter.class);
+        provider = new OpenIDConnectProvider(mock(SSOTokenManager.class), mock(IdentityManager.class), cts,
+                tokenAdapter);
+    }
+
+    @Test
+    public void isOpsTokenForSession_matchingSession_returnsTrue() throws Exception {
+        Token opsToken = mock(Token.class);
+        given(cts.read("ops-id")).willReturn(opsToken);
+        given(tokenAdapter.fromToken(opsToken)).willReturn(opsTokenData("session-id"));
+
+        assertThat(provider.isOpsTokenForSession("ops-id", sessionWithId("session-id"))).isTrue();
+    }
+
+    @Test
+    public void isOpsTokenForSession_differentSession_returnsFalse() throws Exception {
+        Token opsToken = mock(Token.class);
+        given(cts.read("ops-id")).willReturn(opsToken);
+        given(tokenAdapter.fromToken(opsToken)).willReturn(opsTokenData("other-session-id"));
+
+        assertThat(provider.isOpsTokenForSession("ops-id", sessionWithId("session-id"))).isFalse();
+    }
+
+    @Test
+    public void isOpsTokenForSession_missingOpsToken_returnsFalse() {
+        assertThat(provider.isOpsTokenForSession("unknown-ops-id", sessionWithId("session-id"))).isFalse();
+    }
+
+    @Test
+    public void isOpsTokenForSession_missingInput_returnsFalse() {
+        assertThat(provider.isOpsTokenForSession(null, sessionWithId("session-id"))).isFalse();
+        assertThat(provider.isOpsTokenForSession("ops-id", null)).isFalse();
+    }
+
+    private JsonValue opsTokenData(String sessionId) {
+        return new JsonValue(Map.of(OAuth2Constants.JWTTokenParams.LEGACY_OPS, List.of(sessionId)));
+    }
+
+    private SSOToken sessionWithId(String sessionId) {
+        SSOToken session = mock(SSOToken.class);
+        given(session.getTokenID()).willReturn(new SSOTokenID() {
+            @Override
+            public String toString() {
+                return sessionId;
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                return other instanceof SSOTokenID && sessionId.equals(other.toString());
+            }
+
+            @Override
+            public int hashCode() {
+                return sessionId.hashCode();
+            }
+        });
+        return session;
+    }
+}

--- a/openam-oauth2/src/test/java/org/forgerock/openidconnect/restlet/EndSessionTest.java
+++ b/openam-oauth2/src/test/java/org/forgerock/openidconnect/restlet/EndSessionTest.java
@@ -122,10 +122,10 @@ public class EndSessionTest {
     }
 
     @Test
-    public void showConfirmation_withoutIdTokenHint_rendersConfirmation() throws Exception {
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
+    public void endSessionGet_withoutIdTokenHint_rendersConfirmation() throws Exception {
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
 
-        Map<String, Object> dataModel = dataModel(resource.showConfirmation());
+        Map<String, Object> dataModel = dataModel(resource.endSession());
 
         assertThat(dataModel.get("stage")).isEqualTo("confirmation");
         assertThat(dataModel.get("baseUrl")).isEqualTo("https://am.example.com/auth");
@@ -133,28 +133,56 @@ public class EndSessionTest {
     }
 
     @Test
-    public void showConfirmation_noSessionAndNoIdTokenHint_rendersDone() throws Exception {
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.empty());
+    public void endSessionGet_logoutDecisionDoesNotConfirmLogout() throws Exception {
+        given(servletRequest.getParameter("decision")).willReturn("logout");
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
 
-        Map<String, Object> dataModel = dataModel(resource.showConfirmation());
+        Map<String, Object> dataModel = dataModel(resource.endSession());
+
+        assertThat(dataModel.get("stage")).isEqualTo("confirmation");
+        verify(endSessionService, never()).verifyCsrf(any(), any());
+        verify(endSessionService, never()).endSession(any(), any());
+        verify(endSessionService, never()).logout(any());
+    }
+
+    @Test
+    public void endSessionGet_noSessionAndNoIdTokenHint_rendersDone() throws Exception {
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.empty());
+
+        Map<String, Object> dataModel = dataModel(resource.endSession());
 
         assertThat(dataModel.get("stage")).isEqualTo("done");
         verify(endSessionService, never()).resolveClientName(any(), any(), any());
     }
 
     @Test
-    public void showConfirmation_validRequest_validatesAndRenders() throws Exception {
+    public void endSessionGet_validRequest_validatesAndRenders() throws Exception {
         given(servletRequest.getParameter(OAuth2Constants.Params.END_SESSION_ID_TOKEN_HINT)).willReturn(ID_TOKEN);
         given(servletRequest.getParameter(OAuth2Constants.Params.CLIENT_ID)).willReturn(CLIENT_ID);
         given(servletRequest.getParameter(OAuth2Constants.Params.POST_LOGOUT_REDIRECT_URI)).willReturn(REDIRECT_URI);
 
-        assertThat(resource.showConfirmation()).isNotNull();
+        assertThat(resource.endSession()).isNotNull();
 
         verify(endSessionService).validate(eq(oAuth2Request), any(EndSessionParameters.class));
     }
 
     @Test
-    public void showConfirmation_populatesTemplateDataModel() throws Exception {
+    public void endSessionGet_trustedRequestSkipsConfirmationAndEndsSession() throws Exception {
+        SSOToken session = mock(SSOToken.class);
+        given(servletRequest.getParameter(OAuth2Constants.Params.END_SESSION_ID_TOKEN_HINT)).willReturn(ID_TOKEN);
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(session));
+        given(endSessionService.canSkipLogoutConfirmation(eq(oAuth2Request), any(EndSessionParameters.class),
+                eq(session))).willReturn(true);
+
+        resource.endSession();
+
+        verify(endSessionService).endSession(eq(oAuth2Request), any(EndSessionParameters.class));
+        verify(endSessionService, never()).verifyCsrf(any(), any());
+        verify(endSessionService, never()).resolveClientName(any(), any(), any());
+    }
+
+    @Test
+    public void endSessionGet_populatesTemplateDataModel() throws Exception {
         given(servletRequest.getParameter(OAuth2Constants.Params.END_SESSION_ID_TOKEN_HINT)).willReturn(ID_TOKEN);
         given(servletRequest.getParameter(OAuth2Constants.Params.CLIENT_ID)).willReturn(CLIENT_ID);
         given(servletRequest.getParameter(OAuth2Constants.Params.POST_LOGOUT_REDIRECT_URI)).willReturn(REDIRECT_URI);
@@ -165,7 +193,7 @@ public class EndSessionTest {
         given(endSessionService.resolveUserName(any(EndSessionParameters.class), any()))
                 .willReturn(Optional.of("demo"));
 
-        Map<String, Object> dataModel = dataModel(resource.showConfirmation());
+        Map<String, Object> dataModel = dataModel(resource.endSession());
 
         assertThat(dataModel.get("stage")).isEqualTo("confirmation");
         assertThat(dataModel.get("baseUrl")).isEqualTo("https://am.example.com/auth");
@@ -179,22 +207,22 @@ public class EndSessionTest {
     }
 
     @Test(expectedExceptions = OAuth2RestletException.class)
-    public void showConfirmation_invalidIdTokenHint_throwsException() throws Exception {
+    public void endSessionGet_invalidIdTokenHint_throwsException() throws Exception {
         given(servletRequest.getParameter(OAuth2Constants.Params.END_SESSION_ID_TOKEN_HINT)).willReturn(ID_TOKEN);
         willThrow(new BadRequestException("id_token_hint signature could not be verified"))
                 .given(endSessionService).validate(any(), any());
 
-        resource.showConfirmation();
+        resource.endSession();
     }
 
     @Test(expectedExceptions = OAuth2RestletException.class)
-    public void showConfirmation_unregisteredRedirectUri_throwsException() throws Exception {
+    public void endSessionGet_unregisteredRedirectUri_throwsException() throws Exception {
         given(servletRequest.getParameter(OAuth2Constants.Params.END_SESSION_ID_TOKEN_HINT)).willReturn(ID_TOKEN);
         given(servletRequest.getParameter(OAuth2Constants.Params.POST_LOGOUT_REDIRECT_URI)).willReturn(REDIRECT_URI);
         willThrow(new RedirectUriMismatchException())
                 .given(endSessionService).validate(any(), any());
 
-        resource.showConfirmation();
+        resource.endSession();
     }
 
     @Test
@@ -254,7 +282,7 @@ public class EndSessionTest {
     @Test
     public void endSession_unknownDecision_rendersConfirmation() throws Exception {
         given(servletRequest.getParameter("decision")).willReturn("ignore");
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
 
         Map<String, Object> dataModel = dataModel(resource.endSession(null));
 
@@ -297,7 +325,7 @@ public class EndSessionTest {
     public void endSession_withoutIdTokenHint_logsOutBySession() throws Exception {
         given(servletRequest.getParameter("decision")).willReturn("logout");
         SSOToken ssoToken = mock(SSOToken.class);
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.of(ssoToken));
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(ssoToken));
 
         assertThat(resource.endSession(null)).isNotNull();
 
@@ -320,7 +348,7 @@ public class EndSessionTest {
         given(servletRequest.getParameter("decision")).willReturn("logout");
         given(servletRequest.getParameter(OAuth2Constants.Params.POST_LOGOUT_REDIRECT_URI)).willReturn(REDIRECT_URI);
         SSOToken ssoToken = mock(SSOToken.class);
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.of(ssoToken));
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(ssoToken));
 
         Map<String, Object> dataModel = dataModel(resource.endSession(null));
 
@@ -357,13 +385,13 @@ public class EndSessionTest {
     }
 
     @Test(expectedExceptions = OAuth2RestletException.class)
-    public void showConfirmation_unknownClient_throwsOAuth2RestletException() throws Exception {
+    public void endSessionGet_unknownClient_throwsOAuth2RestletException() throws Exception {
         given(servletRequest.getParameter(OAuth2Constants.Params.CLIENT_ID)).willReturn(CLIENT_ID);
-        given(endSessionService.currentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
+        given(endSessionService.getCurrentSession(servletRequest)).willReturn(Optional.of(mock(SSOToken.class)));
         given(endSessionService.resolveClientName(any(), any(), any()))
                 .willThrow(InvalidClientException.class);
 
-        resource.showConfirmation();
+        resource.endSession();
     }
 
     @Test

--- a/openam-server-only/src/main/resources/services/AgentService.xml
+++ b/openam-server-only/src/main/resources/services/AgentService.xml
@@ -28,6 +28,7 @@
 
    Portions Copyrighted 2011-2016 ForgeRock AS.
    Portions Copyrighted 2015 Nomura Research Institute, Ltd.
+   Portions Copyrighted 2026 Wren Security
 -->
 
 <!DOCTYPE ServicesConfiguration
@@ -438,6 +439,20 @@
                             syntax="boolean"
                             i18nKey="a758"
                             order="26200">
+                        <BooleanValues>
+                            <BooleanTrueValue i18nKey="i18nTrue">true</BooleanTrueValue>
+                            <BooleanFalseValue i18nKey="i18nFalse">false</BooleanFalseValue>
+                        </BooleanValues>
+                        <DefaultValues>
+                            <Value>false</Value>
+                        </DefaultValues>
+                    </AttributeSchema>
+                    <AttributeSchema
+                            name="requireLogoutConfirmation"
+                            type="single"
+                            syntax="boolean"
+                            i18nKey="a759"
+                            order="26300">
                         <BooleanValues>
                             <BooleanTrueValue i18nKey="i18nTrue">true</BooleanTrueValue>
                             <BooleanFalseValue i18nKey="i18nFalse">false</BooleanFalseValue>


### PR DESCRIPTION
## Motivation

The `end_session` endpoint added in #308 always renders the logout confirmation page, even when the RP sends an `id_token_hint` that provably belongs to the current user session. OpenID Connect RP-Initiated Logout 1.0 allows the OP to log the user out without asking, provided it can verify which RP and which session the request refers to. Always asking makes the flow needlessly noisy for trusted clients and breaks the expectation that a `post_logout_redirect_uri` is reached without user interaction.

## Solution

The end session endpoint now skips the confirmation page when the request can be trusted, i.e. when **all** of the following hold:

* there is an active SSO session,
* the request carries a valid `id_token_hint` resolving to a known client,
* the ID Token's `org.forgerock.openidconnect.ops` (or legacy `ops`) claim references exactly the current SSO session (Wren:AM does not issue `sid` yet),
* neither the OAuth2 Provider nor the client requires logout confirmation.

Otherwise the confirmation page is displayed as before.

Two new boolean settings control the behaviour, both defaulting to `false`:

* **OAuth2 Provider → Advanced OpenID Connect → Require logout confirmation** (`requireLogoutConfirmation`)  
  Enforces confirmation for all clients of the realm.
* **OAuth2 Client → Require logout confirmation** (`requireLogoutConfirmation`)  
  Lets a single client opt back in to confirmation.
