### PR TITLE
Fix XUI site saving failing on the second attempt

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/global/SitesService.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/services/global/SitesService.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security
  */
 
 /**
@@ -80,7 +81,11 @@ define([
                 url: fetchUrl.default(`/global-config/sites/${id}`, { realm: false }),
                 headers: { "Accept-API-Version": "protocol=1.0,resource=1.0", "If-Match": etag },
                 type: "PUT",
-                data: JSON.stringify(filterUnEditableProperties(data))
+                data: JSON.stringify(filterUnEditableProperties(data)),
+                success: (response, jqXHR) => {
+                    response.etag = jqXHR.getResponseHeader("ETag");
+                    return response;
+                }
             }),
         remove: (id, etag) => {
             const remove = (id, etag) => obj.serviceCall({

--- a/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/deployment/sites/EditSiteView.js
+++ b/openam-ui/openam-ui-ria/src/main/js/org/forgerock/openam/ui/admin/views/deployment/sites/EditSiteView.js
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 Wren Security
  */
 
 define([
@@ -67,11 +68,16 @@ define([
         },
 
         onSave () {
+            toggleSave(this.$el, false);
             SitesService.sites.update(this.data.id, this.jsonSchemaView.getData(), this.data.etag)
                 .then(
-                    () => EventManager.sendEvent(Constants.EVENT_DISPLAY_MESSAGE_REQUEST, "changesSaved"),
+                    (data) => {
+                        this.data.etag = data.etag;
+                        EventManager.sendEvent(Constants.EVENT_DISPLAY_MESSAGE_REQUEST, "changesSaved");
+                    },
                     (response) => Messages.addMessage({ response, type: Messages.TYPE_DANGER })
-                );
+                )
+                .always(() => toggleSave(this.$el, true));
         },
 
         onDelete (event) {


### PR DESCRIPTION
The edit site view never refreshed its cached ETag after a successful save, so the following save sent an outdated revision and the server rejected it with a 412. Take the new ETag from the update response.