### PR TITLE
Fix XUI handling of map-only service schemas

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/models/JSONSchema.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/common/models/JSONSchema.js
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2024 Wren Security.
+ * Portions copyright 2024-2026 Wren Security.
  */
 
 /**
@@ -54,6 +54,16 @@ define([
      */
     function isObjectType (object) {
         return object.type === "object";
+    }
+
+    /**
+     * Determines whether the specified property is a schema in its own right, i.e. an object
+     * declaring nested properties.
+     * @param   {Object}  property Property to examine
+     * @returns {Boolean}          Whether the property is a nested schema
+     */
+    function isNestedSchema (property) {
+        return isObjectType(property) && _.has(property, "properties");
     }
 
     function groupTopLevelSimpleProperties (raw) {
@@ -98,9 +108,7 @@ define([
     * @returns {JSONSchema} JSONSchema new JSONSchema object
     */
     function ungroupCollectionProperties (raw, groupKey) {
-        const collectionProperties = _.pickBy(raw.properties[groupKey].properties, (value) => {
-            return value.type === "object" && _.has(value, "properties");
-        });
+        const collectionProperties = _.pickBy(raw.properties[groupKey].properties, isNestedSchema);
 
         if (_.isEmpty(collectionProperties)) {
             return raw;
@@ -218,10 +226,14 @@ define([
         /**
          * Whether this schema objects' properties are all schemas in their own right.
          * If true, this object is a simply a container for other schemas.
+         * <p>
+         * A property only counts as a schema in its own right when it declares nested
+         * <code>properties</code>.
+         * </p>
          * @returns {Boolean} Whether this object is a collection
          */
         isCollection () {
-            return _.every(this.raw.properties, (property) => property.type === "object");
+            return _.every(this.raw.properties, isNestedSchema);
         }
         isEmpty () {
             return _.isEmpty(this.raw.properties);

--- a/openam-ui/openam-ui-ria/src/test/js/org/forgerock/openam/ui/common/models/JSONSchemaTest.js
+++ b/openam-ui/openam-ui-ria/src/test/js/org/forgerock/openam/ui/common/models/JSONSchemaTest.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security.
  */
 
 define([
@@ -166,6 +167,102 @@ define([
                 });
 
                 expect(jsonSchema.hasInheritance()).to.be.false;
+            });
+        });
+
+        describe("#isCollection", () => {
+            it("returns true when all properties are nested schemas", () => {
+                const jsonSchema = new JSONSchema({
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "object",
+                            properties: {
+                                value: {
+                                    type: "string"
+                                }
+                            }
+                        },
+                        bar: {
+                            type: "object",
+                            properties: {
+                                value: {
+                                    type: "string"
+                                }
+                            }
+                        }
+                    }
+                });
+
+                expect(jsonSchema.isCollection()).to.be.true;
+            });
+
+            it("returns true when there are no properties", () => {
+                const jsonSchema = new JSONSchema({
+                    type: "object"
+                });
+
+                expect(jsonSchema.isCollection()).to.be.true;
+            });
+
+            it("returns false when any property is not of type object", () => {
+                const jsonSchema = new JSONSchema({
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "object",
+                            properties: {
+                                value: {
+                                    type: "string"
+                                }
+                            }
+                        },
+                        bar: {
+                            type: "string"
+                        }
+                    }
+                });
+
+                expect(jsonSchema.isCollection()).to.be.false;
+            });
+
+            it("returns false when any property declares no nested properties", () => {
+                const jsonSchema = new JSONSchema({
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "object",
+                            properties: {
+                                value: {
+                                    type: "string"
+                                }
+                            }
+                        },
+                        bar: {
+                            type: "object"
+                        }
+                    }
+                });
+
+                expect(jsonSchema.isCollection()).to.be.false;
+            });
+
+            it("returns false when the only property is a map", () => {
+                const jsonSchema = new JSONSchema({
+                    type: "object",
+                    properties: {
+                        foo: {
+                            type: "object",
+                            patternProperties: {
+                                ".*": {
+                                    type: "string"
+                                }
+                            }
+                        }
+                    }
+                });
+
+                expect(jsonSchema.isCollection()).to.be.false;
             });
         });
 


### PR DESCRIPTION
Treat object properties as schema groups only when they contain nested properties. This prevents maplist attributes from being incorrectly classified as collections.

Fixes #336.