### PR TITLE
Improve authentication module editing in XUI

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsJsonConverter.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2022 Wren Security
+ * Portions copyright 2022-2026 Wren Security.
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -20,18 +20,13 @@ package org.forgerock.openam.core.rest.sms;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
 
-import java.util.LinkedHashMap;
 import jakarta.inject.Inject;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -108,7 +103,7 @@ public class SmsJsonConverter {
         }
 
         resourceNameToAttributeName = attributeNameToResourceName.inverse();
-        attributeNameToSection = getAttributeNameToSection();
+        attributeNameToSection = SmsSectionReader.readSectionsByAttributeName(schema, debug);
 
         initialised = true;
     }
@@ -461,33 +456,6 @@ public class SmsJsonConverter {
         }
 
         return hiddenAttributeNames;
-    }
-
-    protected Map<String, String> getAttributeNameToSection() {
-        Map<String, String> result = new LinkedHashMap();
-        String serviceSectionFilename = schema.getName() != null ? schema.getName() : schema.getServiceName();
-        serviceSectionFilename = serviceSectionFilename + ".section.properties";
-
-        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(serviceSectionFilename);
-
-        if (inputStream != null) {
-            String line;
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-            try {
-                while ((line = reader.readLine()) != null) {
-                    if (!(line.matches("^\\#.*") || line.isEmpty())) {
-                        String[] attributeValue = line.split("=");
-                        final String sectionName = attributeValue[0];
-                        result.put(attributeValue[1], sectionName);
-                    }
-                }
-            } catch (IOException e) {
-                if (debug.errorEnabled()) {
-                    debug.error("Error reading section properties file", e);
-                }
-            }
-        }
-        return result;
     }
 
     private BiMap<String, String> getAttributeNameToResourceName(ServiceSchema schema) {

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsResourceProvider.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2017 ForgeRock AS.
- * Portions copyright 2022-2026 Wren Security
+ * Portions copyright 2022-2026 Wren Security.
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -36,16 +36,10 @@ import static org.forgerock.openam.rest.RestConstants.COLLECTION;
 import static org.forgerock.openam.rest.RestConstants.NAME;
 import static org.forgerock.util.i18n.LocalizableString.TRANSLATION_KEY_PREFIX;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -471,7 +465,8 @@ public abstract class SmsResourceProvider implements Describable<ApiDescription,
     }
 
     protected void addAttributeSchema(JsonValue result, String path, ServiceSchema schemas, Optional<Context> context) {
-        Map<String, String> attributeSectionMap = getAttributeNameToSection(schemas);
+        Map<String, String> attributeSectionMap =
+                SmsSectionReader.readSectionsByAttributeName(schemas, debug);
         String serviceType = schemas.getServiceType().getType();
         List<String> sections = getSections(attributeSectionMap, serviceType);
 
@@ -638,34 +633,6 @@ public abstract class SmsResourceProvider implements Describable<ApiDescription,
             type = STRING_TYPE;
         }
         return type;
-    }
-
-    protected Map<String, String> getAttributeNameToSection(ServiceSchema schema) {
-        Map<String, String> result = new LinkedHashMap<>();
-
-        String serviceSectionFilename = schema.getName() != null ? schema.getName() : schema.getServiceName();
-        serviceSectionFilename = serviceSectionFilename + ".section.properties";
-
-        InputStream inputStream = getClass().getClassLoader().getResourceAsStream(serviceSectionFilename);
-
-        if (inputStream != null) {
-            String line;
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-            try {
-                while ((line = reader.readLine()) != null) {
-                    if (!(line.matches("^\\#.*") || line.isEmpty())) {
-                        String[] attributeValue = line.split("=");
-                        final String sectionName = attributeValue[0];
-                        result.put(attributeValue[1], sectionName);
-                    }
-                }
-            } catch (IOException e) {
-                if (debug.errorEnabled()) {
-                    debug.error("Error reading section properties file", e);
-                }
-            }
-        }
-        return result;
     }
 
     protected Locale getLocale(Context context) {

--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsSectionReader.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/sms/SmsSectionReader.java
@@ -1,0 +1,79 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security.
+ */
+
+package org.forgerock.openam.core.rest.sms;
+
+import com.sun.identity.shared.debug.Debug;
+import com.sun.identity.sm.ServiceSchema;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+ /**
+  * A reader for SMS schema section layouts.
+  */
+final class SmsSectionReader {
+
+    private SmsSectionReader() {
+    }
+
+    /**
+     * Read the sections associated with attributes in an SMS schema.
+     *
+     * @param schema schema whose section resource should be read
+     * @param debug caller's AM debug instance
+     * @return section names keyed by attribute name in declaration order, or an empty map when no section resource
+     *         can be read
+     */
+    static Map<String, String> readSectionsByAttributeName(ServiceSchema schema, Debug debug) {
+        String schemaName = schema.getName();
+        if (SmsRequestHandler.USE_PARENT_PATH.equals(schema.getResourceName()) || schemaName == null) {
+            schemaName = schema.getServiceName();
+        }
+
+        String filename = schemaName + ".section.properties";
+        Map<String, String> result = new LinkedHashMap<>();
+        InputStream inputStream = SmsSectionReader.class.getClassLoader().getResourceAsStream(filename);
+        if (inputStream == null) {
+            return result;
+        }
+
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String entry = line.trim();
+                if (entry.isEmpty() || entry.startsWith("#")) {
+                    continue;
+                }
+                String[] sectionAndAttribute = entry.split("=", 2);
+                if (sectionAndAttribute.length == 2) {
+                    result.put(sectionAndAttribute[1].trim(), sectionAndAttribute[0].trim());
+                }
+            }
+        } catch (IOException e) {
+            if (debug.errorEnabled()) {
+                debug.error("Error reading section properties file " + filename, e);
+            }
+        }
+        return result;
+    }
+
+}

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsJsonConverterTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsJsonConverterTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2026 Wren Security.
  */
 
 package org.forgerock.openam.core.rest.sms;
@@ -78,13 +79,6 @@ public class SmsJsonConverterTest {
         }
 
         @Override
-        protected HashMap<String, String> getAttributeNameToSection() {
-            final HashMap<String, String> sectionToAttribute = new HashMap<String, String>();
-            sectionToAttribute.put(SECTION_1_STRING_VALUE_NAME, SECTION_1_NAME);
-            return sectionToAttribute;
-        }
-
-        @Override
         protected List<String> getHiddenAttributeNames() {
             return new ArrayList<String>();
         }
@@ -94,6 +88,7 @@ public class SmsJsonConverterTest {
     public void setup() throws UnsupportedEncodingException {
         serviceSchema = mock(ServiceSchema.class);
 
+        given(serviceSchema.getName()).willReturn(SmsJsonConverterTest.class.getSimpleName());
         given(serviceSchema.getAttributeSchemaNames()).willReturn(getHashSet(STRING_VALUE_NAME, INT_VALUE_NAME,
                 BOOLEAN_VALUE_NAME, DECIMAL_VALUE_NAME, ARRAY_VALUE_NAME, MAP_VALUE_NAME, SECTION_1_STRING_VALUE_NAME,
                 SCRIPT_VALUE_NAME, PASSWORD_VALUE_NAME));

--- a/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsSectionReaderTest.java
+++ b/openam-core-rest/src/test/java/org/forgerock/openam/core/rest/sms/SmsSectionReaderTest.java
@@ -1,0 +1,108 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2026 Wren Security.
+ */
+
+package org.forgerock.openam.core.rest.sms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.sun.identity.shared.debug.Debug;
+import com.sun.identity.sm.ServiceSchema;
+
+public class SmsSectionReaderTest {
+
+    private static final String SECTION_PROPERTIES_NAME = "SmsSectionReaderTest";
+
+    private static final String MISSING_SECTION_PROPERTIES_NAME = "MissingSmsSectionReaderTest";
+
+    private Debug debug;
+
+    private ServiceSchema schema;
+
+    @BeforeMethod
+    public void setUp() {
+        debug = mock(Debug.class);
+        schema = mock(ServiceSchema.class);
+    }
+
+    @Test
+    public void loadsSectionPropertiesForNamedSchema() {
+        // Given
+        given(schema.getName()).willReturn(SECTION_PROPERTIES_NAME);
+        given(schema.getServiceName()).willReturn(MISSING_SECTION_PROPERTIES_NAME);
+
+        // When
+        Map<String, String> result = SmsSectionReader.readSectionsByAttributeName(schema, debug);
+
+        // Then
+        assertThat(result).containsExactly(
+                entry("firstAttribute", "general"),
+                entry("secondAttribute", "general"),
+                entry("thirdAttribute", "advanced"));
+    }
+
+    @Test
+    public void loadsSectionPropertiesForUnnamedSchema() {
+        // Given
+        given(schema.getServiceName()).willReturn(SECTION_PROPERTIES_NAME);
+
+        // When
+        Map<String, String> result = SmsSectionReader.readSectionsByAttributeName(schema, debug);
+
+        // Then
+        assertThat(result).containsExactly(
+                entry("firstAttribute", "general"),
+                entry("secondAttribute", "general"),
+                entry("thirdAttribute", "advanced"));
+    }
+
+    @Test
+    public void loadsServiceSectionPropertiesForParentPath() {
+        // Given
+        given(schema.getName()).willReturn(MISSING_SECTION_PROPERTIES_NAME);
+        given(schema.getResourceName()).willReturn(SmsRequestHandler.USE_PARENT_PATH);
+        given(schema.getServiceName()).willReturn(SECTION_PROPERTIES_NAME);
+
+        // When
+        Map<String, String> result = SmsSectionReader.readSectionsByAttributeName(schema, debug);
+
+        // Then
+        assertThat(result).containsExactly(
+                entry("firstAttribute", "general"),
+                entry("secondAttribute", "general"),
+                entry("thirdAttribute", "advanced"));
+    }
+
+    @Test
+    public void returnsEmptyMapWhenSectionPropertiesDoNotExist() {
+        // Given
+        given(schema.getName()).willReturn(MISSING_SECTION_PROPERTIES_NAME);
+
+        // When
+        Map<String, String> result = SmsSectionReader.readSectionsByAttributeName(schema, debug);
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+}

--- a/openam-core-rest/src/test/resources/SmsJsonConverterTest.section.properties
+++ b/openam-core-rest/src/test/resources/SmsJsonConverterTest.section.properties
@@ -1,0 +1,16 @@
+#
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 Wren Security.
+
+section1=section1StringValueName

--- a/openam-core-rest/src/test/resources/SmsSectionReaderTest.section.properties
+++ b/openam-core-rest/src/test/resources/SmsSectionReaderTest.section.properties
@@ -1,0 +1,21 @@
+#
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 Wren Security.
+
+general=firstAttribute
+general = secondAttribute
+
+  # Whitespace-prefixed comments and declarations without a separator are ignored.
+ignored declaration
+  advanced = thirdAttribute

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/AuthenticationService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/realm/AuthenticationService.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
- * Portions copyright 2024 Wren Security.
+ * Portions copyright 2024-2026 Wren Security.
  */
 
 /**
@@ -24,9 +24,11 @@ define([
     "org/forgerock/commons/ui/common/main/AbstractDelegate",
     "org/forgerock/commons/ui/common/util/Constants",
     "org/forgerock/openam/ui/admin/services/SMSServiceUtils",
+    "org/forgerock/openam/ui/common/models/JSONSchema",
+    "org/forgerock/openam/ui/common/models/JSONValues",
     "org/forgerock/openam/ui/common/services/fetchUrl",
     "org/forgerock/openam/ui/common/util/Promise"
-], ($, _, AbstractDelegate, Constants, SMSServiceUtils, fetchUrl, Promise) => {
+], ($, _, AbstractDelegate, Constants, SMSServiceUtils, JSONSchema, JSONValues, fetchUrl, Promise) => {
     const obj = new AbstractDelegate(`${Constants.host}/${Constants.context}/json`);
 
     obj.authentication = {
@@ -157,11 +159,20 @@ define([
                     data: JSON.stringify(data)
                 });
             },
-            get (realm, name, type, options) {
-                return obj.serviceCall(_.merge({
+            get (realm, name, type) {
+                const getValues = () => obj.serviceCall({
                     url: fetchUrl.default(`/realm-config/authentication/modules/${type}/${name}`, { realm }),
                     headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" }
-                }, options)).then((data) => data);
+                }).then((response) => new JSONValues(response));
+
+                return Promise.all([
+                    this.schema(realm, type),
+                    getValues()
+                ]).then(([schema, values]) => ({
+                    name: values.raw._type.name,
+                    schema,
+                    values
+                }));
             },
             exists (realm, name) {
                 var promise = $.Deferred(),
@@ -189,8 +200,8 @@ define([
                     url: fetchUrl.default(`/realm-config/authentication/modules/${type}/${name}`, { realm }),
                     headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" },
                     type: "PUT",
-                    data: JSON.stringify(data)
-                });
+                    data: new JSONValues(data).toJSON()
+                }).then((response) => new JSONValues(response));
             },
             types: {
                 all (realm) {
@@ -199,12 +210,6 @@ define([
                         headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" },
                         type: "POST"
                     }).done(SMSServiceUtils.sortResultBy("name"));
-                },
-                get (realm, type) {
-                    // TODO: change this to a proper server-side call when OPENAM-7242 is implemented
-                    return obj.authentication.modules.types.all(realm).then(function (data) {
-                        return _.find(data.result, { "_id": type });
-                    });
                 }
             },
             schema (realm, type) {
@@ -212,9 +217,7 @@ define([
                     url: fetchUrl.default(`/realm-config/authentication/modules/${type}?_action=schema`, { realm }),
                     headers: { "Accept-API-Version": "protocol=1.0,resource=1.0" },
                     type: "POST"
-                }).then(function (data) {
-                    return SMSServiceUtils.sanitizeSchema(data);
-                });
+                }).then((data) => new JSONSchema(data));
             }
         }
     };

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authentication/modules/EditModuleView.jsm
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/realms/authentication/modules/EditModuleView.jsm
@@ -12,77 +12,25 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security.
  */
-
-import $ from "jquery";
-import "bootstrap-tabdrop"; // jquery dependency
 
 import AbstractView from "org/forgerock/commons/ui/common/main/AbstractView";
 import AuthenticationService from "org/forgerock/openam/ui/admin/services/realm/AuthenticationService";
-import Constants from "org/forgerock/commons/ui/common/util/Constants";
-import EventManager from "org/forgerock/commons/ui/common/main/EventManager";
-import Form from "org/forgerock/openam/ui/admin/models/Form";
-import Messages from "org/forgerock/commons/ui/common/components/Messages";
-import Promise from "org/forgerock/openam/ui/common/util/Promise";
+import EditSchemaComponent from "org/forgerock/openam/ui/admin/views/common/schema/EditSchemaComponent";
 
-class ListRealmsView extends AbstractView {
-    constructor () {
-        super();
-        this.template = "templates/admin/views/realms/authentication/modules/EditModuleViewTemplate.html";
-        this.events = {
-            "click [data-revert]"          : "revert",
-            "click [data-save]"            : "save",
-            "show.bs.tab ul.nav.nav-tabs a": "renderTab"
-        };
-    }
-    render ([realmPath, type, name]) {
-        this.data.realmPath = realmPath;
-        this.data.type = type;
-        this.data.name = name;
-
-        Promise.all([
-            AuthenticationService.authentication.modules.schema(this.data.realmPath, this.data.type),
-            AuthenticationService.authentication.modules.get(
-                this.data.realmPath, this.data.name, this.data.type,
-                { errorsHandlers: { "Not Found": { status: 404 } } }),
-            AuthenticationService.authentication.modules.types.get(this.data.realmPath, this.data.type)
-        ]).then(([schemaData, valuesData, moduleType]) => {
-            this.data.schema = schemaData;
-            this.data.values = valuesData;
-            this.data.typeDescription = moduleType.name;
-
-            this.parentRender(() => {
-                if (!this.data.schema.grouped) {
-                    this.data.form = new Form(this.$el.find("#tabpanel")[0], this.data.schema, this.data.values);
-                }
-
-                this.$el.find("ul.nav a:first").tab("show");
-                this.$el.find(".tab-menu .nav-tabs").tabdrop();
-            });
-        }, () => {
-            this.data.error = $.t("console.authentication.modules.notFound", { name });
-            this.parentRender();
+class EditModuleView extends AbstractView {
+    render ([realmPath, moduleType, moduleName]) {
+        const editComponent = new EditSchemaComponent({
+            data: { moduleName },
+            template: "templates/admin/views/realms/authentication/modules/EditModuleViewTemplate.html",
+            getInstance: () => AuthenticationService.authentication.modules.get(realmPath, moduleName, moduleType),
+            updateInstance: (values) =>
+                AuthenticationService.authentication.modules.update(realmPath, moduleName, moduleType, values)
         });
-    }
-    save () {
-        AuthenticationService.authentication.modules
-            .update(this.data.realmPath, this.data.name, this.data.type, this.data.form.data())
-            .then(() => {
-                EventManager.sendEvent(Constants.EVENT_DISPLAY_MESSAGE_REQUEST, "changesSaved");
-            }, (response) => {
-                Messages.addMessage({ type: Messages.TYPE_DANGER, response });
-            });
-    }
-    revert () {
-        this.data.form.reset();
-    }
-    renderTab (event) {
-        const id = $(event.target).attr("href").slice(1);
-        const schema = this.data.schema.properties[id];
-        const element = this.$el.find("#tabpanel").empty().get(0);
 
-        this.data.form = new Form(element, schema, this.data.values);
+        this.parentRender(() => { this.$el.append(editComponent.render().$el); });
     }
 }
 
-export default ListRealmsView;
+export default EditModuleView;

--- a/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authentication/modules/EditModuleViewTemplate.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/admin/views/realms/authentication/modules/EditModuleViewTemplate.html
@@ -1,30 +1,14 @@
-{{> headers/_TitleWithSubAndIcon title=name type=typeDescription icon="link" }}
+{{> headers/_TitleWithSubAndIcon title=moduleName type=name icon="link" }}
 
-{{#if values}}
-    {{#if schema.grouped}}
-    <div class="tab-menu">
-        <ul class="nav nav-tabs" role="tablist">
-            {{#each schema.orderedProperties}}
-                <li><a href="#{{this._id}}" role="tab" data-toggle="tab" aria-expanded="false">{{this.title}}</a></li>
-            {{/each}}
-        </ul>
-    </div>
-    {{/if}}
-
-    <div class="panel panel-default {{#if schema.grouped}}fr-panel-tab{{/if}}">
-        <div class="panel-body tab-content">
-            <div role="tabpanel" class="tab-pane active" id="tabpanel"></div>
-        </div>
-        <div class="panel-footer clearfix">
-            {{> form/_JSONSchemaFooter revert=true }}
-        </div>
-    </div>
+{{#if hasTabs}}
+    <form data-json-form></form>
 {{else}}
     <div class="panel panel-default">
         <div class="panel-body">
-            <div class="call-to-action-block">
-                <h3>{{error}}</h3>
-            </div>
+            <form data-json-form></form>
+        </div>
+        <div class="panel-footer clearfix">
+            {{> form/_JSONSchemaFooter}}
         </div>
     </div>
 {{/if}}


### PR DESCRIPTION
This PR updates authentication module configuration pages to use `EditSchemaComponent`, the shared schema editor used by other XUI configuration.

Authentication module sub-schemas can use a parent REST resource while their section layout is declared by the owning SMS service. The existing section readers always preferred the sub-schema name when present, so the service-level `.section.properties` resource was not loaded for these schemas. The new `SmsSectionReader` resolves the owning service resource for parent-path schemas and centralizes section-property loading for `SmsJsonConverter` and `SmsResourceProvider`.

The authentication module view now works with `JSONSchema` and `JSONValues` and delegates rendering, validation, and updates to `EditSchemaComponent` instead of maintaining a separate form implementation. This aligns authentication module editing with other schema-driven XUI configuration without adding module-specific UI.

<table>
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center"><img src="https://github.com/user-attachments/assets/ea16bf26-2015-4c82-be1f-156e81083456" alt="Authentication module editor before the change" width="480"></td>
    <td align="center"><img src="https://github.com/user-attachments/assets/691921f6-4082-4e38-8d4d-6f7587657671" alt="Authentication module editor after the change" width="480"></td>
  </tr>
</table>


