### PR TITLE
Fix SMS configuration change listener handling

### DIFF
--- a/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/devices/services/AuthenticatorDeviceServiceFactory.java
+++ b/openam-core-rest/src/main/java/org/forgerock/openam/core/rest/devices/services/AuthenticatorDeviceServiceFactory.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2016 ForgeRock AS.
+* Portions copyright 2026 Wren Security.
 */
 package org.forgerock.openam.core.rest.devices.services;
 
@@ -115,6 +116,7 @@ public class AuthenticatorDeviceServiceFactory<T extends DeviceService> {
                     break;
                 case REMOVED:
                     serviceCache.remove(DNMapper.orgNameToRealmName(orgName));
+                    break;
                 default:
                     debug.error("Unknown function requested on to update preferences for organization {}", type);
             }

--- a/openam-core/src/main/java/org/forgerock/openam/sm/config/ConsoleConfigHandlerImpl.java
+++ b/openam-core/src/main/java/org/forgerock/openam/sm/config/ConsoleConfigHandlerImpl.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security.
  */
 package org.forgerock.openam.sm.config;
 
@@ -209,14 +210,13 @@ public final class ConsoleConfigHandlerImpl implements ConsoleConfigHandler {
     }
 
     private void notifyListeners(String source, String orgName) {
-        List<ConsoleConfigListener> listeners = sourceListeners.get(source);
+        String realm = dnUtils.orgNameToRealmName(orgName);
+        attributeCache.remove(CacheKey.newInstance(source, realm));
 
+        List<ConsoleConfigListener> listeners = sourceListeners.get(source);
         if (isEmpty(listeners)) {
             return;
         }
-
-        String realm = dnUtils.orgNameToRealmName(orgName);
-        attributeCache.remove(CacheKey.newInstance(source, realm));
 
         for (ConsoleConfigListener listener : listeners) {
             try {


### PR DESCRIPTION
This PR fixes cache handling in two listeners for SMS configuration changes.

`ConsoleConfigHandlerImpl` previously invalidated cached attributes only when an application listener was registered for the changed configuration source. When no listener was registered, it returned without clearing the cache and subsequent reads could continue using stale values. Cache invalidation now happens before the listener lookup, ensuring that the next read reloads the changed SMS configuration independently of listener registration.

`AuthenticatorDeviceServiceFactory` removed the cached service after receiving a removal event but then fell through to the default switch branch, logging the valid event as an unknown operation. The removal branch now terminates after clearing the cache.